### PR TITLE
Add CAAC logging primitives

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -10,6 +10,7 @@
 - broker message names and payload validators
 - service-access capability/status/request/signal contract shapes
 - CAAC Storage primitive records for encrypted content-addressed objects, encrypted index shards, key grants, pins, availability refs, graph edges, and encrypted detail refs
+- CAAC Logging primitive records for safe structured event envelopes, redaction classes, correlation refs, and encrypted detail references
 - shared record codecs where multiple repos previously duplicated the same shape
 - cross-language test vectors
 
@@ -20,6 +21,7 @@
 - gateway admission policy
 - NVR camera/media policy
 - storage service implementation or object policy
+- logging service observation, storage, query, or projection policy
 - app controllers or domain navigation
 
 ## CAAC v1
@@ -92,3 +94,15 @@ Protocol owns the reusable record shapes:
 - `EncryptedDetailRef`
 
 Storage data and index payloads are encrypted with symmetric keys. Those keys are wrapped and granted through CAAC capabilities, while key-wallet authority stays outside the storage service. Storage hosts and intermediaries may pin, sync, and share ciphertext without learning plaintext metadata or long-lived account secrets.
+
+## CAAC Logging
+
+Protocol owns shared log/event record shapes and validation only. Logging is blind by default:
+
+- producers create safe facts from their own plaintext context
+- producers encrypt sensitive detail before it enters a logging surface
+- log records carry searchable safe facts plus optional `EncryptedDetailRef`
+- `constitute-logging` must not receive or return decrypted detail
+- client/device wallets or explicitly authorized analyzer services handle decrypt/view
+
+Sensitive payloads, credentials, CAAC request bodies, service capability values, decrypted request bodies, raw secret material, and credential-bearing URLs are never valid safe facts.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Shared non-UI protocol, crypto-envelope, service-access, broker, and record prim
 - Service-access capability/status/signal contract names and codecs
 - Runtime broker message constants and validators
 - CAAC Storage primitive records for encrypted objects, encrypted index shards, key grants, pin leases, availability refs, graph edges, and encrypted detail refs
+- CAAC Logging primitive records for blind structured events, safe facts, redaction classes, correlation refs, and encrypted detail refs
 - Shared record codecs where records are duplicated across repos
 - Rust/JS fixtures proving the shared contract stays aligned
 
@@ -21,5 +22,6 @@ Shared non-UI protocol, crypto-envelope, service-access, broker, and record prim
 - `constitute-gateway` owns hosted-service admission and capability issuance policy.
 - `constitute-nvr` owns camera/media service behavior and capability enforcement.
 - `constitute-storage` owns the SQLite/files service implementation, pin/prune behavior, and local materialized search.
+- `constitute-logging` owns event observation, dedupe, safe-fact indexing, hot query/watch projections, and storage archive submission.
 
 Protocol code stays policy-neutral: it validates shapes and cryptographic envelopes, but downstream services decide whether a valid capability is sufficient for a specific operation.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,7 @@ export const SERVICE_ACCESS_EVENTS: Readonly<Record<string, string>>;
 export const SERVICE_ACCESS_KINDS: Readonly<Record<string, string>>;
 export const STORAGE: Readonly<Record<string, string>>;
 export const STORAGE_KEY_GRANULARITY: Readonly<Record<string, string>>;
