### PR TITLE
Add service projection contracts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -9,6 +9,7 @@
 - CAAC v1 envelope shape and validation helpers
 - broker message names and payload validators
 - service-access capability/status/request/signal contract shapes
+- hosted-service descriptors, service exchange frames, service projection records, cursor/freshness, diagnostics, and transport-neutral control/observe contract shapes
 - CAAC Storage primitive records for encrypted content-addressed objects, encrypted index shards, key grants, pins, availability refs, graph edges, and encrypted detail refs
 - CAAC Logging primitive records for safe structured event envelopes, redaction classes, correlation refs, and encrypted detail references
 - shared record codecs where multiple repos previously duplicated the same shape
@@ -77,6 +78,54 @@ The current first-party service-access vocabulary is:
 
 The launch-token vocabulary is retired in consumers of this package.
 
+## Service Control And Observation
+
+Gateway is host/control-plane and route authority. Services own semantic validation and response shaping.
+
+Protocol owns the shared frame and record shapes for:
+
+- `HostedServiceDescriptor`
+- `ServiceExchangeFrame`
+- `ProjectionRecord`
+- `DiagnosticEvent`
+
+The service exchange frame families are:
+
+- `service.describe.request`
+- `service.describe.response`
+- `service.projection.request`
+- `service.projection.response`
+- `service.control.request`
+- `service.control.response`
+- `service.invoke.request`
+- `service.invoke.response`
+- `service.watch.request`
+- `service.watch.event`
+- `service.close`
+
+Service communication is protocol frames over transport adapters. HTTP is not an ecosystem contract. Temporary local transports may exist only below the protocol boundary and should carry generic service frames, not service-specific routes or query semantics.
+
+## Runtime Projections
+
+Runtime projections are retained, capability-scoped, app-consumable state channels.
+Protocol owns the generic shape only:
+
+- `ProjectionChannel`
+- `ProjectionCursor`
+- `ProjectionFreshness`
+- `ProjectionPolicy`
+- `ProjectionCoverage`
+- `ProjectionSyncState`
+- `ProjectionObserverUpdate`
+- `ProjectionRecord`
+
+Projection channels are explicit names, not arbitrary data pipes. The initial channels are:
+
+- `logging.events`
+- `logging.health`
+
+Broker/control messages may establish access or repair stale projections through service-owned exchange. They are not the primary browser data surface. Browser apps consume retained/runtime-materialized projections first. Runtime synchronization, cursors, and chunks are below the projection boundary and must not become app table logic.
+
 ## CAAC Storage
 
 CAAC Storage is the current storage access model. It is not a separate SCAAC architecture.
@@ -102,6 +151,8 @@ Protocol owns shared log/event record shapes and validation only. Logging is bli
 - producers create safe facts from their own plaintext context
 - producers encrypt sensitive detail before it enters a logging surface
 - log records carry searchable safe facts plus optional `EncryptedDetailRef`
+- logging event projections remain generic: one event envelope contract, dynamic `safeFacts`, typed refs, tags, severity, category, and outcome
+- logging projection policy/coverage records describe sync target, rolling scope, verbosity, retention target, materialized count, target count, and sync state
 - `constitute-logging` must not receive or return decrypted detail
 - client/device wallets or explicitly authorized analyzer services handle decrypt/view
 

--- a/src/broker.rs
+++ b/src/broker.rs
@@ -5,6 +5,10 @@ pub const BROKER_SERVICE_SIGNAL_RESPONSE: &str = "gateway.serviceSignal.response
 pub const BROKER_SERVICE_ACCESS_CONTEXT_GET: &str = "serviceAccessContext.get";
 pub const BROKER_SERVICE_ACCESS_CONTEXT_PUT: &str = "serviceAccessContext.put";
 pub const BROKER_SERVICE_ACCESS_CONTEXT_DELETE: &str = "serviceAccessContext.delete";
