### PR TITLE
Add runtime surface contract grammar

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -213,6 +213,7 @@ export type LogEventEnvelope = {
   tags?: string[];
   safeFacts: Record<string, unknown>;
   detailRef?: EncryptedDetailRef;
+  encryptedDetailRefs?: EncryptedDetailRef[];
   redaction?: LogRedactionClass[];
 };
 
@@ -1570,6 +1571,7 @@ export function assertStorageIndexShard(shard: unknown): StorageIndexShard;
 export function logEventId(event: Partial<LogEventEnvelope>): string;
 export function rejectSensitiveSafeFacts(value: unknown): void;
 export function assertLogEventEnvelope(event: unknown): LogEventEnvelope;
+export function assertEncryptedDetailRef(ref: unknown, context?: string): EncryptedDetailRef;
 export function makeLogEventEnvelope(input: Partial<LogEventEnvelope>): LogEventEnvelope;
 export function rejectUnsafeSafeFacts(value: unknown): void;
 export function assertHostedServiceDescriptor(descriptor: unknown): HostedServiceDescriptor;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,7 @@ export const DEFAULT_REQUEST_TTL_SECONDS: number;
 export const BROKER: Readonly<Record<string, string>>;
 export const SERVICE_SURFACE: Readonly<Record<string, unknown>>;
 export const SURFACE_APP: Readonly<Record<string, unknown>>;
+export const SERVICE_REGISTRY: Readonly<Record<string, unknown>>;
 export const STORAGE: Readonly<Record<string, string>>;
 export const STORAGE_KEY_GRANULARITY: Readonly<Record<string, string>>;
 export const LOGGING: Readonly<Record<string, unknown>>;