+export const LOGGING: Readonly<Record<string, unknown>>;
 
 export type CaacRecipient = {
   recipientPk: string;
@@ -138,6 +139,66 @@ export type StorageAvailabilityRef = {
   expiresAt?: number;
 };
 
+export type LogSeverity = "debug" | "info" | "notice" | "warning" | "error" | "critical";
+export type LogCategory =
+  | "system"
+  | "serviceAccess"
+  | "serviceSignal"
+  | "hostedService"
+  | "gatewayControl"
+  | "cameraDevice"
+  | "mediaProjection"
+  | "recording"
+  | "worker"
+  | "storage"
+  | "logging";
+export type LogOutcome = "observed" | "succeeded" | "failed" | "denied" | "degraded" | "recovered";
+export type LogRedactionClass = "safe" | "redacted" | "encryptedDetail" | "sensitiveOmitted";
+
+export type LogProducerRef = {
+  service: string;
+  component: string;
+  instanceId?: string;
+  gatewayPk?: string;
+  servicePk?: string;
+};
+
+export type LogSubjectRef = {
+  kind: string;
+  id?: string;
+  display?: string;
+};
+
+export type LogResourceRef = {
+  kind: string;
+  id?: string;
+  display?: string;
+};
+
+export type LogCorrelationRef = {
+  correlationId: string;
+  causationId?: string;
+  traceId?: string;
+};
+
+export type LogEventEnvelope = {
+  schemaVersion: 1;
+  eventId: string;
+  occurredAt: number;
+  receivedAt?: number;
+  producer: LogProducerRef;
+  category: LogCategory;
+  severity: LogSeverity;
+  outcome: LogOutcome;
+  subject?: LogSubjectRef;
+  resource?: LogResourceRef;
+  correlation?: LogCorrelationRef;
+  tags?: string[];
+  safeFacts: Record<string, unknown>;
+  detailRef?: EncryptedDetailRef;
+  redaction?: LogRedactionClass[];
+};
+
 export function bytesToHex(bytes: Uint8Array): string;
 export function hexToBytes(hex: string): Uint8Array;
 export function utf8ToBytes(value: string): Uint8Array;
@@ -192,3 +253,7 @@ export function makeStorageObjectManifest(input?: {
   encryptionAlg?: string;
 }): StorageObjectManifest;
 export function assertStorageIndexShard(shard: unknown): StorageIndexShard;
+export function logEventId(event: Partial<LogEventEnvelope>): string;
+export function rejectSensitiveSafeFacts(value: unknown): void;
+export function assertLogEventEnvelope(event: unknown): LogEventEnvelope;
+export function makeLogEventEnvelope(input: Partial<LogEventEnvelope>): LogEventEnvelope;

--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,46 @@ export const STORAGE_KEY_GRANULARITY = Object.freeze({
   FIELD_FAMILY: "fieldFamily",
 });
 
+export const LOGGING = Object.freeze({
+  SCHEMA_VERSION: 1,
+  EVENT_ID_PREFIX: "constitute-log-event-v1",
+  SEVERITY: Object.freeze({
+    DEBUG: "debug",
+    INFO: "info",
+    NOTICE: "notice",
+    WARNING: "warning",
+    ERROR: "error",
+    CRITICAL: "critical",
+  }),
+  CATEGORY: Object.freeze({
+    SYSTEM: "system",
+    SERVICE_ACCESS: "serviceAccess",
+    SERVICE_SIGNAL: "serviceSignal",
+    HOSTED_SERVICE: "hostedService",
+    GATEWAY_CONTROL: "gatewayControl",
+    CAMERA_DEVICE: "cameraDevice",
+    MEDIA_PROJECTION: "mediaProjection",
+    RECORDING: "recording",
+    WORKER: "worker",
+    STORAGE: "storage",
+    LOGGING: "logging",
+  }),
+  OUTCOME: Object.freeze({
+    OBSERVED: "observed",
+    SUCCEEDED: "succeeded",
+    FAILED: "failed",
+    DENIED: "denied",
+    DEGRADED: "degraded",
+    RECOVERED: "recovered",
+  }),
+  REDACTION: Object.freeze({
+    SAFE: "safe",
+    REDACTED: "redacted",
+    ENCRYPTED_DETAIL: "encryptedDetail",
+    SENSITIVE_OMITTED: "sensitiveOmitted",
+  }),
+});
+
 export function bytesToHex(bytes) {
   return nobleBytesToHex(bytes);
 }
@@ -415,4 +455,105 @@ export function assertStorageIndexShard(shard) {
   if (!String(shard.ciphertextHash || "").trim()) throw new Error("storage index shard missing ciphertext hash");
   if (!Array.isArray(shard.chunks) || shard.chunks.length === 0) throw new Error("storage index shard has no chunks");
   return shard;
+}
+
+const SENSITIVE_SAFE_FACT_KEY_FRAGMENTS = [
+  "argv",
+  "body",
+  "caac",
+  "capability",
+  "credential",
+  "decrypted",
+  "password",
+  "payload",
+  "private",
+  "raw",
+  "rtsp",
+  "secret",
+  "servicecapability",
+  "token",
+];
+
+function withoutLogComputedFields(event) {
+  const clone = structuredClone(event || {});
+  delete clone.eventId;
+  delete clone.receivedAt;
+  return clone;
+}
+
+export function logEventId(event) {
+  return sha256Hex(`${LOGGING.EVENT_ID_PREFIX}|${canonicalJson(withoutLogComputedFields(event))}`);
+}
+
+export function rejectSensitiveSafeFacts(value) {
+  if (Array.isArray(value)) {
+    for (const item of value) rejectSensitiveSafeFacts(item);
+    return;
+  }
+  if (!value || typeof value !== "object") return;
+  for (const [key, next] of Object.entries(value)) {
+    const lowered = String(key).toLowerCase();
+    if (SENSITIVE_SAFE_FACT_KEY_FRAGMENTS.some((fragment) => lowered.includes(fragment))) {
+      throw new Error(`unsafe log safe fact key: ${key}`);
+    }
+    rejectSensitiveSafeFacts(next);
+  }
+}
+
+export function assertLogEventEnvelope(event) {
+  if (!event || typeof event !== "object") throw new Error("log event must be an object");
+  if (event.schemaVersion !== LOGGING.SCHEMA_VERSION) throw new Error("unsupported log schema version");
+  if (!String(event.eventId || "").trim()) throw new Error("log event missing event id");
+  if (!Number(event.occurredAt || 0)) throw new Error("log event missing occurred timestamp");
+  if (!event.producer || typeof event.producer !== "object") throw new Error("log event missing producer");
+  if (!String(event.producer.service || "").trim()) throw new Error("log event missing producer service");
+  if (!String(event.producer.component || "").trim()) throw new Error("log event missing producer component");
+  const severities = Object.values(LOGGING.SEVERITY);
+  const categories = Object.values(LOGGING.CATEGORY);
+  const outcomes = Object.values(LOGGING.OUTCOME);
+  if (!severities.includes(event.severity)) throw new Error("invalid log severity");
+  if (!categories.includes(event.category)) throw new Error("invalid log category");
+  if (!outcomes.includes(event.outcome)) throw new Error("invalid log outcome");
+  if (!event.safeFacts || typeof event.safeFacts !== "object" || Array.isArray(event.safeFacts)) {
+    throw new Error("log safe facts must be an object");
+  }
+  rejectSensitiveSafeFacts(event.safeFacts);
+  if (event.eventId !== logEventId(event)) throw new Error("log event id mismatch");
+  return event;
+}
+
+export function makeLogEventEnvelope({
+  occurredAt = nowSeconds(),
+  receivedAt,
+  producer,
+  category = LOGGING.CATEGORY.SYSTEM,
+  severity = LOGGING.SEVERITY.INFO,
+  outcome = LOGGING.OUTCOME.OBSERVED,
+  subject,
+  resource,
+  correlation,
+  tags = [],
+  safeFacts = {},
+  detailRef,
+  redaction = [LOGGING.REDACTION.SAFE],
+} = {}) {
+  const event = {
+    schemaVersion: LOGGING.SCHEMA_VERSION,
+    eventId: "",
+    occurredAt,
+    producer,
+    category,
+    severity,
+    outcome,
+    tags,
+    safeFacts,
+    redaction,
+  };
+  if (receivedAt !== undefined) event.receivedAt = receivedAt;
+  if (subject) event.subject = subject;
+  if (resource) event.resource = resource;
+  if (correlation) event.correlation = correlation;
+  if (detailRef) event.detailRef = detailRef;
+  event.eventId = logEventId(event);
+  return assertLogEventEnvelope(event);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod broker;
 pub mod caac;
 pub mod crypto;
+pub mod logging;
 pub mod nostr;
 pub mod records;
 pub mod service_access;
@@ -9,6 +10,7 @@ pub mod storage;
 pub use broker::*;
 pub use caac::*;
 pub use crypto::*;
+pub use logging::*;
 pub use nostr::*;
 pub use records::*;
 pub use service_access::*;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,273 @@
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::crypto::{canonical_json, sha256_hex};
+use crate::storage::EncryptedDetailRef;
+
+pub const LOG_SCHEMA_VERSION: u16 = 1;
+pub const LOG_EVENT_ID_PREFIX: &str = "constitute-log-event-v1";
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum LogSeverity {
+    Debug,
+    Info,
+    Notice,
+    Warning,
+    Error,
+    Critical,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum LogCategory {
+    System,
+    ServiceAccess,
+    ServiceSignal,
+    HostedService,
+    GatewayControl,
+    CameraDevice,
+    MediaProjection,
+    Recording,
+    Worker,
+    Storage,
+    Logging,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum LogOutcome {
+    Observed,
+    Succeeded,
+    Failed,
+    Denied,
+    Degraded,
+    Recovered,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum LogRedactionClass {
+    Safe,
+    Redacted,
+    EncryptedDetail,
+    SensitiveOmitted,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LogProducerRef {
+    pub service: String,
+    pub component: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instance_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gateway_pk: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_pk: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LogSubjectRef {
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LogResourceRef {
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct LogCorrelationRef {
+    pub correlation_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub causation_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LogEventEnvelope {
+    pub schema_version: u16,
+    pub event_id: String,
+    pub occurred_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub received_at: Option<u64>,
+    pub producer: LogProducerRef,
+    pub category: LogCategory,
+    pub severity: LogSeverity,
+    pub outcome: LogOutcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject: Option<LogSubjectRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource: Option<LogResourceRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub correlation: Option<LogCorrelationRef>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail_ref: Option<EncryptedDetailRef>,
+    #[serde(default)]
+    pub redaction: Vec<LogRedactionClass>,
+}
+
+pub fn log_event_id(event: &LogEventEnvelope) -> Result<String> {
+    let mut value = serde_json::to_value(event)?;
+    if let Value::Object(map) = &mut value {
+        map.remove("eventId");
+        map.remove("receivedAt");
+    }
+    Ok(sha256_hex(format!(
+        "{}|{}",
+        LOG_EVENT_ID_PREFIX,
+        canonical_json(&value)?
+    )))
+}
+
+pub fn validate_log_event(event: &LogEventEnvelope) -> Result<()> {
+    if event.schema_version != LOG_SCHEMA_VERSION {
+        return Err(anyhow!("unsupported log schema version"));
+    }
+    if event.producer.service.trim().is_empty() {
+        return Err(anyhow!("log event missing producer service"));
+    }
+    if event.producer.component.trim().is_empty() {
+        return Err(anyhow!("log event missing producer component"));
+    }
+    if event.occurred_at == 0 {
+        return Err(anyhow!("log event missing occurred timestamp"));
+    }
+    if !event.safe_facts.is_object() {
+        return Err(anyhow!("log safe facts must be an object"));
+    }
+    reject_sensitive_safe_facts(&event.safe_facts)?;
+    let expected = log_event_id(event)?;
+    if event.event_id != expected {
+        return Err(anyhow!("log event id mismatch"));
+    }
+    Ok(())
+}
+
+pub fn reject_sensitive_safe_facts(value: &Value) -> Result<()> {
+    match value {
+        Value::Object(map) => {
+            for (key, next) in map {
+                let lowered = key.to_ascii_lowercase();
+                if SENSITIVE_SAFE_FACT_KEY_FRAGMENTS
+                    .iter()
+                    .any(|fragment| lowered.contains(fragment))
+                {
+                    return Err(anyhow!("unsafe log safe fact key: {}", key));
+                }
+                reject_sensitive_safe_facts(next)?;
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                reject_sensitive_safe_facts(item)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+const SENSITIVE_SAFE_FACT_KEY_FRAGMENTS: &[&str] = &[
+    "argv",
+    "body",
+    "caac",
+    "capability",
+    "credential",
+    "decrypted",
+    "password",
+    "payload",
+    "private",
+    "raw",
+    "rtsp",
+    "secret",
+    "servicecapability",
+    "token",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn event(safe_facts: Value) -> LogEventEnvelope {
+        let mut event = LogEventEnvelope {
+            schema_version: LOG_SCHEMA_VERSION,
+            event_id: String::new(),
+            occurred_at: 1_700_000_000,
+            received_at: None,
+            producer: LogProducerRef {
+                service: "gateway".to_string(),
+                component: "managed".to_string(),
+                instance_id: Some("gateway-1".to_string()),
+                gateway_pk: None,
+                service_pk: None,
+            },
+            category: LogCategory::ServiceAccess,
+            severity: LogSeverity::Info,
+            outcome: LogOutcome::Succeeded,
+            subject: Some(LogSubjectRef {
+                kind: "service".to_string(),
+                id: Some("nvr".to_string()),
+                display: Some("Security Cameras".to_string()),
+            }),
+            resource: None,
+            correlation: Some(LogCorrelationRef {
+                correlation_id: "corr-1".to_string(),
+                causation_id: None,
+                trace_id: None,
+            }),
+            tags: vec!["service-access".to_string()],
+            safe_facts,
+            detail_ref: None,
+            redaction: vec![LogRedactionClass::Safe],
+        };
+        event.event_id = log_event_id(&event).expect("event id");
+        event
+    }
+
+    #[test]
+    fn validates_log_event() {
+        let event = event(json!({
+            "service": "nvr",
+            "operation": "request",
+            "result": "accepted"
+        }));
+        validate_log_event(&event).expect("valid log event");
+    }
+
+    #[test]
+    fn rejects_sensitive_safe_fact_keys() {
+        let event = event(json!({
+            "service": "nvr",
+            "serviceCapability": "secret"
+        }));
+        assert!(validate_log_event(&event).is_err());
+    }
+
+    #[test]
+    fn rejects_log_event_id_mismatch() {
+        let mut event = event(json!({ "operation": "request" }));
+        event.event_id = "bad".to_string();
+        assert!(validate_log_event(&event).is_err());
+    }
+}

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   BROKER,
+  LOGGING,
   ReplayCache,
   SERVICE_ACCESS_EVENTS,
   SERVICE_ACCESS_KINDS,
@@ -9,10 +10,12 @@ import {
   assertStorageChunkRef,
   assertStorageObjectManifest,
   assertStorageIndexShard,
+  assertLogEventEnvelope,
   buildUnsignedEvent,
   eventIdHex,
   makeStorageChunkRef,
   makeStorageObjectManifest,
+  makeLogEventEnvelope,
   openEnvelope,
   pubkeyFromSecretKey,
   sealEnvelope,
@@ -130,4 +133,42 @@ test("storage manifest helpers validate ciphertext-addressed objects", () => {
     createdAt: 1700000000,
   };
   assertStorageIndexShard(shard);
+});
+
+test("logging helpers validate safe event envelopes", () => {
+  const event = makeLogEventEnvelope({
+    occurredAt: 1700000000,
+    producer: {
+      service: "gateway",
+      component: "managed",
+      instanceId: "gateway-1",
+    },
+    category: LOGGING.CATEGORY.SERVICE_ACCESS,
+    severity: LOGGING.SEVERITY.INFO,
+    outcome: LOGGING.OUTCOME.SUCCEEDED,
+    subject: {
+      kind: "service",
+      id: "nvr",
+      display: "Security Cameras",
+    },
+    correlation: {
+      correlationId: "corr-1",
+    },
+    tags: ["service-access"],
+    safeFacts: {
+      service: "nvr",
+      operation: "request",
+      result: "accepted",
+    },
+  });
+  assertLogEventEnvelope(event);
+
+  const bad = structuredClone(event);
+  bad.safeFacts.serviceCapability = "secret";
+  bad.eventId = event.eventId;
+  assert.throws(() => assertLogEventEnvelope(bad), /unsafe log safe fact key/);
+
+  const mismatch = structuredClone(event);
+  mismatch.eventId = "bad";
+  assert.throws(() => assertLogEventEnvelope(mismatch), /log event id mismatch/);
 });


### PR DESCRIPTION
## Summary
- add blind CAAC logging event contracts and safe-fact validation
- add JS helpers and declarations for logging event construction/validation
- add protocol tests for unsafe safe-fact rejection and event id determinism

Closes #4.