### PR TITLE
Add CAAC storage primitives

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,6 +9,7 @@
 - CAAC v1 envelope shape and validation helpers
 - broker message names and payload validators
 - service-access capability/status/request/signal contract shapes
+- CAAC Storage primitive records for encrypted content-addressed objects, encrypted index shards, key grants, pins, availability refs, graph edges, and encrypted detail refs
 - shared record codecs where multiple repos previously duplicated the same shape
 - cross-language test vectors
 
@@ -18,7 +19,7 @@
 - account runtime worker implementation
 - gateway admission policy
 - NVR camera/media policy
-- storage object policy
+- storage service implementation or object policy
 - app controllers or domain navigation
 
 ## CAAC v1
@@ -73,3 +74,21 @@ The current first-party service-access vocabulary is:
 - `gateway.service_access`
 
 The launch-token vocabulary is retired in consumers of this package.
+
+## CAAC Storage
+
+CAAC Storage is the current storage access model. It is not a separate SCAAC architecture.
+
+Protocol owns the reusable record shapes:
+
+- `StorageContainer`
+- `StorageObjectManifest`
+- `StorageChunkRef`
+- `StorageIndexShard`
+- `StorageGraphEdge`
+- `StorageKeyGrant`
+- `StoragePinLease`
+- `StorageAvailabilityRef`
+- `EncryptedDetailRef`
+
+Storage data and index payloads are encrypted with symmetric keys. Those keys are wrapped and granted through CAAC capabilities, while key-wallet authority stays outside the storage service. Storage hosts and intermediaries may pin, sync, and share ciphertext without learning plaintext metadata or long-lived account secrets.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Shared non-UI protocol, crypto-envelope, service-access, broker, and record prim
 - CAAC v1 sealed envelopes for cryptography-assured access control
 - Service-access capability/status/signal contract names and codecs
 - Runtime broker message constants and validators
+- CAAC Storage primitive records for encrypted objects, encrypted index shards, key grants, pin leases, availability refs, graph edges, and encrypted detail refs
 - Shared record codecs where records are duplicated across repos
 - Rust/JS fixtures proving the shared contract stays aligned
 
@@ -19,5 +20,6 @@ Shared non-UI protocol, crypto-envelope, service-access, broker, and record prim
 - `constitute-account` owns browser-side identity/session/runtime authority.
 - `constitute-gateway` owns hosted-service admission and capability issuance policy.
 - `constitute-nvr` owns camera/media service behavior and capability enforcement.
+- `constitute-storage` owns the SQLite/files service implementation, pin/prune behavior, and local materialized search.
 
 Protocol code stays policy-neutral: it validates shapes and cryptographic envelopes, but downstream services decide whether a valid capability is sufficient for a specific operation.

--- a/src/caac.rs
+++ b/src/caac.rs
@@ -247,13 +247,15 @@ pub fn verify_envelope_signature(envelope: &CaacEnvelope) -> Result<bool> {
     let sig_bytes = hex_to_bytes(&envelope.signature)?;
     let sig = Signature::from_slice(&sig_bytes).map_err(|_| anyhow!("invalid caac signature"))?;
     let pk_bytes = hex_to_bytes(&envelope.issuer_pk)?;
-    let pk = XOnlyPublicKey::from_slice(&pk_bytes).map_err(|_| anyhow!("invalid caac issuer pk"))?;
+    let pk =
+        XOnlyPublicKey::from_slice(&pk_bytes).map_err(|_| anyhow!("invalid caac issuer pk"))?;
     let secp = Secp256k1::new();
     Ok(secp.verify_schnorr(&sig, &msg, &pk).is_ok())
 }
 
 pub fn encode_envelope_base64(envelope: &CaacEnvelope) -> Result<String> {
-    let bytes = serde_json::to_vec(envelope).map_err(|_| anyhow!("caac envelope serialize failed"))?;
+    let bytes =
+        serde_json::to_vec(envelope).map_err(|_| anyhow!("caac envelope serialize failed"))?;
     Ok(B64.encode(bytes))
 }
 