+pub const BROKER_PROJECTION_GET: &str = "projection.get";
+pub const BROKER_PROJECTION_PUT: &str = "projection.put";
+pub const BROKER_SERVICE_PROJECTION_REQUEST: &str = "service.projection.request";
+pub const BROKER_SERVICE_PROJECTION_RESPONSE: &str = "service.projection.response";
 
 pub fn is_protocol_broker_message(name: &str) -> bool {
     matches!(
@@ -16,5 +20,9 @@ pub fn is_protocol_broker_message(name: &str) -> bool {
             | BROKER_SERVICE_ACCESS_CONTEXT_GET
             | BROKER_SERVICE_ACCESS_CONTEXT_PUT
             | BROKER_SERVICE_ACCESS_CONTEXT_DELETE
+            | BROKER_PROJECTION_GET
+            | BROKER_PROJECTION_PUT
+            | BROKER_SERVICE_PROJECTION_REQUEST
+            | BROKER_SERVICE_PROJECTION_RESPONSE
     )
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,11 +4,14 @@ export const DEFAULT_CAPABILITY_TTL_SECONDS: number;
 export const MAX_CAPABILITY_TTL_SECONDS: number;
 export const DEFAULT_REQUEST_TTL_SECONDS: number;
 export const BROKER: Readonly<Record<string, string>>;
+export const SERVICE_EXCHANGE: Readonly<Record<string, unknown>>;
 export const SERVICE_ACCESS_EVENTS: Readonly<Record<string, string>>;
 export const SERVICE_ACCESS_KINDS: Readonly<Record<string, string>>;
 export const STORAGE: Readonly<Record<string, string>>;
 export const STORAGE_KEY_GRANULARITY: Readonly<Record<string, string>>;
 export const LOGGING: Readonly<Record<string, unknown>>;
+export const PROJECTION: Readonly<Record<string, unknown>>;
+export const DIAGNOSTICS: Readonly<Record<string, unknown>>;
 
 export type CaacRecipient = {
   recipientPk: string;
@@ -154,6 +157,8 @@ export type LogCategory =
   | "logging";
 export type LogOutcome = "observed" | "succeeded" | "failed" | "denied" | "degraded" | "recovered";
 export type LogRedactionClass = "safe" | "redacted" | "encryptedDetail" | "sensitiveOmitted";
+export type LogVerbosityClass = "critical" | "normal" | "verbose" | "noise";
+export type LogRetentionClass = "forever" | "long" | "rolling" | "short" | "ephemeral";
 
 export type LogProducerRef = {
   service: string;
@@ -197,6 +202,139 @@ export type LogEventEnvelope = {
   safeFacts: Record<string, unknown>;
   detailRef?: EncryptedDetailRef;
   redaction?: LogRedactionClass[];
+};
+
+export type ProjectionFreshnessState = "fresh" | "stale" | "missing" | "error";
+
+export type ProjectionCursor = {
+  value: string;
+  updatedAt: number;
+};
+
+export type ProjectionFreshness = {
+  state: ProjectionFreshnessState;
+  updatedAt: number;
+  staleAfter?: number;
+  reason?: string;
+};
+
+export type ProjectionChannel = {
+  channelId: string;
+  service: string;
+  projectionKind: string;
+  capabilityScope: string;
+};
+
+export type ServiceProjectionRequest = {
+  requestId: string;
+  channelId: string;
+  service: string;
+  cursor?: string;
+  limit?: number;
+  filters?: Record<string, unknown>;
+  policy?: ProjectionPolicy;
+};
+
+export type HostedServiceDescriptor = {
+  service: string;
+  servicePk: string;
+  hostGatewayPk: string;
+  display?: Record<string, unknown>;
+  capabilities?: string[];
+  projectionChannels?: string[];
+  invocationKinds?: string[];
+  transportHints?: Record<string, unknown>;
+  healthSummary?: Record<string, unknown>;
+};
+
+export type ServiceExchangeFrame = {
+  frameId: string;
+  schemaVersion: number;
+  kind: string;
+  issuerPk: string;
+  recipientServicePk: string;
+  hostGatewayPk: string;
+  issuedAt: number;
+  expiresAt: number;
+  traceId?: string;
+  requestId?: string;
+  correlationId?: string;
+  routeHint?: Record<string, unknown>;
+  sealedPayload?: Record<string, unknown>;
+  signature: string;
+};
+
+export type ProjectionRecord = {
+  channelId: string;
+  service: string;
+  servicePk: string;
+  producer?: Record<string, unknown>;
+  cursor?: ProjectionCursor;
+  freshness: ProjectionFreshness;
+  scope?: Record<string, unknown>;
+  payloadSchema?: string;
+  payload: Record<string, unknown>;
+  safeFacts?: Record<string, unknown>;
+  encryptedDetailRefs?: unknown[];
+  diagnostics?: unknown[];
+};
+
+export type ProjectionSyncState = "idle" | "syncing" | "degraded" | "stale" | "blocked" | "completeEnough";
+
+export type ProjectionPolicy = {
+  policyId: string;
+  channelId: string;
+  service: string;
+  scope?: Record<string, unknown>;
+  rollingWindowHours?: number;
+  maxVerbosityClass?: LogVerbosityClass;
+  minSeverity?: LogSeverity;
+  excludedVerbosityClasses?: LogVerbosityClass[];
+  syncDepthTarget?: Record<string, unknown>;
+  retentionTarget?: Record<string, unknown>;
+};
+
+export type ProjectionCoverage = {
+  materializedCount: number;
+  targetCount?: number;
+  completionRatio: number;
+  completeSeverityBands?: string[];
+  oldestObservedAt?: number;
+  newestObservedAt?: number;
+  syncState: ProjectionSyncState;
+};
+
+export type ProjectionObserverUpdate = {
+  projectionKey: string;
+  changedCount: number;
+  coverage: ProjectionCoverage;
+  freshness: ProjectionFreshness;
+  diagnostics?: unknown[];
+};
+
+export type DiagnosticEvent = {
+  diagnosticId: string;
+  schemaVersion: number;
+  occurredAt: number;
+  level: string;
+  surface?: string;
+  component?: string;
+  operation: string;
+  stage?: string;
+  traceId?: string;
+  requestId?: string;
+  correlationId?: string;
+  channelId?: string;
+  service?: string;
+  servicePk?: string;
+  hostGatewayPk?: string;
+  routeKind?: string;
+  durationMs?: number;
+  counts?: Record<string, number>;
+  safeFacts?: Record<string, unknown>;
+  errorCode?: string;
+  errorMessage?: string;
+  encryptedDetailRefs?: unknown[];
 };
 
 export function bytesToHex(bytes: Uint8Array): string;
@@ -257,3 +395,19 @@ export function logEventId(event: Partial<LogEventEnvelope>): string;
 export function rejectSensitiveSafeFacts(value: unknown): void;
 export function assertLogEventEnvelope(event: unknown): LogEventEnvelope;
 export function makeLogEventEnvelope(input: Partial<LogEventEnvelope>): LogEventEnvelope;
+export function rejectUnsafeSafeFacts(value: unknown): void;
+export function assertHostedServiceDescriptor(descriptor: unknown): HostedServiceDescriptor;
+export function assertServiceExchangeFrame(frame: unknown): ServiceExchangeFrame;
+export function makeServiceExchangeFrame(input: Partial<ServiceExchangeFrame>): ServiceExchangeFrame;
+export function assertProjectionChannelId(channelId: unknown, descriptor?: Partial<HostedServiceDescriptor>): string;
+export function assertProjectionFreshness(freshness: unknown): ProjectionFreshness;
+export function assertServiceProjectionRequest(request: unknown, descriptor?: Partial<HostedServiceDescriptor>): ServiceProjectionRequest;
+export function assertProjectionPolicy(policy: unknown, descriptor?: Partial<HostedServiceDescriptor>): ProjectionPolicy;
+export function makeProjectionPolicy(input: Partial<ProjectionPolicy>): ProjectionPolicy;
+export function assertProjectionCoverage(coverage: unknown): ProjectionCoverage;
+export function makeProjectionCoverage(input: Partial<ProjectionCoverage>): ProjectionCoverage;
+export function assertProjectionObserverUpdate(update: unknown): ProjectionObserverUpdate;
+export function makeProjectionObserverUpdate(input: Partial<ProjectionObserverUpdate>): ProjectionObserverUpdate;
+export function assertProjectionRecord(result: unknown, descriptor?: Partial<HostedServiceDescriptor>): ProjectionRecord;
+export function makeProjectionRecord(input: Partial<ProjectionRecord>): ProjectionRecord;
+export function assertDiagnosticEvent(event: unknown): DiagnosticEvent;

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,28 @@ export const BROKER = Object.freeze({
   SERVICE_ACCESS_CONTEXT_GET: "serviceAccessContext.get",
   SERVICE_ACCESS_CONTEXT_PUT: "serviceAccessContext.put",
   SERVICE_ACCESS_CONTEXT_DELETE: "serviceAccessContext.delete",
+  PROJECTION_GET: "projection.get",
+  PROJECTION_PUT: "projection.put",
+  PROJECTION_POLICY_PUT: "projection.policy.put",
+  SERVICE_PROJECTION_REQUEST: "service.projection.request",
+  SERVICE_PROJECTION_RESPONSE: "service.projection.response",
+});
+
+export const SERVICE_EXCHANGE = Object.freeze({
+  SCHEMA_VERSION: 1,
+  KIND: Object.freeze({
+    DESCRIBE_REQUEST: "service.describe.request",
+    DESCRIBE_RESPONSE: "service.describe.response",
+    PROJECTION_REQUEST: "service.projection.request",
+    PROJECTION_RESPONSE: "service.projection.response",
+    CONTROL_REQUEST: "service.control.request",
+    CONTROL_RESPONSE: "service.control.response",
+    INVOKE_REQUEST: "service.invoke.request",
+    INVOKE_RESPONSE: "service.invoke.response",
+    WATCH_REQUEST: "service.watch.request",
+    WATCH_EVENT: "service.watch.event",
+    CLOSE: "service.close",
+  }),
 });
 
 export const SERVICE_ACCESS_EVENTS = Object.freeze({
@@ -92,6 +114,53 @@ export const LOGGING = Object.freeze({
     REDACTED: "redacted",
     ENCRYPTED_DETAIL: "encryptedDetail",
     SENSITIVE_OMITTED: "sensitiveOmitted",
+  }),
+  VERBOSITY_CLASS: Object.freeze({
+    CRITICAL: "critical",
+    NORMAL: "normal",
+    VERBOSE: "verbose",
+    NOISE: "noise",
+  }),
+  RETENTION_CLASS: Object.freeze({
+    FOREVER: "forever",
+    LONG: "long",
+    ROLLING: "rolling",
+    SHORT: "short",
+    EPHEMERAL: "ephemeral",
+  }),
+});
+
+export const PROJECTION = Object.freeze({
+  CHANNEL: Object.freeze({
+    LOGGING_EVENTS: "logging.events",
+    LOGGING_HEALTH: "logging.health",
+    LOGGING_DASHBOARD: "logging.dashboard",
+    DIAGNOSTICS_EVENTS: "diagnostics.events",
+  }),
+  FRESHNESS: Object.freeze({
+    FRESH: "fresh",
+    STALE: "stale",
+    MISSING: "missing",
+    ERROR: "error",
+  }),
+  SYNC_STATE: Object.freeze({
+    IDLE: "idle",
+    SYNCING: "syncing",
+    DEGRADED: "degraded",
+    STALE: "stale",
+    BLOCKED: "blocked",
+    COMPLETE_ENOUGH: "completeEnough",
+  }),
+});
+
+export const DIAGNOSTICS = Object.freeze({
+  SCHEMA_VERSION: 1,
+  CHANNEL_EVENTS: "diagnostics.events",
+  LEVEL: Object.freeze({
+    DEBUG: "debug",
+    INFO: "info",
+    WARN: "warn",
+    ERROR: "error",
   }),
 });
 
@@ -556,4 +625,298 @@ export function makeLogEventEnvelope({
   if (detailRef) event.detailRef = detailRef;
   event.eventId = logEventId(event);
   return assertLogEventEnvelope(event);
+}
+
+const UNSAFE_SAFE_FACT_KEY_RE = /(password|credential|secret|token|capability|servicecapability|privatekey|secretkey|rtspurl|authorization|rawpayload|requestbody)/i;
+const UNSAFE_SAFE_FACT_VALUE_RE = /(rtsp:\/\/|authorization:|servicecapability|-----begin)/i;
+
+export function rejectUnsafeSafeFacts(value, path = "") {
+  if (value == null) return;
+  if (Array.isArray(value)) {
+    for (const item of value) rejectUnsafeSafeFacts(item, path);
+    return;
+  }
+  if (typeof value === "object") {
+    for (const [key, child] of Object.entries(value)) {
+      if (UNSAFE_SAFE_FACT_KEY_RE.test(key)) throw new Error(`unsafe safe fact key: ${path}${key}`);
+      rejectUnsafeSafeFacts(child, `${path}${key}.`);
+    }
+    return;
+  }
+  if (typeof value === "string" && UNSAFE_SAFE_FACT_VALUE_RE.test(value)) {
+    throw new Error("unsafe safe fact value");
+  }
+}
+
+export function assertHostedServiceDescriptor(descriptor) {
+  if (!descriptor || typeof descriptor !== "object") throw new Error("service descriptor must be an object");
+  if (!String(descriptor.service || "").trim()) throw new Error("service descriptor missing service");
+  if (!String(descriptor.servicePk || "").trim()) throw new Error("service descriptor missing servicePk");
+  if (!String(descriptor.hostGatewayPk || "").trim()) throw new Error("service descriptor missing hostGatewayPk");
+  if (descriptor.projectionChannels !== undefined && !Array.isArray(descriptor.projectionChannels)) {
+    throw new Error("service descriptor projectionChannels must be an array");
+  }
+  for (const channel of descriptor.projectionChannels || []) {
+    if (!String(channel || "").trim()) throw new Error("service descriptor contains empty projection channel");
+  }
+  return descriptor;
+}
+
+export function assertServiceExchangeFrame(frame) {
+  if (!frame || typeof frame !== "object") throw new Error("service exchange frame must be an object");
+  if (!String(frame.frameId || "").trim()) throw new Error("service exchange missing frameId");
+  if (!Number(frame.schemaVersion || 0)) throw new Error("service exchange missing schemaVersion");
+  if (!Object.values(SERVICE_EXCHANGE.KIND).includes(String(frame.kind || "").trim())) {
+    throw new Error("unsupported service exchange kind");
+  }
+  if (!String(frame.issuerPk || "").trim()) throw new Error("service exchange missing issuerPk");
+  if (!String(frame.recipientServicePk || "").trim()) throw new Error("service exchange missing recipientServicePk");
+  if (!String(frame.hostGatewayPk || "").trim()) throw new Error("service exchange missing hostGatewayPk");
+  if (!Number(frame.issuedAt || 0) || !Number(frame.expiresAt || 0) || Number(frame.expiresAt) <= Number(frame.issuedAt)) {
+    throw new Error("service exchange invalid time bounds");
+  }
+  if (!String(frame.signature || "").trim()) throw new Error("service exchange missing signature");
+  return frame;
+}
+
+export function makeServiceExchangeFrame(input = {}) {
+  const now = nowSeconds();
+  return assertServiceExchangeFrame({
+    frameId: String(input.frameId || `service-frame-${sha256Hex(`${now}:${Math.random()}`).slice(0, 24)}`),
+    schemaVersion: Number(input.schemaVersion || SERVICE_EXCHANGE.SCHEMA_VERSION),
+    kind: String(input.kind || ""),
+    issuerPk: String(input.issuerPk || ""),
+    recipientServicePk: String(input.recipientServicePk || ""),
+    hostGatewayPk: String(input.hostGatewayPk || ""),
+    issuedAt: Number(input.issuedAt || now),
+    expiresAt: Number(input.expiresAt || now + DEFAULT_REQUEST_TTL_SECONDS),
+    ...(input.traceId ? { traceId: String(input.traceId) } : {}),
+    ...(input.requestId ? { requestId: String(input.requestId) } : {}),
+    ...(input.correlationId ? { correlationId: String(input.correlationId) } : {}),
+    routeHint: input.routeHint && typeof input.routeHint === "object" ? input.routeHint : {},
+    sealedPayload: input.sealedPayload && typeof input.sealedPayload === "object" ? input.sealedPayload : {},
+    signature: String(input.signature || "unsigned-local-frame"),
+  });
+}
+
+export function assertProjectionChannelId(channelId, descriptor) {
+  const value = String(channelId || "").trim();
+  if (!value) throw new Error("projection missing channel id");
+  const descriptorChannels = Array.isArray(descriptor?.projectionChannels) ? descriptor.projectionChannels : [];
+  if (descriptorChannels.length > 0) {
+    if (!descriptorChannels.includes(value)) throw new Error("unsupported projection channel");
+    return value;
+  }
+  if (!Object.values(PROJECTION.CHANNEL).includes(value)) {
+    throw new Error("unsupported projection channel");
+  }
+  return value;
+}
+
+export function assertProjectionFreshness(freshness) {
+  if (!freshness || typeof freshness !== "object") throw new Error("projection freshness must be an object");
+  if (!Object.values(PROJECTION.FRESHNESS).includes(freshness.state)) throw new Error("invalid projection freshness state");
+  if (!Number(freshness.updatedAt || 0)) throw new Error("projection freshness missing updatedAt");
+  return freshness;
+}
+
+export function assertServiceProjectionRequest(request, descriptor) {
+  if (!request || typeof request !== "object") throw new Error("service projection request must be an object");
+  if (!String(request.requestId || "").trim()) throw new Error("service projection missing requestId");
+  assertProjectionChannelId(request.channelId, descriptor);
+  if (!String(request.service || "").trim()) throw new Error("service projection missing service");
+  const filters = request.filters ?? {};
+  if (!filters || typeof filters !== "object" || Array.isArray(filters)) {
+    throw new Error("service projection filters must be an object");
+  }
+  if (request.policy !== undefined) {
+    assertProjectionPolicy(request.policy, descriptor);
+    if (request.policy.channelId !== request.channelId) throw new Error("projection policy channel mismatch");
+    if (request.policy.service !== request.service) throw new Error("projection policy service mismatch");
+  }
+  return request;
+}
+
+export function assertProjectionPolicy(policy, descriptor) {
+  if (!policy || typeof policy !== "object") throw new Error("projection policy must be an object");
+  if (!String(policy.policyId || "").trim()) throw new Error("projection policy missing policyId");
+  assertProjectionChannelId(policy.channelId, descriptor);
+  if (!String(policy.service || "").trim()) throw new Error("projection policy missing service");
+  const scope = policy.scope ?? {};
+  if (!scope || typeof scope !== "object" || Array.isArray(scope)) throw new Error("projection policy scope must be an object");
+  if (policy.rollingWindowHours !== undefined && Number(policy.rollingWindowHours) <= 0) {
+    throw new Error("projection policy rolling window must be positive");
+  }
+  if (policy.maxVerbosityClass !== undefined && !Object.values(LOGGING.VERBOSITY_CLASS).includes(policy.maxVerbosityClass)) {
+    throw new Error("invalid projection policy verbosity class");
+  }
+  if (policy.minSeverity !== undefined && !Object.values(LOGGING.SEVERITY).includes(policy.minSeverity)) {
+    throw new Error("invalid projection policy severity");
+  }
+  const excluded = policy.excludedVerbosityClasses ?? [];
+  if (!Array.isArray(excluded)) throw new Error("projection policy excluded verbosity classes must be an array");
+  for (const value of excluded) {
+    if (!Object.values(LOGGING.VERBOSITY_CLASS).includes(value)) throw new Error("invalid projection policy excluded verbosity class");
+  }
+  for (const [field, value] of Object.entries({
+    syncDepthTarget: policy.syncDepthTarget ?? {},
+    retentionTarget: policy.retentionTarget ?? {},
+  })) {
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      throw new Error(`projection policy ${field} must be an object`);
+    }
+  }
+  return policy;
+}
+
+export function makeProjectionPolicy({
+  policyId,
+  channelId,
+  service,
+  scope = {},
+  rollingWindowHours,
+  maxVerbosityClass,
+  minSeverity,
+  excludedVerbosityClasses = [],
+  syncDepthTarget = {},
+  retentionTarget = {},
+} = {}) {
+  return assertProjectionPolicy({
+    policyId,
+    channelId,
+    service,
+    scope,
+    ...(rollingWindowHours !== undefined ? { rollingWindowHours: Number(rollingWindowHours) } : {}),
+    ...(maxVerbosityClass ? { maxVerbosityClass } : {}),
+    ...(minSeverity ? { minSeverity } : {}),
+    excludedVerbosityClasses,
+    syncDepthTarget,
+    retentionTarget,
+  });
+}
+
+export function assertProjectionCoverage(coverage) {
+  if (!coverage || typeof coverage !== "object") throw new Error("projection coverage must be an object");
+  if (!Number.isFinite(Number(coverage.materializedCount)) || Number(coverage.materializedCount) < 0) {
+    throw new Error("projection coverage invalid materialized count");
+  }
+  if (coverage.targetCount !== undefined && (!Number.isFinite(Number(coverage.targetCount)) || Number(coverage.targetCount) < 0)) {
+    throw new Error("projection coverage invalid target count");
+  }
+  const ratio = Number(coverage.completionRatio);
+  if (!Number.isFinite(ratio) || ratio < 0 || ratio > 1) {
+    throw new Error("projection coverage completion ratio must be 0..1");
+  }
+  if (!Object.values(PROJECTION.SYNC_STATE).includes(coverage.syncState)) {
+    throw new Error("invalid projection sync state");
+  }
+  if (coverage.completeSeverityBands !== undefined && !Array.isArray(coverage.completeSeverityBands)) {
+    throw new Error("projection coverage severity bands must be an array");
+  }
+  return coverage;
+}
+
+export function makeProjectionCoverage({
+  materializedCount = 0,
+  targetCount,
+  completionRatio = 0,
+  completeSeverityBands = [],
+  oldestObservedAt,
+  newestObservedAt,
+  syncState = PROJECTION.SYNC_STATE.IDLE,
+} = {}) {
+  return assertProjectionCoverage({
+    materializedCount: Number(materializedCount),
+    ...(targetCount !== undefined ? { targetCount: Number(targetCount) } : {}),
+    completionRatio: Number(completionRatio),
+    completeSeverityBands,
+    ...(oldestObservedAt !== undefined ? { oldestObservedAt: Number(oldestObservedAt) } : {}),
+    ...(newestObservedAt !== undefined ? { newestObservedAt: Number(newestObservedAt) } : {}),
+    syncState,
+  });
+}
+
+export function assertProjectionObserverUpdate(update) {
+  if (!update || typeof update !== "object") throw new Error("projection observer update must be an object");
+  if (!String(update.projectionKey || "").trim()) throw new Error("projection observer update missing projection key");
+  if (!Number.isFinite(Number(update.changedCount)) || Number(update.changedCount) < 0) {
+    throw new Error("projection observer update invalid changed count");
+  }
+  assertProjectionCoverage(update.coverage);
+  assertProjectionFreshness(update.freshness);
+  if (update.diagnostics !== undefined && !Array.isArray(update.diagnostics)) {
+    throw new Error("projection observer diagnostics must be an array");
+  }
+  return update;
+}
+
+export function makeProjectionObserverUpdate({
+  projectionKey,
+  changedCount = 0,
+  coverage,
+  freshness,
+  diagnostics = [],
+} = {}) {
+  return assertProjectionObserverUpdate({
+    projectionKey,
+    changedCount: Number(changedCount),
+    coverage,
+    freshness,
+    diagnostics,
+  });
+}
+
+export function assertProjectionRecord(result, descriptor) {
+  if (!result || typeof result !== "object") throw new Error("projection record must be an object");
+  assertProjectionChannelId(result.channelId, descriptor);
+  if (!String(result.service || "").trim()) throw new Error("projection record missing service");
+  if (!String(result.servicePk || "").trim()) throw new Error("projection record missing servicePk");
+  assertProjectionFreshness(result.freshness);
+  const payload = result.payload ?? {};
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("projection record payload must be an object");
+  }
+  rejectUnsafeSafeFacts(result.safeFacts ?? {});
+  return result;
+}
+
+export function makeProjectionRecord({
+  channelId,
+  service,
+  servicePk,
+  producer = {},
+  cursor,
+  freshness,
+  scope = {},
+  payloadSchema,
+  payload = {},
+  safeFacts = {},
+  encryptedDetailRefs = [],
+  diagnostics = [],
+} = {}) {
+  return assertProjectionRecord({
+    channelId,
+    service,
+    servicePk,
+    producer,
+    ...(cursor ? { cursor } : {}),
+    freshness,
+    scope,
+    ...(payloadSchema ? { payloadSchema } : {}),
+    payload,
+    safeFacts,
+    encryptedDetailRefs,
+    diagnostics,
+  });
+}
+
+export function assertDiagnosticEvent(event) {
+  if (!event || typeof event !== "object") throw new Error("diagnostic event must be an object");
+  if (!String(event.diagnosticId || "").trim()) throw new Error("diagnostic missing diagnosticId");
+  if (!Number(event.schemaVersion || 0)) throw new Error("diagnostic missing schemaVersion");
+  if (!Number(event.occurredAt || 0)) throw new Error("diagnostic missing occurredAt");
+  if (!Object.values(DIAGNOSTICS.LEVEL).includes(String(event.level || "").trim())) throw new Error("invalid diagnostic level");
+  if (!String(event.operation || "").trim()) throw new Error("diagnostic missing operation");
+  rejectUnsafeSafeFacts(event.safeFacts ?? {});
+  return event;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,9 @@ pub mod caac;
 pub mod crypto;
 pub mod logging;
 pub mod nostr;
+pub mod projection;
 pub mod records;
+pub mod service;
 pub mod service_access;
 pub mod storage;
 
@@ -12,6 +14,8 @@ pub use caac::*;
 pub use crypto::*;
 pub use logging::*;
 pub use nostr::*;
+pub use projection::*;
 pub use records::*;
+pub use service::*;
 pub use service_access::*;
 pub use storage::*;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -57,6 +57,25 @@ pub enum LogRedactionClass {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
+pub enum LogVerbosityClass {
+    Critical,
+    Normal,
+    Verbose,
+    Noise,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum LogRetentionClass {
+    Forever,
+    Long,
+    Rolling,
+    Short,
+    Ephemeral,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
 pub struct LogProducerRef {
     pub service: String,
     pub component: String,

--- a/src/projection.rs
+++ b/src/projection.rs
@@ -1,0 +1,382 @@
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const PROJECTION_CHANNEL_LOGGING_EVENTS: &str = "logging.events";
+pub const PROJECTION_CHANNEL_LOGGING_HEALTH: &str = "logging.health";
+pub const PROJECTION_CHANNEL_LOGGING_DASHBOARD: &str = "logging.dashboard";
+pub const PROJECTION_CHANNEL_DIAGNOSTICS_EVENTS: &str = "diagnostics.events";
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ProjectionFreshnessState {
+    Fresh,
+    Stale,
+    Missing,
+    Error,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectionCursor {
+    pub value: String,
+    pub updated_at: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectionFreshness {
+    pub state: ProjectionFreshnessState,
+    pub updated_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stale_after: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectionChannel {
+    pub channel_id: String,
+    pub service: String,
+    pub projection_kind: String,
+    pub capability_scope: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum ProjectionSyncState {
+    Idle,
+    Syncing,
+    Degraded,
+    Stale,
+    Blocked,
+    CompleteEnough,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectionPolicy {
+    pub policy_id: String,
+    pub channel_id: String,
+    pub service: String,
+    #[serde(default)]
+    pub scope: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rolling_window_hours: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_verbosity_class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_severity: Option<String>,
+    #[serde(default)]
+    pub excluded_verbosity_classes: Vec<String>,
+    #[serde(default)]
+    pub sync_depth_target: Value,
+    #[serde(default)]
+    pub retention_target: Value,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectionCoverage {
+    pub materialized_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_count: Option<u64>,
+    pub completion_ratio: f64,
+    #[serde(default)]
+    pub complete_severity_bands: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oldest_observed_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub newest_observed_at: Option<u64>,
+    pub sync_state: ProjectionSyncState,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectionObserverUpdate {
+    pub projection_key: String,
+    pub changed_count: u64,
+    pub coverage: ProjectionCoverage,
+    pub freshness: ProjectionFreshness,
+    #[serde(default)]
+    pub diagnostics: Vec<Value>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ServiceProjectionRequest {
+    pub request_id: String,
+    pub channel_id: String,
+    pub service: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    #[serde(default)]
+    pub filters: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub policy: Option<ProjectionPolicy>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectionRecord {
+    pub channel_id: String,
+    pub service: String,
+    pub service_pk: String,
+    #[serde(default)]
+    pub producer: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<ProjectionCursor>,
+    pub freshness: ProjectionFreshness,
+    #[serde(default)]
+    pub scope: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub payload_schema: Option<String>,
+    #[serde(default)]
+    pub payload: Value,
+    #[serde(default)]
+    pub safe_facts: Value,
+    #[serde(default)]
+    pub encrypted_detail_refs: Vec<Value>,
+    #[serde(default)]
+    pub diagnostics: Vec<Value>,
+}
+
+pub fn validate_projection_channel_id_with_allowed(
+    channel_id: &str,
+    allowed: &[String],
+) -> Result<()> {
+    let trimmed = channel_id.trim();
+    if trimmed.is_empty() {
+        return Err(anyhow!("projection missing channel id"));
+    }
+    if !allowed.is_empty() {
+        return allowed
+            .iter()
+            .any(|channel| channel == trimmed)
+            .then_some(())
+            .ok_or_else(|| anyhow!("unsupported projection channel"));
+    }
+    match trimmed {
+        PROJECTION_CHANNEL_LOGGING_EVENTS
+        | PROJECTION_CHANNEL_LOGGING_HEALTH
+        | PROJECTION_CHANNEL_LOGGING_DASHBOARD
+        | PROJECTION_CHANNEL_DIAGNOSTICS_EVENTS => Ok(()),
+        _ => Err(anyhow!("unsupported projection channel")),
+    }
+}
+
+pub fn validate_projection_channel_id(channel_id: &str) -> Result<()> {
+    validate_projection_channel_id_with_allowed(channel_id, &[])
+}
+
+pub fn validate_service_projection_request(req: &ServiceProjectionRequest) -> Result<()> {
+    if req.request_id.trim().is_empty() {
+        return Err(anyhow!("service projection missing request id"));
+    }
+    validate_projection_channel_id(&req.channel_id)?;
+    if req.service.trim().is_empty() {
+        return Err(anyhow!("service projection missing service"));
+    }
+    if !req.filters.is_object() {
+        return Err(anyhow!("service projection filters must be an object"));
+    }
+    if let Some(policy) = &req.policy {
+        validate_projection_policy(policy)?;
+        if policy.channel_id != req.channel_id {
+            return Err(anyhow!("projection policy channel mismatch"));
+        }
+        if policy.service != req.service {
+            return Err(anyhow!("projection policy service mismatch"));
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_projection_policy(policy: &ProjectionPolicy) -> Result<()> {
+    if policy.policy_id.trim().is_empty() {
+        return Err(anyhow!("projection policy missing policyId"));
+    }
+    validate_projection_channel_id(&policy.channel_id)?;
+    if policy.service.trim().is_empty() {
+        return Err(anyhow!("projection policy missing service"));
+    }
+    if !policy.scope.is_object() {
+        return Err(anyhow!("projection policy scope must be an object"));
+    }
+    if policy.rolling_window_hours == Some(0) {
+        return Err(anyhow!("projection policy rolling window must be positive"));
+    }
+    if !policy.sync_depth_target.is_null() && !policy.sync_depth_target.is_object() {
+        return Err(anyhow!(
+            "projection policy sync depth target must be an object"
+        ));
+    }
+    if !policy.retention_target.is_null() && !policy.retention_target.is_object() {
+        return Err(anyhow!(
+            "projection policy retention target must be an object"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_projection_coverage(coverage: &ProjectionCoverage) -> Result<()> {
+    if !coverage.completion_ratio.is_finite()
+        || coverage.completion_ratio < 0.0
+        || coverage.completion_ratio > 1.0
+    {
+        return Err(anyhow!("projection coverage completion ratio must be 0..1"));
+    }
+    if let Some(target_count) = coverage.target_count {
+        if coverage.materialized_count > target_count && target_count > 0 {
+            return Err(anyhow!(
+                "projection coverage materialized count exceeds target"
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_projection_observer_update(update: &ProjectionObserverUpdate) -> Result<()> {
+    if update.projection_key.trim().is_empty() {
+        return Err(anyhow!("projection observer update missing projection key"));
+    }
+    validate_projection_coverage(&update.coverage)?;
+    if update.freshness.updated_at == 0 {
+        return Err(anyhow!(
+            "projection observer update missing freshness timestamp"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_projection_record(record: &ProjectionRecord, allowed: &[String]) -> Result<()> {
+    validate_projection_channel_id_with_allowed(&record.channel_id, allowed)?;
+    if record.service.trim().is_empty() {
+        return Err(anyhow!("projection record missing service"));
+    }
+    if record.service_pk.trim().is_empty() {
+        return Err(anyhow!("projection record missing servicePk"));
+    }
+    if !record.payload.is_object() {
+        return Err(anyhow!("projection record payload must be an object"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn validates_service_projection_records() {
+        let req = ServiceProjectionRequest {
+            request_id: "projection-1".to_string(),
+            channel_id: PROJECTION_CHANNEL_LOGGING_EVENTS.to_string(),
+            service: "logging".to_string(),
+            cursor: None,
+            limit: Some(100),
+            filters: json!({ "severity": "error" }),
+            policy: Some(ProjectionPolicy {
+                policy_id: "logging.default.72h.low".to_string(),
+                channel_id: PROJECTION_CHANNEL_LOGGING_EVENTS.to_string(),
+                service: "logging".to_string(),
+                scope: json!({ "rolling": "72h" }),
+                rolling_window_hours: Some(72),
+                max_verbosity_class: Some("normal".to_string()),
+                min_severity: Some("debug".to_string()),
+                excluded_verbosity_classes: vec!["noise".to_string()],
+                sync_depth_target: json!({ "mode": "policyComplete" }),
+                retention_target: json!({ "mode": "loggingDefault" }),
+            }),
+        };
+        validate_service_projection_request(&req).expect("valid request");
+
+        let result = ProjectionRecord {
+            channel_id: req.channel_id,
+            service: req.service,
+            service_pk: "logging-service-pk".to_string(),
+            producer: json!({ "service": "logging" }),
+            cursor: Some(ProjectionCursor {
+                value: "cursor-1".to_string(),
+                updated_at: 1_700_000_000,
+            }),
+            freshness: ProjectionFreshness {
+                state: ProjectionFreshnessState::Fresh,
+                updated_at: 1_700_000_000,
+                stale_after: Some(1_700_000_030),
+                reason: None,
+            },
+            scope: json!({}),
+            payload_schema: Some("constitute.logging.events.v1".to_string()),
+            payload: json!({ "events": [] }),
+            safe_facts: json!({}),
+            encrypted_detail_refs: vec![],
+            diagnostics: vec![],
+        };
+        validate_projection_record(&result, &[]).expect("valid result");
+        assert!(
+            validate_projection_record(&result, &[PROJECTION_CHANNEL_LOGGING_HEALTH.to_string()])
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_projection_channel() {
+        let req = ServiceProjectionRequest {
+            request_id: "projection-1".to_string(),
+            channel_id: "logging.raw".to_string(),
+            service: "logging".to_string(),
+            cursor: None,
+            limit: None,
+            filters: json!({}),
+            policy: None,
+        };
+        assert!(validate_service_projection_request(&req).is_err());
+    }
+
+    #[test]
+    fn validates_projection_policy_coverage_and_observer_update() {
+        let policy = ProjectionPolicy {
+            policy_id: "logging.default.72h.low".to_string(),
+            channel_id: PROJECTION_CHANNEL_LOGGING_EVENTS.to_string(),
+            service: "logging".to_string(),
+            scope: json!({ "range": "rolling" }),
+            rolling_window_hours: Some(72),
+            max_verbosity_class: Some("normal".to_string()),
+            min_severity: Some("debug".to_string()),
+            excluded_verbosity_classes: vec!["noise".to_string()],
+            sync_depth_target: json!({ "mode": "policyComplete" }),
+            retention_target: json!({ "normalInfo": "48h" }),
+        };
+        validate_projection_policy(&policy).expect("valid policy");
+
+        let coverage = ProjectionCoverage {
+            materialized_count: 100,
+            target_count: Some(200),
+            completion_ratio: 0.5,
+            complete_severity_bands: vec!["critical".to_string(), "error".to_string()],
+            oldest_observed_at: Some(1_700_000_000),
+            newest_observed_at: Some(1_700_000_100),
+            sync_state: ProjectionSyncState::Syncing,
+        };
+        validate_projection_coverage(&coverage).expect("valid coverage");
+
+        let update = ProjectionObserverUpdate {
+            projection_key: "logging:service-pk:logging.events:logging.default.72h.low".to_string(),
+            changed_count: 20,
+            coverage,
+            freshness: ProjectionFreshness {
+                state: ProjectionFreshnessState::Fresh,
+                updated_at: 1_700_000_100,
+                stale_after: Some(1_700_000_160),
+                reason: None,
+            },
+            diagnostics: vec![],
+        };
+        validate_projection_observer_update(&update).expect("valid observer update");
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,0 +1,172 @@
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+pub const SERVICE_FRAME_DESCRIBE_REQUEST: &str = "service.describe.request";
+pub const SERVICE_FRAME_DESCRIBE_RESPONSE: &str = "service.describe.response";
+pub const SERVICE_FRAME_PROJECTION_REQUEST: &str = "service.projection.request";
+pub const SERVICE_FRAME_PROJECTION_RESPONSE: &str = "service.projection.response";
+pub const SERVICE_FRAME_CONTROL_REQUEST: &str = "service.control.request";
+pub const SERVICE_FRAME_CONTROL_RESPONSE: &str = "service.control.response";
+pub const SERVICE_FRAME_INVOKE_REQUEST: &str = "service.invoke.request";
+pub const SERVICE_FRAME_INVOKE_RESPONSE: &str = "service.invoke.response";
+pub const SERVICE_FRAME_WATCH_REQUEST: &str = "service.watch.request";
+pub const SERVICE_FRAME_WATCH_EVENT: &str = "service.watch.event";
+pub const SERVICE_FRAME_CLOSE: &str = "service.close";
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct HostedServiceDescriptor {
+    pub service: String,
+    pub service_pk: String,
+    pub host_gateway_pk: String,
+    #[serde(default)]
+    pub display: Value,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(default)]
+    pub projection_channels: Vec<String>,
+    #[serde(default)]
+    pub invocation_kinds: Vec<String>,
+    #[serde(default)]
+    pub transport_hints: Value,
+    #[serde(default)]
+    pub health_summary: Value,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ServiceExchangeFrame {
+    pub frame_id: String,
+    pub schema_version: u32,
+    pub kind: String,
+    pub issuer_pk: String,
+    pub recipient_service_pk: String,
+    pub host_gateway_pk: String,
+    pub issued_at: u64,
+    pub expires_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trace_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub request_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub correlation_id: Option<String>,
+    #[serde(default)]
+    pub route_hint: Value,
+    #[serde(default)]
+    pub sealed_payload: Value,
+    pub signature: String,
+}
+
+pub fn is_service_exchange_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        SERVICE_FRAME_DESCRIBE_REQUEST
+            | SERVICE_FRAME_DESCRIBE_RESPONSE
+            | SERVICE_FRAME_PROJECTION_REQUEST
+            | SERVICE_FRAME_PROJECTION_RESPONSE
+            | SERVICE_FRAME_CONTROL_REQUEST
+            | SERVICE_FRAME_CONTROL_RESPONSE
+            | SERVICE_FRAME_INVOKE_REQUEST
+            | SERVICE_FRAME_INVOKE_RESPONSE
+            | SERVICE_FRAME_WATCH_REQUEST
+            | SERVICE_FRAME_WATCH_EVENT
+            | SERVICE_FRAME_CLOSE
+    )
+}
+
+pub fn validate_hosted_service_descriptor(descriptor: &HostedServiceDescriptor) -> Result<()> {
+    if descriptor.service.trim().is_empty() {
+        return Err(anyhow!("service descriptor missing service"));
+    }
+    if descriptor.service_pk.trim().is_empty() {
+        return Err(anyhow!("service descriptor missing servicePk"));
+    }
+    if descriptor.host_gateway_pk.trim().is_empty() {
+        return Err(anyhow!("service descriptor missing hostGatewayPk"));
+    }
+    for channel in &descriptor.projection_channels {
+        if channel.trim().is_empty() {
+            return Err(anyhow!(
+                "service descriptor contains empty projection channel"
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn validate_service_exchange_frame(frame: &ServiceExchangeFrame) -> Result<()> {
+    if frame.frame_id.trim().is_empty() {
+        return Err(anyhow!("service exchange missing frameId"));
+    }
+    if frame.schema_version == 0 {
+        return Err(anyhow!("service exchange missing schemaVersion"));
+    }
+    if !is_service_exchange_kind(frame.kind.trim()) {
+        return Err(anyhow!("unsupported service exchange kind"));
+    }
+    if frame.issuer_pk.trim().is_empty() {
+        return Err(anyhow!("service exchange missing issuerPk"));
+    }
+    if frame.recipient_service_pk.trim().is_empty() {
+        return Err(anyhow!("service exchange missing recipientServicePk"));
+    }
+    if frame.host_gateway_pk.trim().is_empty() {
+        return Err(anyhow!("service exchange missing hostGatewayPk"));
+    }
+    if frame.issued_at == 0 || frame.expires_at == 0 || frame.expires_at <= frame.issued_at {
+        return Err(anyhow!("service exchange invalid time bounds"));
+    }
+    if frame.signature.trim().is_empty() {
+        return Err(anyhow!("service exchange missing signature"));
+    }
+    Ok(())
+}
+
+pub fn reject_unsafe_safe_facts(value: &Value) -> Result<()> {
+    fn walk(path: &str, value: &Value) -> Result<()> {
+        match value {
+            Value::Object(map) => {
+                for (key, child) in map {
+                    let lowered = key.to_ascii_lowercase();
+                    let banned = [
+                        "password",
+                        "credential",
+                        "secret",
+                        "token",
+                        "capability",
+                        "servicecapability",
+                        "privatekey",
+                        "secretkey",
+                        "rtspurl",
+                        "authorization",
+                        "rawpayload",
+                        "requestbody",
+                    ];
+                    if banned.iter().any(|needle| lowered.contains(needle)) {
+                        return Err(anyhow!("unsafe safe fact key: {path}{key}"));
+                    }
+                    walk(&format!("{path}{key}."), child)?;
+                }
+            }
+            Value::String(text) => {
+                let lowered = text.to_ascii_lowercase();
+                if lowered.contains("rtsp://")
+                    || lowered.contains("authorization:")
+                    || lowered.contains("servicecapability")
+                    || lowered.contains("-----begin")
+                {
+                    return Err(anyhow!("unsafe safe fact value"));
+                }
+            }
+            Value::Array(items) => {
+                for item in items {
+                    walk(path, item)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+    walk("", value)
+}

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -2,8 +2,11 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   BROKER,
+  DIAGNOSTICS,
   LOGGING,
+  PROJECTION,
   ReplayCache,
+  SERVICE_EXCHANGE,
   SERVICE_ACCESS_EVENTS,
   SERVICE_ACCESS_KINDS,
   STORAGE,
@@ -11,11 +14,24 @@ import {
   assertStorageObjectManifest,
   assertStorageIndexShard,
   assertLogEventEnvelope,
+  assertDiagnosticEvent,
+  assertHostedServiceDescriptor,
+  assertProjectionCoverage,
+  assertProjectionObserverUpdate,
+  assertProjectionPolicy,
+  assertProjectionRecord,
+  assertServiceExchangeFrame,
+  assertServiceProjectionRequest,
   buildUnsignedEvent,
   eventIdHex,
   makeStorageChunkRef,
   makeStorageObjectManifest,
   makeLogEventEnvelope,
+  makeProjectionCoverage,
+  makeProjectionObserverUpdate,
+  makeProjectionPolicy,
+  makeProjectionRecord,
+  makeServiceExchangeFrame,
   openEnvelope,
   pubkeyFromSecretKey,
   sealEnvelope,
@@ -96,12 +112,122 @@ test("sealed envelope rejects expiry, tamper, and replay", () => {
 test("exports current service-access vocabulary only", () => {
   assert.equal(BROKER.SERVICE_ACCESS_REQUEST, "gateway.serviceAccess.request");
   assert.equal(BROKER.SERVICE_SIGNAL_REQUEST, "gateway.serviceSignal.request");
+  assert.equal(BROKER.SERVICE_PROJECTION_REQUEST, "service.projection.request");
   assert.equal(SERVICE_ACCESS_EVENTS.REQUEST, "gateway_service_access_request");
   assert.equal(SERVICE_ACCESS_EVENTS.SIGNAL_REQUEST, "gateway_service_signal_request");
   assert.equal(SERVICE_ACCESS_EVENTS.SIGNAL_STATUS, "gateway_service_signal_status");
   assert.equal(SERVICE_ACCESS_EVENTS.SIGNAL, "gateway_service_signal");
   assert.equal(SERVICE_ACCESS_EVENTS.GRANT, "gateway.service_access");
   assert.equal(SERVICE_ACCESS_KINDS.INVOCATION, "service_access.invocation");
+});
+
+test("service projection helpers validate retained logging projection records", () => {
+  const descriptor = assertHostedServiceDescriptor({
+    service: "logging",
+    servicePk: pubkeyFromSecretKey(SERVICE_SK),
+    hostGatewayPk: pubkeyFromSecretKey(GATEWAY_SK),
+    display: { name: "Constitute Logging" },
+    projectionChannels: [
+      PROJECTION.CHANNEL.LOGGING_EVENTS,
+      PROJECTION.CHANNEL.LOGGING_HEALTH,
+      PROJECTION.CHANNEL.LOGGING_DASHBOARD,
+    ],
+    capabilities: ["log_observation"],
+  });
+
+  const policy = makeProjectionPolicy({
+    policyId: "logging.default.72h.low",
+    channelId: PROJECTION.CHANNEL.LOGGING_EVENTS,
+    service: "logging",
+    scope: { range: "rolling" },
+    rollingWindowHours: 72,
+    maxVerbosityClass: LOGGING.VERBOSITY_CLASS.NORMAL,
+    minSeverity: LOGGING.SEVERITY.DEBUG,
+    excludedVerbosityClasses: [LOGGING.VERBOSITY_CLASS.NOISE],
+    syncDepthTarget: { mode: "policyComplete" },
+    retentionTarget: { normalInfo: "48h" },
+  });
+  assertProjectionPolicy(policy, descriptor);
+
+  const request = {
+    requestId: "projection-1",
+    channelId: PROJECTION.CHANNEL.LOGGING_EVENTS,
+    service: "logging",
+    limit: 100,
+    filters: {
+      severity: "error",
+    },
+    policy,
+  };
+  assertServiceProjectionRequest(request, descriptor);
+
+  const frame = makeServiceExchangeFrame({
+    kind: SERVICE_EXCHANGE.KIND.PROJECTION_REQUEST,
+    issuerPk: pubkeyFromSecretKey(BROWSER_SK),
+    recipientServicePk: descriptor.servicePk,
+    hostGatewayPk: descriptor.hostGatewayPk,
+    requestId: request.requestId,
+    sealedPayload: request,
+  });
+  assertServiceExchangeFrame(frame);
+
+  const result = makeProjectionRecord({
+    channelId: request.channelId,
+    service: "logging",
+    servicePk: descriptor.servicePk,
+    producer: { service: "logging" },
+    cursor: {
+      value: "cursor-1",
+      updatedAt: 1700000000,
+    },
+    freshness: {
+      state: PROJECTION.FRESHNESS.FRESH,
+      updatedAt: 1700000000,
+      staleAfter: 1700000030,
+    },
+    payload: {
+      events: [],
+      coverage: makeProjectionCoverage({
+        materializedCount: 0,
+        targetCount: 0,
+        completionRatio: 1,
+        syncState: PROJECTION.SYNC_STATE.COMPLETE_ENOUGH,
+      }),
+    },
+    safeFacts: {
+      count: 0,
+    },
+  });
+  assertProjectionRecord(result, descriptor);
+
+  const observerUpdate = makeProjectionObserverUpdate({
+    projectionKey: "logging:service-pk:logging.events:logging.default.72h.low",
+    changedCount: 0,
+    coverage: result.payload.coverage,
+    freshness: result.freshness,
+  });
+  assertProjectionCoverage(observerUpdate.coverage);
+  assertProjectionObserverUpdate(observerUpdate);
+
+  const narrowDescriptor = assertHostedServiceDescriptor({
+    ...descriptor,
+    projectionChannels: [PROJECTION.CHANNEL.LOGGING_HEALTH],
+  });
+  assert.throws(() => assertProjectionRecord(result, narrowDescriptor), /unsupported projection channel/);
+
+  assert.throws(() => assertServiceProjectionRequest({
+    ...request,
+    channelId: "logging.raw",
+  }, descriptor), /unsupported projection channel/);
+
+  assert.throws(() => assertDiagnosticEvent({
+    diagnosticId: "diag-1",
+    schemaVersion: DIAGNOSTICS.SCHEMA_VERSION,
+    occurredAt: 1700000000,
+    level: DIAGNOSTICS.LEVEL.ERROR,
+    operation: "logging-ui.projection.failed",
+    safeFacts: { serviceCapability: "secret" },
+  }), /unsafe safe fact key/);
 });
 
 test("storage manifest helpers validate ciphertext-addressed objects", () => {


### PR DESCRIPTION
## Summary
- Adds service descriptors, service exchange frames, projection records/policies/coverage, diagnostics, and logging verbosity/retention primitives.
- Adds protocol parity coverage for service-owned logging projection records.

## Verification
- cargo test
- npm test -- --runInBand