@@ -652,6 +653,55 @@ export type DirectoryEntry = {
   capabilityRef?: string;
   channelId?: string;
   issuedAt: number;
+};
+
+export type ServiceRegistryClaimState = "claimed" | "retracted" | "expired" | "blocked";
+export type ServiceRegistryClaimKind = "service" | "member" | "capability" | "channel" | "surface";
+export type ServiceRegistryMaterializationState = "ready" | "partial" | "stale" | "blocked";
+
+export type ServiceRegistryClaim = {
+  kind?: "service.registry.claim";
+  claimId: string;
+  schemaVersion: 1;
+  claimKind: ServiceRegistryClaimKind;
+  state: ServiceRegistryClaimState;
+  ownerRef: string;
+  writerRef: string;
+  subjectRef: string;
+  scopeRef: string;
+  service?: string;
+  servicePk?: string;
+  serviceRef?: string;
+  memberRef?: string;
+  hostGatewayPk?: string;
+  capabilityRefs?: string[];
+  channelRefs?: string[];
+  nodeRefs?: string[];
+  surfaceRefs?: string[];
+  evidenceRefs?: string[];
+  safeFacts?: Record<string, unknown>;
+  issuedAt: number;
+  expiresAt?: number;
+  retractedAt?: number;
+};
+
+export type ServiceRegistryMaterialization = {
+  kind?: "service.registry.materialization";
+  registryId: string;
+  schemaVersion: 1;
+  scopeRef: string;
+  state: ServiceRegistryMaterializationState;
+  revision: number;
+  claimRefs?: string[];
+  participantRefs?: string[];
+  serviceRefs?: string[];
+  services?: unknown[];
+  entries?: DirectoryEntry[];
+  coverage?: ProjectionCoverage;
+  freshness?: ProjectionFreshness;
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
 };
 
 export type BootstrapCarrierRecord = {
@@ -1576,6 +1626,8 @@ export function assertRouteObservation(record: unknown): RouteObservation;
 export function assertStreamRoutePlan(record: unknown): StreamRoutePlan;
 export function assertMemberPresence(record: unknown, opts?: { now?: number }): MemberPresence;
 export function assertDirectoryEntry(record: unknown): DirectoryEntry;
+export function assertServiceRegistryClaim(record: unknown): ServiceRegistryClaim;
+export function assertServiceRegistryMaterialization(record: unknown): ServiceRegistryMaterialization;
 export function assertBootstrapCarrierRecord(record: unknown): BootstrapCarrierRecord;
 export function assertSwarmIdentity(record: unknown): SwarmIdentityRecord;
 export function assertSwarmDevice(record: unknown): SwarmDeviceRecord;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@ export const MAX_CAPABILITY_TTL_SECONDS: number;
 export const DEFAULT_REQUEST_TTL_SECONDS: number;
 export const BROKER: Readonly<Record<string, string>>;
 export const SERVICE_SURFACE: Readonly<Record<string, unknown>>;
+export const SURFACE_APP: Readonly<Record<string, unknown>>;
 export const STORAGE: Readonly<Record<string, string>>;
 export const STORAGE_KEY_GRANULARITY: Readonly<Record<string, string>>;
 export const LOGGING: Readonly<Record<string, unknown>>;
@@ -1394,6 +1395,62 @@ export type MediaTransportObservation = {
   expiresAt?: number;
 };
 
+export type SurfaceModuleRole =
+  | "runtimeClient"
+  | "projectionModel"
+  | "platformAdapter"
+  | "serviceSurfaceAdapter"
+  | "productView"
+  | "operatorHelper"
+  | "releaseHelper";
+
+export type SurfaceModuleParticipantSide = "window" | "runtime" | "service" | "operator" | "native" | "storage";
+export type SurfaceModuleFulfillmentMode = "bundled" | "swarmPackage" | "storageObject" | "nativeInstalled" | "devOverlay";
+export type SurfaceAppUpdatePostureState = "static" | "compatible" | "updateAvailable" | "blocked";
+
+export type SurfaceModuleClaim = {
+  moduleRef: string;
+  role: SurfaceModuleRole;
+  participantSide: SurfaceModuleParticipantSide;
+  fulfillmentMode: SurfaceModuleFulfillmentMode;
+  primitiveRefs: string[];
+  version: string;
+  buildId?: string;
+  requiredCapabilities?: string[];
+  sandbox?: Record<string, unknown>;
+  inputs?: string[];
+  outputs?: string[];
+  evidenceContract?: Record<string, unknown>;
+  lifecycle?: Record<string, unknown>;
+  materializationBudgetRef?: string;
+  fallbackRefs?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type SurfaceAppContract = {
+  contractId: string;
+  schemaVersion: 1;
+  appId: string;
+  version: string;
+  displayName: string;
+  serviceRef?: string;
+  appRef?: string;
+  surfaceRef?: string;
+  requiredPrimitives?: string[];
+  requiredModuleRoles: SurfaceModuleRole[];
+  modules: SurfaceModuleClaim[];
+  projectionSubscriptions?: unknown[];
+  permissionRequirements?: unknown[];
+  capabilityRequirements?: unknown[];
+  materializationBudgets?: unknown[];
+  fallbackPolicy?: Record<string, unknown>;
+  updatePosture?: { state?: SurfaceAppUpdatePostureState; [key: string]: unknown };
+  releasePosture?: Record<string, unknown>;
+  issuedAt: number;
+  expiresAt?: number;
+};
+
 export type AppRecipe = {
   recipeId: string;
   name: string;
@@ -1575,5 +1632,7 @@ export function assertStreamSessionClose(record: unknown): StreamSessionClose;
 export function assertMediaFulfillmentEvidence(record: unknown): MediaFulfillmentEvidence;
 export function assertMediaTransportPath(record: unknown): MediaTransportPath;
 export function assertMediaTransportObservation(record: unknown): MediaTransportObservation;
+export function assertSurfaceModuleClaim(record: unknown): SurfaceModuleClaim;
+export function assertSurfaceAppContract(record: unknown): SurfaceAppContract;
 export function assertAppRecipe(record: unknown): AppRecipe;
 export function assertAppRunnerAdvertisement(record: unknown): AppRunnerAdvertisement;

--- a/src/index.js
+++ b/src/index.js
@@ -1005,6 +1005,8 @@ export const SWARM = Object.freeze({
     MEDIA_FULFILLMENT_EVIDENCE: "media.fulfillment.evidence",
     MEDIA_TRANSPORT_PATH: "media.transport.path",
     MEDIA_TRANSPORT_OBSERVATION: "media.transport.observation",
+    SERVICE_REGISTRY_CLAIM: "service.registry.claim",
+    SERVICE_REGISTRY_MATERIALIZATION: "service.registry.materialization",
   }),
   RECORD_KIND: Object.freeze({
     NODE_CAPABILITY: "node.capability",
@@ -1044,6 +1046,8 @@ export const SWARM = Object.freeze({
     MEDIA_FULFILLMENT_EVIDENCE: "media.fulfillment.evidence",
     MEDIA_TRANSPORT_PATH: "media.transport.path",
     MEDIA_TRANSPORT_OBSERVATION: "media.transport.observation",
+    SERVICE_REGISTRY_CLAIM: "service.registry.claim",
+    SERVICE_REGISTRY_MATERIALIZATION: "service.registry.materialization",
   }),
   AUTHORITY_DOMAIN: Object.freeze({
     IDENTITY: "identity",
@@ -1484,6 +1488,29 @@ export const SWARM = Object.freeze({
   }),
   STREAM_CANDIDATE_ACTIONABILITY: Object.freeze({
     USABLE: "usable",
+    BLOCKED: "blocked",
+  }),
+});
+
+export const SERVICE_REGISTRY = Object.freeze({
+  SCHEMA_VERSION: 1,
+  CLAIM_KIND: Object.freeze({
+    SERVICE: "service",
+    MEMBER: "member",
+    CAPABILITY: "capability",
+    CHANNEL: "channel",
+    SURFACE: "surface",
+  }),
+  CLAIM_STATE: Object.freeze({
+    CLAIMED: "claimed",
+    RETRACTED: "retracted",
+    EXPIRED: "expired",
+    BLOCKED: "blocked",
+  }),
+  MATERIALIZATION_STATE: Object.freeze({
+    READY: "ready",
+    PARTIAL: "partial",
+    STALE: "stale",
     BLOCKED: "blocked",
   }),
 });
@@ -2384,6 +2411,58 @@ export function assertDirectoryEntry(record) {
   if (record.capabilityRef !== undefined) assertCapabilityName(record.capabilityRef);
   if (record.channelId !== undefined) requireString(record.channelId, "directory entry channelId");
   if (!Number(record.issuedAt || 0)) throw new Error("directory entry missing issuedAt");
+  return record;
+}
+
+export function assertServiceRegistryClaim(record) {
+  if (!isObject(record)) throw new Error("service registry claim must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.SERVICE_REGISTRY_CLAIM, "service registry claim");
+  requireString(record.claimId, "service registry claim claimId");
+  if (Number(record.schemaVersion || 0) !== SERVICE_REGISTRY.SCHEMA_VERSION) throw new Error("unsupported service registry claim schemaVersion");
+  requireString(record.claimKind, "service registry claim claimKind");
+  if (!Object.values(SERVICE_REGISTRY.CLAIM_KIND).includes(record.claimKind)) throw new Error("invalid service registry claim kind");
+  requireString(record.state, "service registry claim state");
+  if (!Object.values(SERVICE_REGISTRY.CLAIM_STATE).includes(record.state)) throw new Error("invalid service registry claim state");
+  requireString(record.ownerRef, "service registry claim ownerRef");
+  requireString(record.writerRef, "service registry claim writerRef");
+  requireString(record.subjectRef, "service registry claim subjectRef");
+  requireString(record.scopeRef, "service registry claim scopeRef");
+  if (record.service !== undefined) requireString(record.service, "service registry claim service");
+  if (record.servicePk !== undefined) requireString(record.servicePk, "service registry claim servicePk");
+  if (record.serviceRef !== undefined) requireString(record.serviceRef, "service registry claim serviceRef");
+  if (record.memberRef !== undefined) requireString(record.memberRef, "service registry claim memberRef");
+  if (record.hostGatewayPk !== undefined) requireString(record.hostGatewayPk, "service registry claim hostGatewayPk");
+  requireArray(record.capabilityRefs || [], "service registry claim capabilityRefs").forEach(assertCapabilityName);
+  requireArray(record.channelRefs || [], "service registry claim channelRefs").forEach((entry) => requireString(entry, "service registry claim channelRef"));
+  requireArray(record.nodeRefs || [], "service registry claim nodeRefs").forEach((entry) => requireString(entry, "service registry claim nodeRef"));
+  requireArray(record.surfaceRefs || [], "service registry claim surfaceRefs").forEach((entry) => requireString(entry, "service registry claim surfaceRef"));
+  requireArray(record.evidenceRefs || [], "service registry claim evidenceRefs").forEach((entry) => requireString(entry, "service registry claim evidenceRef"));
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "service registry claim safeFacts");
+  if (!Number(record.issuedAt || 0)) throw new Error("service registry claim missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) throw new Error("service registry claim expires before issuedAt");
+  if (record.retractedAt !== undefined && Number(record.retractedAt || 0) <= Number(record.issuedAt || 0)) throw new Error("service registry claim retracted before issuedAt");
+  return record;
+}
+
+export function assertServiceRegistryMaterialization(record) {
+  if (!isObject(record)) throw new Error("service registry materialization must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.SERVICE_REGISTRY_MATERIALIZATION, "service registry materialization");
+  requireString(record.registryId, "service registry materialization registryId");
+  if (Number(record.schemaVersion || 0) !== SERVICE_REGISTRY.SCHEMA_VERSION) throw new Error("unsupported service registry materialization schemaVersion");
+  requireString(record.scopeRef, "service registry materialization scopeRef");
+  requireString(record.state, "service registry materialization state");
+  if (!Object.values(SERVICE_REGISTRY.MATERIALIZATION_STATE).includes(record.state)) throw new Error("invalid service registry materialization state");
+  if (!Number.isFinite(Number(record.revision))) throw new Error("service registry materialization missing revision");
+  requireArray(record.claimRefs || [], "service registry materialization claimRefs").forEach((entry) => requireString(entry, "service registry materialization claimRef"));
+  requireArray(record.participantRefs || [], "service registry materialization participantRefs").forEach((entry) => requireString(entry, "service registry materialization participantRef"));
+  requireArray(record.serviceRefs || [], "service registry materialization serviceRefs").forEach((entry) => requireString(entry, "service registry materialization serviceRef"));
+  requireArray(record.services || [], "service registry materialization services").forEach(assertHostedServiceDescriptor);
+  requireArray(record.entries || [], "service registry materialization entries").forEach(assertDirectoryEntry);
+  if (record.coverage !== undefined) assertProjectionCoverage(record.coverage);
+  if (record.freshness !== undefined) assertProjectionFreshness(record.freshness);
+  requireArray(record.blockedReasons || [], "service registry materialization blockedReasons").forEach((entry) => requireString(entry, "service registry materialization blockedReason"));
+  if (!Number(record.issuedAt || 0)) throw new Error("service registry materialization missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) throw new Error("service registry materialization expires before issuedAt");
   return record;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,40 @@ export const SERVICE_SURFACE = Object.freeze({
   }),
 });
 
+export const SURFACE_APP = Object.freeze({
+  SCHEMA_VERSION: 1,
+  MODULE_ROLE: Object.freeze({
+    RUNTIME_CLIENT: "runtimeClient",
+    PROJECTION_MODEL: "projectionModel",
+    PLATFORM_ADAPTER: "platformAdapter",
+    SERVICE_SURFACE_ADAPTER: "serviceSurfaceAdapter",
+    PRODUCT_VIEW: "productView",
+    OPERATOR_HELPER: "operatorHelper",
+    RELEASE_HELPER: "releaseHelper",
+  }),
+  PARTICIPANT_SIDE: Object.freeze({
+    WINDOW: "window",
+    RUNTIME: "runtime",
+    SERVICE: "service",
+    OPERATOR: "operator",
+    NATIVE: "native",
+    STORAGE: "storage",
+  }),
+  FULFILLMENT_MODE: Object.freeze({
+    BUNDLED: "bundled",
+    SWARM_PACKAGE: "swarmPackage",
+    STORAGE_OBJECT: "storageObject",
+    NATIVE_INSTALLED: "nativeInstalled",
+    DEV_OVERLAY: "devOverlay",
+  }),
+  UPDATE_POSTURE: Object.freeze({
+    STATIC: "static",
+    COMPATIBLE: "compatible",
+    UPDATE_AVAILABLE: "updateAvailable",
+    BLOCKED: "blocked",
+  }),
+});
+
 export const STORAGE = Object.freeze({
   OBJECT_HASH_ALG: "sha256-ciphertext-v1",
   CHUNK_HASH_ALG: "sha256-ciphertext-v1",
@@ -3549,6 +3583,64 @@ export function assertAppRecipe(record) {
   requireArray(record.requiredCapabilities, "app recipe requiredCapabilities").forEach(assertCapabilityName);
   requireArray(record.requiredChannels, "app recipe requiredChannels");
   requireArray(record.roles, "app recipe roles");
+  return record;
+}
+
+export function assertSurfaceModuleClaim(record) {
+  if (!isObject(record)) throw new Error("surface module claim must be an object");
+  requireString(record.moduleRef, "surface module claim moduleRef");
+  requireString(record.role, "surface module claim role");
+  if (!Object.values(SURFACE_APP.MODULE_ROLE).includes(record.role)) throw new Error("invalid surface module role");
+  requireString(record.participantSide, "surface module claim participantSide");
+  if (!Object.values(SURFACE_APP.PARTICIPANT_SIDE).includes(record.participantSide)) throw new Error("invalid surface module participantSide");
+  requireString(record.fulfillmentMode, "surface module claim fulfillmentMode");
+  if (!Object.values(SURFACE_APP.FULFILLMENT_MODE).includes(record.fulfillmentMode)) throw new Error("invalid surface module fulfillmentMode");
+  requireString(record.version, "surface module claim version");
+  requireArray(record.primitiveRefs || [], "surface module claim primitiveRefs");
+  requireArray(record.requiredCapabilities || [], "surface module claim requiredCapabilities");
+  requireArray(record.inputs || [], "surface module claim inputs");
+  requireArray(record.outputs || [], "surface module claim outputs");
+  requireArray(record.fallbackRefs || [], "surface module claim fallbackRefs");
+  if (record.sandbox !== undefined && !isObject(record.sandbox)) throw new Error("surface module claim sandbox must be an object");
+  if (record.evidenceContract !== undefined && !isObject(record.evidenceContract)) throw new Error("surface module claim evidenceContract must be an object");
+  if (record.lifecycle !== undefined && !isObject(record.lifecycle)) throw new Error("surface module claim lifecycle must be an object");
+  if (record.materializationBudgetRef !== undefined) requireString(record.materializationBudgetRef, "surface module claim materializationBudgetRef");
+  if (!Number(record.issuedAt || 0)) throw new Error("surface module claim missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) throw new Error("surface module claim expires before issuedAt");
+  return record;
+}
+
+export function assertSurfaceAppContract(record) {
+  if (!isObject(record)) throw new Error("surface app contract must be an object");
+  requireString(record.contractId, "surface app contract contractId");
+  if (Number(record.schemaVersion || 0) !== SURFACE_APP.SCHEMA_VERSION) throw new Error("unsupported surface app contract schemaVersion");
+  requireString(record.appId, "surface app contract appId");
+  requireString(record.version, "surface app contract version");
+  requireString(record.displayName, "surface app contract displayName");
+  requireArray(record.requiredPrimitives || [], "surface app contract requiredPrimitives");
+  const requiredRoles = requireNonEmptyArray(record.requiredModuleRoles, "surface app contract requiredModuleRoles");
+  for (const role of requiredRoles) {
+    if (!Object.values(SURFACE_APP.MODULE_ROLE).includes(role)) throw new Error("invalid surface app required module role");
+  }
+  const modules = requireNonEmptyArray(record.modules, "surface app contract modules").map(assertSurfaceModuleClaim);
+  const coveredRoles = new Set(modules.map((module) => module.role));
+  for (const role of requiredRoles) {
+    if (!coveredRoles.has(role)) throw new Error(`surface app contract missing module role ${role}`);
+  }
+  requireArray(record.projectionSubscriptions || [], "surface app contract projectionSubscriptions");
+  requireArray(record.permissionRequirements || [], "surface app contract permissionRequirements");
+  requireArray(record.capabilityRequirements || [], "surface app contract capabilityRequirements");
+  requireArray(record.materializationBudgets || [], "surface app contract materializationBudgets");
+  if (record.fallbackPolicy !== undefined && !isObject(record.fallbackPolicy)) throw new Error("surface app contract fallbackPolicy must be an object");
+  if (record.updatePosture !== undefined) {
+    if (!isObject(record.updatePosture)) throw new Error("surface app contract updatePosture must be an object");
+    if (record.updatePosture.state !== undefined && !Object.values(SURFACE_APP.UPDATE_POSTURE).includes(record.updatePosture.state)) {
+      throw new Error("invalid surface app update posture state");
+    }
+  }
+  if (record.releasePosture !== undefined && !isObject(record.releasePosture)) throw new Error("surface app contract releasePosture must be an object");
+  if (!Number(record.issuedAt || 0)) throw new Error("surface app contract missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) throw new Error("surface app contract expires before issuedAt");
   return record;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -529,6 +529,20 @@ export function rejectSensitiveSafeFacts(value) {
   }
 }
 
+export function assertEncryptedDetailRef(ref, context = "encrypted detail ref") {
+  if (!ref || typeof ref !== "object" || Array.isArray(ref)) throw new Error(`${context} must be an object`);
+  for (const field of ["objectId", "containerId", "keyRef", "manifestHash"]) {
+    if (!String(ref[field] || "").trim()) throw new Error(`${context} missing ${field}`);
+  }
+  if (ref.summaryTags !== undefined) {
+    if (!Array.isArray(ref.summaryTags)) throw new Error(`${context} summaryTags must be an array`);
+    for (const tag of ref.summaryTags) {
+      if (!String(tag || "").trim()) throw new Error(`${context} summaryTags must be non-empty strings`);
+    }
+  }
+  return ref;
+}
+
 export function assertLogEventEnvelope(event) {
   if (!event || typeof event !== "object") throw new Error("log event must be an object");
   if (event.schemaVersion !== LOGGING.SCHEMA_VERSION) throw new Error("unsupported log schema version");
@@ -547,6 +561,11 @@ export function assertLogEventEnvelope(event) {
     throw new Error("log safe facts must be an object");
   }
   rejectSensitiveSafeFacts(event.safeFacts);
+  if (event.detailRef !== undefined) assertEncryptedDetailRef(event.detailRef, "log detailRef");
+  if (event.encryptedDetailRefs !== undefined) {
+    if (!Array.isArray(event.encryptedDetailRefs)) throw new Error("log encryptedDetailRefs must be an array");
+    for (const ref of event.encryptedDetailRefs) assertEncryptedDetailRef(ref, "log encryptedDetailRefs entry");
+  }
   if (event.eventId !== logEventId(event)) throw new Error("log event id mismatch");
   return event;
 }
@@ -564,6 +583,7 @@ export function makeLogEventEnvelope({
   tags = [],
   safeFacts = {},
   detailRef,
+  encryptedDetailRefs = [],
   redaction = [LOGGING.REDACTION.SAFE],
 } = {}) {
   const event = {
@@ -583,6 +603,7 @@ export function makeLogEventEnvelope({
   if (resource) event.resource = resource;
   if (correlation) event.correlation = correlation;
   if (detailRef) event.detailRef = detailRef;
+  if (encryptedDetailRefs?.length) event.encryptedDetailRefs = encryptedDetailRefs;
   event.eventId = logEventId(event);
   return assertLogEventEnvelope(event);
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -141,6 +141,8 @@ pub struct LogEventEnvelope {
     pub safe_facts: Value,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub detail_ref: Option<EncryptedDetailRef>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub encrypted_detail_refs: Vec<EncryptedDetailRef>,
     #[serde(default)]
     pub redaction: Vec<LogRedactionClass>,
 }
@@ -175,9 +177,34 @@ pub fn validate_log_event(event: &LogEventEnvelope) -> Result<()> {
         return Err(anyhow!("log safe facts must be an object"));
     }
     reject_sensitive_safe_facts(&event.safe_facts)?;
+    if let Some(detail_ref) = &event.detail_ref {
+        validate_encrypted_detail_ref(detail_ref, "log detailRef")?;
+    }
+    for detail_ref in &event.encrypted_detail_refs {
+        validate_encrypted_detail_ref(detail_ref, "log encryptedDetailRefs entry")?;
+    }
     let expected = log_event_id(event)?;
     if event.event_id != expected {
         return Err(anyhow!("log event id mismatch"));
+    }
+    Ok(())
+}
+
+pub fn validate_encrypted_detail_ref(detail_ref: &EncryptedDetailRef, context: &str) -> Result<()> {
+    if detail_ref.object_id.trim().is_empty() {
+        return Err(anyhow!("{} missing objectId", context));
+    }
+    if detail_ref.container_id.trim().is_empty() {
+        return Err(anyhow!("{} missing containerId", context));
+    }
+    if detail_ref.key_ref.trim().is_empty() {
+        return Err(anyhow!("{} missing keyRef", context));
+    }
+    if detail_ref.manifest_hash.trim().is_empty() {
+        return Err(anyhow!("{} missing manifestHash", context));
+    }
+    if detail_ref.summary_tags.iter().any(|tag| tag.trim().is_empty()) {
+        return Err(anyhow!("{} summaryTags must be non-empty strings", context));
     }
     Ok(())
 }
@@ -258,6 +285,7 @@ mod tests {
             tags: vec!["capability".to_string()],
             safe_facts,
             detail_ref: None,
+            encrypted_detail_refs: Vec::new(),
             redaction: vec![LogRedactionClass::Safe],
         };
         event.event_id = log_event_id(&event).expect("event id");
@@ -295,5 +323,25 @@ mod tests {
         let mut event = event(json!({ "operation": "request" }));
         event.event_id = "bad".to_string();
         assert!(validate_log_event(&event).is_err());
+    }
+
+    #[test]
+    fn validates_encrypted_detail_refs() {
+        let mut event = event(json!({ "operation": "request" }));
+        event.encrypted_detail_refs = vec![EncryptedDetailRef {
+            object_id: "object-log-detail-1".to_string(),
+            container_id: "container-log-detail".to_string(),
+            key_ref: "container-log-detail:key".to_string(),
+            manifest_hash: "sha256:manifest-log-detail".to_string(),
+            summary_tags: vec!["debug-detail".to_string()],
+        }];
+        event.redaction = vec![LogRedactionClass::Safe, LogRedactionClass::EncryptedDetail];
+        event.event_id = log_event_id(&event).expect("event id");
+        validate_log_event(&event).expect("valid detail ref");
+
+        let mut bad = event;
+        bad.encrypted_detail_refs[0].container_id = String::new();
+        bad.event_id = log_event_id(&bad).expect("event id");
+        assert!(validate_log_event(&bad).is_err());
     }
 }

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -666,8 +666,17 @@ test("logging helpers validate safe event envelopes", () => {
       operation: "request",
       result: "accepted",
     },
+    encryptedDetailRefs: [{
+      objectId: "object-log-detail-1",
+      containerId: "container-log-detail",
+      keyRef: "container-log-detail:key",
+      manifestHash: "sha256:manifest-log-detail",
+      summaryTags: ["debug-detail"],
+    }],
+    redaction: [LOGGING.REDACTION.SAFE, LOGGING.REDACTION.ENCRYPTED_DETAIL],
   });
   assertLogEventEnvelope(event);
+  assert.equal(event.encryptedDetailRefs.length, 1);
 
   const bad = structuredClone(event);
   bad.safeFacts.privateToken = "secret";
@@ -682,6 +691,11 @@ test("logging helpers validate safe event envelopes", () => {
   const mismatch = structuredClone(event);
   mismatch.eventId = "bad";
   assert.throws(() => assertLogEventEnvelope(mismatch), /log event id mismatch/);
+
+  const badDetail = structuredClone(event);
+  badDetail.encryptedDetailRefs = [{ objectId: "object-only" }];
+  badDetail.eventId = event.eventId;
+  assert.throws(() => assertLogEventEnvelope(badDetail), /encryptedDetailRefs entry missing containerId/);
 });
 
 const TEST_COVERAGE = {

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -8,6 +8,7 @@ import {
   PROJECTION,
   ReplayCache,
   SERVICE_SURFACE,
+  SURFACE_APP,
   STORAGE,
   STREAM_SESSION_LIFECYCLE_PHASE,
   SWARM,
@@ -75,6 +76,8 @@ import {
   assertMediaFulfillmentEvidence,
   assertMediaTransportPath,
   assertMediaTransportObservation,
+  assertSurfaceAppContract,
+  assertSurfaceModuleClaim,
   assertConsumerFloor,
   assertContributionLifecycle,
   assertSwarmActivation,
@@ -398,6 +401,111 @@ test("service surface helpers validate node projections and settable fields", ()
     nodePath: "health",
     desired: { status: "ok" },
   }, surface), /not settable/);
+});
+
+test("surface app contracts validate module roles and fulfillment boundaries", () => {
+  const issuedAt = 1700000000;
+  const runtimeClient = assertSurfaceModuleClaim({
+    moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
+    role: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+    participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+    fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+    version: "0.1.0",
+    primitiveRefs: ["runtime.attach"],
+    requiredCapabilities: ["runtime.snapshot.subscribe"],
+    inputs: ["runtime.snapshot"],
+    outputs: ["runtime.intent"],
+    issuedAt,
+    expiresAt: issuedAt + 3600,
+  });
+  assert.equal(runtimeClient.role, SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT);
+
+  const contract = assertSurfaceAppContract({
+    contractId: "surface-app:nvr-ui",
+    schemaVersion: SURFACE_APP.SCHEMA_VERSION,
+    appId: "constitute-nvr-ui",
+    version: "0.1.0",
+    displayName: "Security Cameras",
+    requiredPrimitives: [
+      "runtime.attach",
+      "projection.materialization",
+      "media.transport.path",
+    ],
+    requiredModuleRoles: [
+      SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+      SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+      SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
+      SURFACE_APP.MODULE_ROLE.SERVICE_SURFACE_ADAPTER,
+      SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+    ],
+    modules: [
+      runtimeClient,
+      {
+        moduleRef: "constitute-nvr-ui/nvr-projection-model@0.1.0",
+        role: SURFACE_APP.MODULE_ROLE.PROJECTION_MODEL,
+        participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+        fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+        version: "0.1.0",
+        primitiveRefs: ["projection.materialization"],
+        inputs: ["runtime.snapshot"],
+        outputs: ["inventory.read-model"],
+        issuedAt,
+      },
+      {
+        moduleRef: "constitute-ui/media-webrtc-adapter@0.1.0",
+        role: SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER,
+        participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+        fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+        version: "0.1.0",
+        primitiveRefs: ["media.transport.path"],
+        inputs: ["stream.session.answer"],
+        outputs: ["media.transport.observation"],
+        issuedAt,
+      },
+      {
+        moduleRef: "constitute-nvr-ui/service-surface-adapter@0.1.0",
+        role: SURFACE_APP.MODULE_ROLE.SERVICE_SURFACE_ADAPTER,
+        participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+        fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+        version: "0.1.0",
+        primitiveRefs: ["stream.session.intent"],
+        inputs: ["camera.selection"],
+        outputs: ["runtime.intent"],
+        issuedAt,
+      },
+      {
+        moduleRef: "constitute-nvr-ui/product-view@0.1.0",
+        role: SURFACE_APP.MODULE_ROLE.PRODUCT_VIEW,
+        participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+        fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+        version: "0.1.0",
+        inputs: ["inventory.read-model", "media.render.posture"],
+        outputs: ["user.intent"],
+        issuedAt,
+      },
+    ],
+    projectionSubscriptions: [
+      { projectionId: "nvr.inventory", channelId: "nvr.inventory" },
+    ],
+    materializationBudgets: [
+      { budgetId: "nvr.preview", maxItems: 2, maxBytes: 1000000 },
+    ],
+    updatePosture: {
+      state: SURFACE_APP.UPDATE_POSTURE.STATIC,
+      checkedAt: issuedAt,
+    },
+    issuedAt,
+  });
+
+  assert.equal(contract.modules.length, 5);
+  assert.throws(() => assertSurfaceAppContract({
+    ...contract,
+    modules: contract.modules.filter((module) => module.role !== SURFACE_APP.MODULE_ROLE.PLATFORM_ADAPTER),
+  }), /missing module role platformAdapter/);
+  assert.throws(() => assertSurfaceModuleClaim({
+    ...runtimeClient,
+    role: "runtimePolicy",
+  }), /invalid surface module role/);
 });
 
 test("storage manifest helpers validate ciphertext-addressed objects", () => {

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -8,6 +8,7 @@ import {
   PROJECTION,
   ReplayCache,
   SERVICE_SURFACE,
+  SERVICE_REGISTRY,
   SURFACE_APP,
   STORAGE,
   STREAM_SESSION_LIFECYCLE_PHASE,
@@ -55,6 +56,8 @@ import {
   assertServiceNodeProjectionRecord,
   assertServiceNodeSetRequest,
   assertServiceSurfaceProjection,
+  assertServiceRegistryClaim,
+  assertServiceRegistryMaterialization,
   assertServiceProjectionRequest,
   assertRuntimeActivationRequest,
   assertRoutingScopePosture,
@@ -401,6 +404,104 @@ test("service surface helpers validate node projections and settable fields", ()
     nodePath: "health",
     desired: { status: "ok" },
   }, surface), /not settable/);
+});
+
+test("service registry primitives validate participant claims and materialized directories", () => {
+  const issuedAt = 1700000000;
+  const servicePk = pubkeyFromSecretKey(SERVICE_SK);
+  const gatewayPk = pubkeyFromSecretKey(GATEWAY_SK);
+  const claim = assertServiceRegistryClaim({
+    kind: SWARM.RECORD_KIND.SERVICE_REGISTRY_CLAIM,
+    claimId: "service-registry-claim:nvr",
+    schemaVersion: SERVICE_REGISTRY.SCHEMA_VERSION,
+    claimKind: SERVICE_REGISTRY.CLAIM_KIND.SERVICE,
+    state: SERVICE_REGISTRY.CLAIM_STATE.CLAIMED,
+    ownerRef: `service:${servicePk}`,
+    writerRef: `gateway:${gatewayPk}`,
+    subjectRef: `service:${servicePk}`,
+    scopeRef: "zone:lab",
+    service: "nvr",
+    servicePk,
+    serviceRef: `service:nvr:${servicePk}`,
+    memberRef: servicePk,
+    hostGatewayPk: gatewayPk,
+    capabilityRefs: ["media.stream.preview"],
+    channelRefs: ["nvr.streams"],
+    nodeRefs: ["nvr.streams.preview"],
+    surfaceRefs: ["nvr.surface"],
+    evidenceRefs: ["swarm.edge.session:service"],
+    safeFacts: { service: "nvr" },
+    issuedAt,
+    expiresAt: issuedAt + 90_000,
+  });
+  assert.equal(claim.claimKind, SERVICE_REGISTRY.CLAIM_KIND.SERVICE);
+
+  const materialized = assertServiceRegistryMaterialization({
+    kind: SWARM.RECORD_KIND.SERVICE_REGISTRY_MATERIALIZATION,
+    registryId: "service-registry:lab",
+    schemaVersion: SERVICE_REGISTRY.SCHEMA_VERSION,
+    scopeRef: "zone:lab",
+    state: SERVICE_REGISTRY.MATERIALIZATION_STATE.READY,
+    revision: 7,
+    claimRefs: [claim.claimId],
+    participantRefs: [claim.writerRef],
+    serviceRefs: [claim.serviceRef],
+    services: [
+      {
+        service: "nvr",
+        servicePk,
+        serviceRef: claim.serviceRef,
+        hostGatewayPk: gatewayPk,
+        surfaceChannel: "nvr.surface",
+        nodes: [
+          {
+            path: "streams",
+            nodeId: "nvr.streams.preview",
+            label: "Streams",
+            backingChannel: "nvr.streams",
+            fields: [
+              {
+                fieldId: "sourceId",
+                label: "Source",
+                valueKind: "string",
+                capabilities: [SERVICE_SURFACE.FIELD_CAPABILITY.READ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    entries: [
+      {
+        kind: SWARM.RECORD_KIND.DIRECTORY_ENTRY,
+        entryId: "directory:nvr-streams",
+        subjectRef: claim.subjectRef,
+        source: "memberRecord",
+        capabilityRef: "media.stream.preview",
+        channelId: "nvr.streams",
+        issuedAt,
+      },
+    ],
+    coverage: {
+      materializedCount: 1,
+      targetCount: 1,
+      completionRatio: 1,
+      syncState: PROJECTION.SYNC_STATE.COMPLETE_ENOUGH,
+    },
+    freshness: { state: PROJECTION.FRESHNESS.FRESH, updatedAt: issuedAt },
+    issuedAt,
+  });
+  assert.equal(materialized.services.length, 1);
+
+  assert.throws(() => assertServiceRegistryClaim({
+    ...claim,
+    kind: SWARM.RECORD_KIND.SERVICE_REGISTRY_CLAIM,
+    safeFacts: { servicePrivateUrl: "rtsp://camera" },
+  }), /unsafe safe fact key/);
+  assert.throws(() => assertServiceRegistryMaterialization({
+    ...materialized,
+    state: "complete",
+  }), /invalid service registry materialization state/);
 });
 
 test("surface app contracts validate module roles and fulfillment boundaries", () => {


### PR DESCRIPTION
Adds shared protocol grammar for surface app contracts, service registry contributions, and encrypted log detail references. This gives product surfaces and services a common contract shape for registry truth, materialization posture, and privacy-tiered logging.\n\nValidation: root docs/convergence/affected/browser/native/check:all passed before branch publication; live surface and long-stream proof passed against the convergence train.