@@ -275,7 +277,13 @@ fn derive_recipient_key(
     let sk = SecretKey::from_slice(&sk_bytes).map_err(|_| anyhow!("invalid caac issuer sk"))?;
     let recipient_public = parse_xonly_as_public_key(recipient_pk)?;
     let shared_point = ecdh::shared_secret_point(&recipient_public, &sk);
-    hkdf_key(&shared_point[..32], kind, envelope_id, &issuer_pk, recipient_pk)
+    hkdf_key(
+        &shared_point[..32],
+        kind,
+        envelope_id,
+        &issuer_pk,
+        recipient_pk,
+    )
 }
 
 fn derive_open_key(
@@ -289,7 +297,13 @@ fn derive_open_key(
     let sk = SecretKey::from_slice(&sk_bytes).map_err(|_| anyhow!("invalid caac recipient sk"))?;
     let issuer_public = parse_xonly_as_public_key(issuer_pk)?;
     let shared_point = ecdh::shared_secret_point(&issuer_public, &sk);
-    hkdf_key(&shared_point[..32], kind, envelope_id, issuer_pk, recipient_pk)
+    hkdf_key(
+        &shared_point[..32],
+        kind,
+        envelope_id,
+        issuer_pk,
+        recipient_pk,
+    )
 }
 
 fn hkdf_key(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,8 @@ export const DEFAULT_REQUEST_TTL_SECONDS: number;
 export const BROKER: Readonly<Record<string, string>>;
 export const SERVICE_ACCESS_EVENTS: Readonly<Record<string, string>>;
 export const SERVICE_ACCESS_KINDS: Readonly<Record<string, string>>;
+export const STORAGE: Readonly<Record<string, string>>;
+export const STORAGE_KEY_GRANULARITY: Readonly<Record<string, string>>;
 
 export type CaacRecipient = {
   recipientPk: string;
@@ -36,6 +38,104 @@ export type ServiceAccessContext = {
   serviceCapability: CaacEnvelope;
   issuedAt: number;
   expiresAt: number;
+};
+
+export type StorageKeyGranularity = "container" | "shard" | "entry" | "fieldFamily";
+
+export type StorageContainer = {
+  containerId: string;
+  ownerPk: string;
+  createdAt: number;
+  keyGranularity?: StorageKeyGranularity[];
+  defaultRetentionClass?: string;
+  labels?: string[];
+};
+
+export type StorageChunkRef = {
+  chunkId: string;
+  hash: string;
+  hashAlg: string;
+  size: number;
+};
+
+export type StorageObjectManifest = {
+  objectId: string;
+  containerId: string;
+  contentHash: string;
+  hashAlg: string;
+  encryptionAlg: string;
+  keyRef: string;
+  chunks: StorageChunkRef[];
+  createdAt: number;
+  mediaType?: string;
+  logicalDeletedAt?: number;
+  tags?: string[];
+};
+
+export type EncryptedDetailRef = {
+  objectId: string;
+  containerId: string;
+  keyRef: string;
+  manifestHash: string;
+  summaryTags?: string[];
+};
+
+export type StorageGraphEdge = {
+  edgeId: string;
+  containerId: string;
+  fromRef: string;
+  relation: string;
+  toRef: string;
+  detailRef?: EncryptedDetailRef;
+  createdAt: number;
+};
+
+export type StorageIndexShard = {
+  shardId: string;
+  containerId: string;
+  shardType: string;
+  keyRef: string;
+  ciphertextHash: string;
+  hashAlg: string;
+  chunks: StorageChunkRef[];
+  objectRefs?: string[];
+  graphEdges?: StorageGraphEdge[];
+  createdAt: number;
+};
+
+export type StorageKeyGrant = {
+  grantId: string;
+  containerId: string;
+  keyRef: string;
+  scope: string;
+  recipientPk: string;
+  issuerPk: string;
+  wrappingAlg: string;
+  wrappedKey: string;
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type StoragePinLease = {
+  pinId: string;
+  containerId: string;
+  objectId?: string;
+  chunkHash?: string;
+  pinnedBy: string;
+  retentionClass: string;
+  createdAt: number;
+  expiresAt?: number;
+  lastAccessedAt?: number;
+};
+
+export type StorageAvailabilityRef = {
+  availabilityId: string;
+  storageHostId: string;
+  retentionClass: string;
+  objectId?: string;
+  chunkHash?: string;
+  exportedAt: number;
+  expiresAt?: number;
 };
 
 export function bytesToHex(bytes: Uint8Array): string;
@@ -76,3 +176,19 @@ export class ReplayCache {
 export function serviceAccessContextId(input?: Record<string, unknown>): string;
 export function assertServiceAccessContext(value: unknown): ServiceAccessContext;
 export function makeServiceAccessContext(input: Partial<ServiceAccessContext>): ServiceAccessContext;
+export function storageCiphertextHash(bytes: string | Uint8Array): string;
+export function storageObjectId(input?: { containerId?: string; contentHash?: string }): string;
+export function storageChunkId(hash: string): string;
+export function makeStorageChunkRef(input?: { ciphertext?: string | Uint8Array; chunkId?: string }): StorageChunkRef;
+export function assertStorageChunkRef(chunk: unknown, ciphertext: string | Uint8Array): StorageChunkRef;
+export function assertStorageObjectManifest(manifest: unknown): StorageObjectManifest;
+export function makeStorageObjectManifest(input?: {
+  containerId?: string;
+  keyRef?: string;
+  chunks?: StorageChunkRef[];
+  createdAt?: number;
+  mediaType?: string;
+  tags?: string[];
+  encryptionAlg?: string;
+}): StorageObjectManifest;
+export function assertStorageIndexShard(shard: unknown): StorageIndexShard;

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,21 @@ export const SERVICE_ACCESS_KINDS = Object.freeze({
   CLOSE: "service_access.close",
 });
 
+export const STORAGE = Object.freeze({
+  OBJECT_HASH_ALG: "sha256-ciphertext-v1",
+  CHUNK_HASH_ALG: "sha256-ciphertext-v1",
+  ENCRYPTION_ALG_XCHACHA20POLY1305: "xchacha20poly1305",
+  CAAC_KIND_KEY_GRANT: "storage.key_grant",
+  CAAC_KIND_SERVICE_ACCESS: "storage.service_access",
+});
+
+export const STORAGE_KEY_GRANULARITY = Object.freeze({
+  CONTAINER: "container",
+  SHARD: "shard",
+  ENTRY: "entry",
+  FIELD_FAMILY: "fieldFamily",
+});
+
 export function bytesToHex(bytes) {
   return nobleBytesToHex(bytes);
 }
@@ -312,4 +327,92 @@ export function makeServiceAccessContext({
     expiresAt,
   };
   return assertServiceAccessContext(context);
+}
+
+export function storageCiphertextHash(bytes) {
+  return sha256Hex(bytes instanceof Uint8Array ? bytes : utf8ToBytes(String(bytes ?? "")));
+}
+
+export function storageObjectId({ containerId = "", contentHash = "" } = {}) {
+  return sha256Hex(`constitute-storage-object-v1|${String(containerId).trim()}|${String(contentHash).trim()}`);
+}
+
+export function storageChunkId(hash) {
+  return sha256Hex(`constitute-storage-chunk-v1|${String(hash || "").trim()}`);
+}
+
+export function makeStorageChunkRef({ ciphertext, chunkId } = {}) {
+  const bytes = ciphertext instanceof Uint8Array ? ciphertext : utf8ToBytes(String(ciphertext ?? ""));
+  const hash = storageCiphertextHash(bytes);
+  return {
+    chunkId: chunkId || storageChunkId(hash),
+    hash,
+    hashAlg: STORAGE.CHUNK_HASH_ALG,
+    size: bytes.length,
+  };
+}
+
+export function assertStorageChunkRef(chunk, ciphertext) {
+  if (!chunk || typeof chunk !== "object") throw new Error("storage chunk ref must be an object");
+  if (chunk.hashAlg !== STORAGE.CHUNK_HASH_ALG) throw new Error("unsupported storage chunk hash algorithm");
+  const bytes = ciphertext instanceof Uint8Array ? ciphertext : utf8ToBytes(String(ciphertext ?? ""));
+  if (Number(chunk.size) !== bytes.length) throw new Error("storage chunk size mismatch");
+  if (chunk.hash !== storageCiphertextHash(bytes)) throw new Error("storage chunk hash mismatch");
+  if (chunk.chunkId !== storageChunkId(chunk.hash)) throw new Error("storage chunk id mismatch");
+  return chunk;
+}
+
+export function assertStorageObjectManifest(manifest) {
+  if (!manifest || typeof manifest !== "object") throw new Error("storage manifest must be an object");
+  if (!String(manifest.containerId || "").trim()) throw new Error("storage manifest missing container id");
+  if (!String(manifest.contentHash || "").trim()) throw new Error("storage manifest missing content hash");
+  if (manifest.hashAlg !== STORAGE.OBJECT_HASH_ALG) throw new Error("unsupported storage object hash algorithm");
+  if (manifest.encryptionAlg !== STORAGE.ENCRYPTION_ALG_XCHACHA20POLY1305) {
+    throw new Error("unsupported storage object encryption algorithm");
+  }
+  if (!String(manifest.keyRef || "").trim()) throw new Error("storage manifest missing key ref");
+  if (!Array.isArray(manifest.chunks) || manifest.chunks.length === 0) {
+    throw new Error("storage manifest has no chunks");
+  }
+  if (manifest.objectId !== storageObjectId({ containerId: manifest.containerId, contentHash: manifest.contentHash })) {
+    throw new Error("storage object id mismatch");
+  }
+  return manifest;
+}
+
+export function makeStorageObjectManifest({
+  containerId,
+  keyRef,
+  chunks,
+  createdAt = nowSeconds(),
+  mediaType = "application/octet-stream",
+  tags = [],
+  encryptionAlg = STORAGE.ENCRYPTION_ALG_XCHACHA20POLY1305,
+} = {}) {
+  const chunkRefs = chunks || [];
+  const contentHash = storageCiphertextHash(utf8ToBytes(canonicalJson(chunkRefs.map((chunk) => chunk.hash))));
+  const manifest = {
+    objectId: storageObjectId({ containerId, contentHash }),
+    containerId,
+    contentHash,
+    hashAlg: STORAGE.OBJECT_HASH_ALG,
+    encryptionAlg,
+    keyRef,
+    chunks: chunkRefs,
+    createdAt,
+    mediaType,
+    tags,
+  };
+  return assertStorageObjectManifest(manifest);
+}
+
+export function assertStorageIndexShard(shard) {
+  if (!shard || typeof shard !== "object") throw new Error("storage index shard must be an object");
+  if (!String(shard.shardId || "").trim()) throw new Error("storage index shard missing id");
+  if (!String(shard.containerId || "").trim()) throw new Error("storage index shard missing container id");
+  if (!String(shard.keyRef || "").trim()) throw new Error("storage index shard missing key ref");
+  if (shard.hashAlg !== STORAGE.OBJECT_HASH_ALG) throw new Error("unsupported storage index shard hash algorithm");
+  if (!String(shard.ciphertextHash || "").trim()) throw new Error("storage index shard missing ciphertext hash");
+  if (!Array.isArray(shard.chunks) || shard.chunks.length === 0) throw new Error("storage index shard has no chunks");
+  return shard;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod crypto;
 pub mod nostr;
 pub mod records;
 pub mod service_access;
+pub mod storage;
 
 pub use broker::*;
 pub use caac::*;
@@ -11,3 +12,4 @@ pub use crypto::*;
 pub use nostr::*;
 pub use records::*;
 pub use service_access::*;
+pub use storage::*;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,0 +1,277 @@
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+
+use crate::crypto::sha256_hex;
+
+pub const STORAGE_OBJECT_HASH_ALG: &str = "sha256-ciphertext-v1";
+pub const STORAGE_CHUNK_HASH_ALG: &str = "sha256-ciphertext-v1";
+pub const STORAGE_ENCRYPTION_ALG_XCHACHA20POLY1305: &str = "xchacha20poly1305";
+pub const CAAC_KIND_STORAGE_KEY_GRANT: &str = "storage.key_grant";
+pub const CAAC_KIND_STORAGE_SERVICE_ACCESS: &str = "storage.service_access";
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum StorageKeyGranularity {
+    Container,
+    Shard,
+    Entry,
+    FieldFamily,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageContainer {
+    pub container_id: String,
+    pub owner_pk: String,
+    pub created_at: u64,
+    #[serde(default)]
+    pub key_granularity: Vec<StorageKeyGranularity>,
+    #[serde(default)]
+    pub default_retention_class: String,
+    #[serde(default)]
+    pub labels: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageChunkRef {
+    pub chunk_id: String,
+    pub hash: String,
+    pub hash_alg: String,
+    pub size: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageObjectManifest {
+    pub object_id: String,
+    pub container_id: String,
+    pub content_hash: String,
+    pub hash_alg: String,
+    pub encryption_alg: String,
+    pub key_ref: String,
+    pub chunks: Vec<StorageChunkRef>,
+    pub created_at: u64,
+    #[serde(default)]
+    pub media_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logical_deleted_at: Option<u64>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageGraphEdge {
+    pub edge_id: String,
+    pub container_id: String,
+    pub from_ref: String,
+    pub relation: String,
+    pub to_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail_ref: Option<EncryptedDetailRef>,
+    pub created_at: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageIndexShard {
+    pub shard_id: String,
+    pub container_id: String,
+    pub shard_type: String,
+    pub key_ref: String,
+    pub ciphertext_hash: String,
+    pub hash_alg: String,
+    pub chunks: Vec<StorageChunkRef>,
+    #[serde(default)]
+    pub object_refs: Vec<String>,
+    #[serde(default)]
+    pub graph_edges: Vec<StorageGraphEdge>,
+    pub created_at: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageKeyGrant {
+    pub grant_id: String,
+    pub container_id: String,
+    pub key_ref: String,
+    pub scope: String,
+    pub recipient_pk: String,
+    pub issuer_pk: String,
+    pub wrapping_alg: String,
+    pub wrapped_key: String,
+    pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StoragePinLease {
+    pub pin_id: String,
+    pub container_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunk_hash: Option<String>,
+    pub pinned_by: String,
+    pub retention_class: String,
+    pub created_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_accessed_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct StorageAvailabilityRef {
+    pub availability_id: String,
+    pub storage_host_id: String,
+    pub retention_class: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub object_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub chunk_hash: Option<String>,
+    pub exported_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct EncryptedDetailRef {
+    pub object_id: String,
+    pub container_id: String,
+    pub key_ref: String,
+    pub manifest_hash: String,
+    #[serde(default)]
+    pub summary_tags: Vec<String>,
+}
+
+pub fn storage_ciphertext_hash(bytes: impl AsRef<[u8]>) -> String {
+    sha256_hex(bytes)
+}
+
+pub fn storage_object_id(container_id: &str, content_hash: &str) -> String {
+    sha256_hex(format!(
+        "constitute-storage-object-v1|{}|{}",
+        container_id.trim(),
+        content_hash.trim()
+    ))
+}
+
+pub fn storage_chunk_id(hash: &str) -> String {
+    sha256_hex(format!("constitute-storage-chunk-v1|{}", hash.trim()))
+}
+
+pub fn validate_storage_chunk_ref(chunk: &StorageChunkRef, bytes: &[u8]) -> Result<()> {
+    if chunk.hash_alg != STORAGE_CHUNK_HASH_ALG {
+        return Err(anyhow!("unsupported storage chunk hash algorithm"));
+    }
+    if chunk.size != bytes.len() as u64 {
+        return Err(anyhow!("storage chunk size mismatch"));
+    }
+    let actual = storage_ciphertext_hash(bytes);
+    if chunk.hash != actual {
+        return Err(anyhow!("storage chunk hash mismatch"));
+    }
+    if chunk.chunk_id != storage_chunk_id(&chunk.hash) {
+        return Err(anyhow!("storage chunk id mismatch"));
+    }
+    Ok(())
+}
+
+pub fn validate_storage_manifest(manifest: &StorageObjectManifest) -> Result<()> {
+    if manifest.container_id.trim().is_empty() {
+        return Err(anyhow!("storage manifest missing container id"));
+    }
+    if manifest.content_hash.trim().is_empty() {
+        return Err(anyhow!("storage manifest missing content hash"));
+    }
+    if manifest.hash_alg != STORAGE_OBJECT_HASH_ALG {
+        return Err(anyhow!("unsupported storage object hash algorithm"));
+    }
+    if manifest.encryption_alg != STORAGE_ENCRYPTION_ALG_XCHACHA20POLY1305 {
+        return Err(anyhow!("unsupported storage object encryption algorithm"));
+    }
+    if manifest.key_ref.trim().is_empty() {
+        return Err(anyhow!("storage manifest missing key ref"));
+    }
+    if manifest.chunks.is_empty() {
+        return Err(anyhow!("storage manifest has no chunks"));
+    }
+    if manifest.object_id != storage_object_id(&manifest.container_id, &manifest.content_hash) {
+        return Err(anyhow!("storage object id mismatch"));
+    }
+    Ok(())
+}
+
+pub fn validate_storage_index_shard(shard: &StorageIndexShard) -> Result<()> {
+    if shard.shard_id.trim().is_empty() {
+        return Err(anyhow!("storage index shard missing id"));
+    }
+    if shard.container_id.trim().is_empty() {
+        return Err(anyhow!("storage index shard missing container id"));
+    }
+    if shard.key_ref.trim().is_empty() {
+        return Err(anyhow!("storage index shard missing key ref"));
+    }
+    if shard.hash_alg != STORAGE_OBJECT_HASH_ALG {
+        return Err(anyhow!("unsupported storage index shard hash algorithm"));
+    }
+    if shard.ciphertext_hash.trim().is_empty() {
+        return Err(anyhow!("storage index shard missing ciphertext hash"));
+    }
+    if shard.chunks.is_empty() {
+        return Err(anyhow!("storage index shard has no chunks"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_ciphertext_chunk_and_manifest() {
+        let bytes = b"encrypted bytes";
+        let hash = storage_ciphertext_hash(bytes);
+        let chunk = StorageChunkRef {
+            chunk_id: storage_chunk_id(&hash),
+            hash: hash.clone(),
+            hash_alg: STORAGE_CHUNK_HASH_ALG.to_string(),
+            size: bytes.len() as u64,
+        };
+        validate_storage_chunk_ref(&chunk, bytes).expect("valid chunk");
+        let manifest = StorageObjectManifest {
+            object_id: storage_object_id("container-a", &hash),
+            container_id: "container-a".to_string(),
+            content_hash: hash,
+            hash_alg: STORAGE_OBJECT_HASH_ALG.to_string(),
+            encryption_alg: STORAGE_ENCRYPTION_ALG_XCHACHA20POLY1305.to_string(),
+            key_ref: "container-a:key".to_string(),
+            chunks: vec![chunk],
+            created_at: 1_700_000_000,
+            media_type: "application/octet-stream".to_string(),
+            logical_deleted_at: None,
+            tags: vec!["proof".to_string()],
+        };
+        validate_storage_manifest(&manifest).expect("valid manifest");
+    }
+
+    #[test]
+    fn rejects_bad_chunk_hash() {
+        let mut chunk = StorageChunkRef {
+            chunk_id: storage_chunk_id("bad"),
+            hash: "bad".to_string(),
+            hash_alg: STORAGE_CHUNK_HASH_ALG.to_string(),
+            size: 3,
+        };
+        assert!(validate_storage_chunk_ref(&chunk, b"abc").is_err());
+        let hash = storage_ciphertext_hash(b"abc");
+        chunk.hash = hash;
+        assert!(validate_storage_chunk_ref(&chunk, b"abc").is_err());
+    }
+}

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -5,11 +5,19 @@ import {
   ReplayCache,
   SERVICE_ACCESS_EVENTS,
   SERVICE_ACCESS_KINDS,
+  STORAGE,
+  assertStorageChunkRef,
+  assertStorageObjectManifest,
+  assertStorageIndexShard,
   buildUnsignedEvent,
   eventIdHex,
+  makeStorageChunkRef,
+  makeStorageObjectManifest,
   openEnvelope,
   pubkeyFromSecretKey,
   sealEnvelope,
+  storageCiphertextHash,
+  storageObjectId,
   signEvent,
   verifyEnvelopeSignature,
   verifyEvent,
@@ -91,4 +99,35 @@ test("exports current service-access vocabulary only", () => {
   assert.equal(SERVICE_ACCESS_EVENTS.SIGNAL, "gateway_service_signal");
   assert.equal(SERVICE_ACCESS_EVENTS.GRANT, "gateway.service_access");
   assert.equal(SERVICE_ACCESS_KINDS.INVOCATION, "service_access.invocation");
+});
+
+test("storage manifest helpers validate ciphertext-addressed objects", () => {
+  const ciphertext = new TextEncoder().encode("encrypted bytes");
+  const chunk = makeStorageChunkRef({ ciphertext });
+  assertStorageChunkRef(chunk, ciphertext);
+  const manifest = makeStorageObjectManifest({
+    containerId: "container-a",
+    keyRef: "container-a:key",
+    chunks: [chunk],
+    createdAt: 1700000000,
+    tags: ["proof"],
+  });
+  assert.equal(manifest.hashAlg, STORAGE.OBJECT_HASH_ALG);
+  assert.equal(manifest.encryptionAlg, STORAGE.ENCRYPTION_ALG_XCHACHA20POLY1305);
+  assert.equal(manifest.objectId, storageObjectId({ containerId: "container-a", contentHash: manifest.contentHash }));
+  assertStorageObjectManifest(manifest);
+
+  const shard = {
+    shardId: "shard-a",
+    containerId: "container-a",
+    shardType: "safe-log-facts",
+    keyRef: "container-a:shard-a",
+    ciphertextHash: storageCiphertextHash(ciphertext),
+    hashAlg: STORAGE.OBJECT_HASH_ALG,
+    chunks: [chunk],
+    objectRefs: [manifest.objectId],
+    graphEdges: [],
+    createdAt: 1700000000,
+  };
+  assertStorageIndexShard(shard);
 });


### PR DESCRIPTION
## Summary
- add CAAC Storage record primitives to Rust and JS exports
- add ciphertext hash/object/chunk helper functions and manifest/shard validators
- document protocol/storage boundary and CAAC Storage vocabulary

## Tests
- `npm run build`
- `npm test`
- `wsl -e bash -lc "source ~/.cargo/env && cd /mnt/c/projects/Constitution/constitute-protocol && cargo test"`

Closes #2
