### PR TITLE
Add service manager and agreement authority contracts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1483,6 +1483,25 @@ export type SurfaceModuleFulfillmentMode = "bundled" | "swarmPackage" | "storage
 export type SurfaceAppUpdatePostureState = "static" | "compatible" | "updateAvailable" | "blocked";
 export type SurfaceAppBootstrapPostureState = "static" | "ready" | "degraded" | "blocked" | "unavailable";
 export type ServiceManagerPostureState = "manual" | "ready" | "degraded" | "blocked" | "unavailable";
+export type ServiceManagerOperation =
+  | "install"
+  | "update"
+  | "start"
+  | "stop"
+  | "restart"
+  | "rollback"
+  | "healthCheck"
+  | "promote";
+export type ServiceManagerOperationState =
+  | "requested"
+  | "accepted"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "blocked"
+  | "cancelled"
+  | "superseded";
+export type ServiceManagerProofState = "pending" | "proved" | "failed" | "blocked" | "expired";
 export type SurfaceSecretBoundaryState = "notRequired" | "resolved" | "blocked" | "unavailable";
 export type SurfaceReleasePostureState = "static" | "buildReady" | "releaseReady" | "rollbackReady" | "blocked" | "unavailable";
 
@@ -1560,12 +1579,64 @@ export type ServiceManagerPosture = {
   state: ServiceManagerPostureState;
   serviceRefs?: string[];
   capabilityRefs?: string[];
+  operationRefs?: string[];
+  proofDigestRefs?: string[];
   secretBoundary?: SurfaceSecretBoundary;
   releasePosture?: SurfaceReleasePosture;
   rollbackPosture?: SurfaceReleasePosture;
   evidenceRefs?: string[];
   blockedReasons?: string[];
   issuedAt: number;
+  expiresAt?: number;
+};
+
+export type ServiceManagerOperationPosture = {
+  kind?: "service.manager.operation.posture";
+  operationId: string;
+  managerId: string;
+  subjectRef: string;
+  managerRef: string;
+  requesterRef: string;
+  operation: ServiceManagerOperation;
+  state: ServiceManagerOperationState;
+  serviceRefs?: string[];
+  capabilityRefs?: string[];
+  authorityRefs?: string[];
+  releaseRef?: string;
+  rollbackRef?: string;
+  secretBoundary?: SurfaceSecretBoundary;
+  evidenceRefs?: string[];
+  proofRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+  requestedAt: number;
+  acceptedAt?: number;
+  startedAt?: number;
+  completedAt?: number;
+  observedAt?: number;
+  expiresAt?: number;
+};
+
+export type ServiceManagerProofDigest = {
+  kind?: "service.manager.proof.digest";
+  digestId: string;
+  operationId: string;
+  managerId: string;
+  subjectRef: string;
+  state: ServiceManagerProofState;
+  trainRef?: string;
+  releaseRef?: string;
+  rollbackRef?: string;
+  commitRefs?: string[];
+  artifactRefs?: string[];
+  proofRefs?: string[];
+  metricsRefs?: string[];
+  environmentRefs?: string[];
+  serviceRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+  observedAt: number;
   expiresAt?: number;
 };
 
@@ -1776,6 +1847,8 @@ export function assertMediaTransportObservation(record: unknown): MediaTransport
 export function assertSurfaceModuleClaim(record: unknown): SurfaceModuleClaim;
 export function assertSurfaceAppContract(record: unknown): SurfaceAppContract;
 export function assertServiceManagerPosture(record: unknown): ServiceManagerPosture;
+export function assertServiceManagerOperationPosture(record: unknown): ServiceManagerOperationPosture;
+export function assertServiceManagerProofDigest(record: unknown): ServiceManagerProofDigest;
 export function assertSurfaceAppBootstrapPosture(record: unknown): SurfaceAppBootstrapPosture;
 export function assertAppRecipe(record: unknown): AppRecipe;
 export function assertAppRunnerAdvertisement(record: unknown): AppRunnerAdvertisement;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,7 @@ export const DEFAULT_REQUEST_TTL_SECONDS: number;
 export const BROKER: Readonly<Record<string, string>>;
 export const SERVICE_SURFACE: Readonly<Record<string, unknown>>;
 export const SURFACE_APP: Readonly<Record<string, unknown>>;
+export const AGREEMENT: Readonly<Record<string, unknown>>;
 export const SERVICE_REGISTRY: Readonly<Record<string, unknown>>;
 export const STORAGE: Readonly<Record<string, string>>;
 export const STORAGE_KEY_GRANULARITY: Readonly<Record<string, string>>;
@@ -1155,6 +1156,162 @@ export type SwarmRevocationRecord = {
   issuedAt: number;
 };
 
+export type AgreementPlane = "actionAuthority" | "accessAuthority" | "deliveryWitness" | "materialization";
+export type ActionGrantState = "requested" | "accepted" | "applied" | "rejected" | "blocked" | "expired" | "revoked";
+export type RootAuthorityOperation = "addRoot" | "refreshRoot" | "rotateRoot" | "revokeRoot" | "enrollDevice" | "revokeDevice";
+export type AccessEpochChangeKind = "create" | "addMember" | "removeMember" | "rotateKey" | "revokeMember" | "partitionSplit" | "partitionMerge" | "purposeKey";
+export type AgreementContentClass = "safeFacts" | "safeIndex" | "uiProjection" | "encryptedDetail" | "encryptedRaw" | "mediaReference" | "diagnosticDetail";
+export type AgreementPrivacyTier = "publicSafe" | "domainSafe" | "domainEncrypted" | "privateEncrypted";
+export type AgreementSafeFactPolicy = "none" | "minimal" | "indexOnly" | "projectionSafe";
+
+export type AuthorityRootOperationRecord = {
+  kind?: "authority.root.operation";
+  operationId: string;
+  operation: RootAuthorityOperation;
+  identityRef: string;
+  actorRef: string;
+  targetRef: string;
+  adminGrantRefs: string[];
+  rootRefs?: string[];
+  deviceRefs?: string[];
+  notificationRefs?: string[];
+  evidenceRefs?: string[];
+  state: ActionGrantState;
+  blockedReason?: string;
+  safeFacts?: Record<string, unknown>;
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type ActionAuthorityGrantRecord = {
+  kind?: "authority.action.grant";
+  grantId: string;
+  plane?: AgreementPlane;
+  issuerRef: string;
+  subjectRef: string;
+  audienceRefs: string[];
+  authorityDomain: SwarmAuthorityDomain;
+  resourceRef: string;
+  action: string;
+  state?: ActionGrantState;
+  scope?: Record<string, unknown>;
+  capabilityRefs?: string[];
+  parentGrantRefs?: string[];
+  revocationRefs?: string[];
+  evidenceRefs?: string[];
+  elevated?: boolean;
+  rootRefs?: string[];
+  delegation?: Record<string, unknown>;
+  blockedReason?: string;
+  safeFacts?: Record<string, unknown>;
+  privateRefs?: Array<Record<string, unknown>>;
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type ActionAuthorityExerciseRecord = {
+  kind?: "authority.action.exercise";
+  exerciseId: string;
+  grantId: string;
+  actorRef: string;
+  subjectRef: string;
+  resourceRef: string;
+  action: string;
+  state: ActionGrantState;
+  evidenceRefs?: string[];
+  resultRefs?: string[];
+  blockedReason?: string;
+  safeFacts?: Record<string, unknown>;
+  issuedAt: number;
+  observedAt?: number;
+};
+
+export type AuthorityGrantRevocationPostureRecord = {
+  kind?: "authority.grant.revocationPosture";
+  revocationId: string;
+  targetGrantRef: string;
+  issuerRef: string;
+  authorityDomain: SwarmAuthorityDomain;
+  affectedGrantRefs: string[];
+  affectedAccessGroupRefs?: string[];
+  inheritedScopeRefs?: string[];
+  state: ActionGrantState;
+  reasonCode: string;
+  evidenceRefs?: string[];
+  issuedAt: number;
+  effectiveAt?: number;
+};
+
+export type AccessGroupRecord = {
+  kind?: "access.group";
+  groupId: string;
+  ownerRef: string;
+  subjectRef: string;
+  contentClasses: AgreementContentClass[];
+  memberRefs: string[];
+  adminRefs: string[];
+  currentEpochId: string;
+  partitionRefs?: string[];
+  policyRefs?: string[];
+  safeFacts?: Record<string, unknown>;
+  issuedAt: number;
+};
+
+export type AccessEpochRecord = {
+  kind?: "access.epoch";
+  epochId: string;
+  groupId: string;
+  sequence: number;
+  changeKind: AccessEpochChangeKind;
+  previousEpochId?: string;
+  memberRefs: string[];
+  addedMemberRefs?: string[];
+  removedMemberRefs?: string[];
+  partitionRefs?: string[];
+  keyRef: string;
+  proofRefs: string[];
+  safeFacts?: Record<string, unknown>;
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type PrivateContentEnvelopeRecord = {
+  kind?: "private.content.envelope";
+  envelopeId: string;
+  contentClass: AgreementContentClass;
+  accessGroupRef: string;
+  epochId: string;
+  subjectRef: string;
+  issuerRef: string;
+  ciphertextRef?: string;
+  storageObjectRef?: string;
+  detailRef?: string;
+  mediaObjectRef?: string;
+  caacEnvelopeRef?: string;
+  recipientRefs?: string[];
+  keyRef?: string;
+  summarySafeFacts?: Record<string, unknown>;
+  evidenceRefs?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type EventFabricAccessClassRecord = {
+  kind?: "event.fabric.accessClass";
+  classId: string;
+  contentClass: AgreementContentClass;
+  privacyTier: AgreementPrivacyTier;
+  eventClasses: string[];
+  accessGroupRefs: string[];
+  processorRoleRefs?: string[];
+  storageClass: string;
+  retentionClass: string;
+  safeFactPolicy: AgreementSafeFactPolicy;
+  indexPolicy?: Record<string, unknown>;
+  safeFacts?: Record<string, unknown>;
+  issuedAt: number;
+};
+
 export type ProjectionSnapshot = {
   projectionId: string;
   policyId: string;
@@ -1800,6 +1957,14 @@ export function assertSwarmInteraction(record: unknown): SwarmInteractionRecord;
 export function assertSwarmActivation(record: unknown): SwarmActivationRecord;
 export function assertSwarmRelease(record: unknown): SwarmReleaseRecord;
 export function assertSwarmRevocation(record: unknown): SwarmRevocationRecord;
+export function assertAuthorityRootOperation(record: unknown): AuthorityRootOperationRecord;
+export function assertActionAuthorityGrant(record: unknown): ActionAuthorityGrantRecord;
+export function assertActionAuthorityExercise(record: unknown): ActionAuthorityExerciseRecord;
+export function assertAuthorityGrantRevocationPosture(record: unknown): AuthorityGrantRevocationPostureRecord;
+export function assertAccessGroup(record: unknown): AccessGroupRecord;
+export function assertAccessEpoch(record: unknown): AccessEpochRecord;
+export function assertPrivateContentEnvelope(record: unknown): PrivateContentEnvelopeRecord;
+export function assertEventFabricAccessClass(record: unknown): EventFabricAccessClassRecord;
 export function assertSwarmIdentityGraph(records: unknown): unknown[];
 export function assertCaacEnvelopeForMode(envelope: unknown, opts?: { mode?: string; now?: number }): CaacEnvelope | Record<string, unknown>;
 export function buildCapabilityDirectoryProjection(input?: {

--- a/src/index.js
+++ b/src/index.js
@@ -75,6 +75,33 @@ export const SURFACE_APP = Object.freeze({
     BLOCKED: "blocked",
     UNAVAILABLE: "unavailable",
   }),
+  SERVICE_MANAGER_OPERATION: Object.freeze({
+    INSTALL: "install",
+    UPDATE: "update",
+    START: "start",
+    STOP: "stop",
+    RESTART: "restart",
+    ROLLBACK: "rollback",
+    HEALTH_CHECK: "healthCheck",
+    PROMOTE: "promote",
+  }),
+  SERVICE_MANAGER_OPERATION_STATE: Object.freeze({
+    REQUESTED: "requested",
+    ACCEPTED: "accepted",
+    RUNNING: "running",
+    SUCCEEDED: "succeeded",
+    FAILED: "failed",
+    BLOCKED: "blocked",
+    CANCELLED: "cancelled",
+    SUPERSEDED: "superseded",
+  }),
+  SERVICE_MANAGER_PROOF_STATE: Object.freeze({
+    PENDING: "pending",
+    PROVED: "proved",
+    FAILED: "failed",
+    BLOCKED: "blocked",
+    EXPIRED: "expired",
+  }),
   SECRET_BOUNDARY: Object.freeze({
     NOT_REQUIRED: "notRequired",
     RESOLVED: "resolved",
@@ -1128,6 +1155,8 @@ export const SWARM = Object.freeze({
     SERVICE_REGISTRY_CLAIM: "service.registry.claim",
     SERVICE_REGISTRY_MATERIALIZATION: "service.registry.materialization",
     SERVICE_MANAGER_POSTURE: "service.manager.posture",
+    SERVICE_MANAGER_OPERATION_POSTURE: "service.manager.operation.posture",
+    SERVICE_MANAGER_PROOF_DIGEST: "service.manager.proof.digest",
     SURFACE_APP_BOOTSTRAP_POSTURE: "surface.app.bootstrap.posture",
   }),
   RECORD_KIND: Object.freeze({
@@ -1171,6 +1200,8 @@ export const SWARM = Object.freeze({
     SERVICE_REGISTRY_CLAIM: "service.registry.claim",
     SERVICE_REGISTRY_MATERIALIZATION: "service.registry.materialization",
     SERVICE_MANAGER_POSTURE: "service.manager.posture",
+    SERVICE_MANAGER_OPERATION_POSTURE: "service.manager.operation.posture",
+    SERVICE_MANAGER_PROOF_DIGEST: "service.manager.proof.digest",
     SURFACE_APP_BOOTSTRAP_POSTURE: "surface.app.bootstrap.posture",
   }),
   AUTHORITY_DOMAIN: Object.freeze({
@@ -3858,6 +3889,8 @@ export function assertServiceManagerPosture(record) {
   if (!Object.values(SURFACE_APP.SERVICE_MANAGER_POSTURE).includes(state)) throw new Error("invalid service manager posture state");
   assertOptionalReferenceList(record.serviceRefs, "service manager posture serviceRefs");
   assertOptionalCapabilityList(record.capabilityRefs, "service manager posture capabilityRefs");
+  assertOptionalReferenceList(record.operationRefs, "service manager posture operationRefs");
+  assertOptionalReferenceList(record.proofDigestRefs, "service manager posture proofDigestRefs");
   if (record.secretBoundary !== undefined) assertSurfaceSecretBoundary(record.secretBoundary, "service manager secretBoundary");
   if (record.releasePosture !== undefined) assertSurfaceReleasePosture(record.releasePosture, "service manager releasePosture");
   if (record.rollbackPosture !== undefined) assertSurfaceReleasePosture(record.rollbackPosture, "service manager rollbackPosture");
@@ -3868,6 +3901,94 @@ export function assertServiceManagerPosture(record) {
   }
   if (!Number(record.issuedAt || 0)) throw new Error("service manager posture missing issuedAt");
   if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) throw new Error("service manager posture expires before issuedAt");
+  return record;
+}
+
+function assertSurfaceOperationTimeline(record, context, baseField = "requestedAt") {
+  const base = Number(record[baseField] || 0);
+  if (!base) throw new Error(`${context} missing ${baseField}`);
+  for (const field of ["acceptedAt", "startedAt", "completedAt", "observedAt", "expiresAt"]) {
+    if (record[field] === undefined) continue;
+    const value = Number(record[field] || 0);
+    if (!value) throw new Error(`${context} invalid ${field}`);
+    if (value <= base && field === "expiresAt") throw new Error(`${context} expires before ${baseField}`);
+    if (value < base && field !== "expiresAt") throw new Error(`${context} ${field} before ${baseField}`);
+  }
+  if (record.startedAt !== undefined && record.completedAt !== undefined && Number(record.completedAt || 0) < Number(record.startedAt || 0)) {
+    throw new Error(`${context} completedAt before startedAt`);
+  }
+}
+
+function assertSurfaceManagerSensitiveBoundary(record, context) {
+  rejectForbiddenKeys(record, new Set(["secret", "password", "token", "privateKey", "secretKey", "value", "contents", "plaintext", "ciphertext"]), context);
+  rejectRouteControlByteFields(record, context);
+}
+
+export function assertServiceManagerOperationPosture(record) {
+  if (!isObject(record)) throw new Error("service manager operation posture must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.SERVICE_MANAGER_OPERATION_POSTURE, "service manager operation posture");
+  requireString(record.operationId, "service manager operation posture operationId");
+  requireString(record.managerId, "service manager operation posture managerId");
+  requireString(record.subjectRef, "service manager operation posture subjectRef");
+  requireString(record.managerRef, "service manager operation posture managerRef");
+  requireString(record.requesterRef, "service manager operation posture requesterRef");
+  const operation = requireString(record.operation, "service manager operation posture operation");
+  if (!Object.values(SURFACE_APP.SERVICE_MANAGER_OPERATION).includes(operation)) throw new Error("invalid service manager operation");
+  const state = requireString(record.state, "service manager operation posture state");
+  if (!Object.values(SURFACE_APP.SERVICE_MANAGER_OPERATION_STATE).includes(state)) throw new Error("invalid service manager operation state");
+  assertOptionalReferenceList(record.serviceRefs, "service manager operation posture serviceRefs");
+  assertOptionalCapabilityList(record.capabilityRefs, "service manager operation posture capabilityRefs");
+  assertOptionalReferenceList(record.authorityRefs, "service manager operation posture authorityRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "service manager operation posture evidenceRefs");
+  assertOptionalReferenceList(record.proofRefs, "service manager operation posture proofRefs");
+  if (record.releaseRef !== undefined) requireString(record.releaseRef, "service manager operation posture releaseRef");
+  if (record.rollbackRef !== undefined) requireString(record.rollbackRef, "service manager operation posture rollbackRef");
+  if (operation === SURFACE_APP.SERVICE_MANAGER_OPERATION.ROLLBACK && !String(record.rollbackRef || "").trim()) {
+    throw new Error("service manager rollback operation requires rollbackRef");
+  }
+  if (record.secretBoundary !== undefined) assertSurfaceSecretBoundary(record.secretBoundary, "service manager operation secretBoundary");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "service manager operation posture blockedReasons");
+  if ([SURFACE_APP.SERVICE_MANAGER_OPERATION_STATE.BLOCKED, SURFACE_APP.SERVICE_MANAGER_OPERATION_STATE.FAILED].includes(state) && blockedReasons.length === 0) {
+    throw new Error("service manager blocked or failed operation requires blockedReasons");
+  }
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "service manager operation posture safeFacts");
+  assertSurfaceManagerSensitiveBoundary(record, "service manager operation posture");
+  assertSurfaceOperationTimeline(record, "service manager operation posture", "requestedAt");
+  return record;
+}
+
+export function assertServiceManagerProofDigest(record) {
+  if (!isObject(record)) throw new Error("service manager proof digest must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.SERVICE_MANAGER_PROOF_DIGEST, "service manager proof digest");
+  requireString(record.digestId, "service manager proof digest digestId");
+  requireString(record.operationId, "service manager proof digest operationId");
+  requireString(record.managerId, "service manager proof digest managerId");
+  requireString(record.subjectRef, "service manager proof digest subjectRef");
+  const state = requireString(record.state, "service manager proof digest state");
+  if (!Object.values(SURFACE_APP.SERVICE_MANAGER_PROOF_STATE).includes(state)) throw new Error("invalid service manager proof digest state");
+  if (record.trainRef !== undefined) requireString(record.trainRef, "service manager proof digest trainRef");
+  if (record.releaseRef !== undefined) requireString(record.releaseRef, "service manager proof digest releaseRef");
+  if (record.rollbackRef !== undefined) requireString(record.rollbackRef, "service manager proof digest rollbackRef");
+  assertOptionalReferenceList(record.commitRefs, "service manager proof digest commitRefs");
+  assertOptionalReferenceList(record.artifactRefs, "service manager proof digest artifactRefs");
+  assertOptionalReferenceList(record.proofRefs, "service manager proof digest proofRefs");
+  assertOptionalReferenceList(record.metricsRefs, "service manager proof digest metricsRefs");
+  assertOptionalReferenceList(record.environmentRefs, "service manager proof digest environmentRefs");
+  assertOptionalReferenceList(record.serviceRefs, "service manager proof digest serviceRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "service manager proof digest evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "service manager proof digest blockedReasons");
+  if ([SURFACE_APP.SERVICE_MANAGER_PROOF_STATE.BLOCKED, SURFACE_APP.SERVICE_MANAGER_PROOF_STATE.FAILED].includes(state) && blockedReasons.length === 0) {
+    throw new Error("service manager blocked or failed proof digest requires blockedReasons");
+  }
+  const artifactRefs = assertOptionalReferenceList(record.artifactRefs, "service manager proof digest artifactRefs");
+  const proofRefs = assertOptionalReferenceList(record.proofRefs, "service manager proof digest proofRefs");
+  if (state === SURFACE_APP.SERVICE_MANAGER_PROOF_STATE.PROVED && artifactRefs.length === 0 && proofRefs.length === 0) {
+    throw new Error("service manager proved proof digest requires artifactRefs or proofRefs");
+  }
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "service manager proof digest safeFacts");
+  assertSurfaceManagerSensitiveBoundary(record, "service manager proof digest");
+  if (!Number(record.observedAt || 0)) throw new Error("service manager proof digest missing observedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.observedAt || 0)) throw new Error("service manager proof digest expires before observedAt");
   return record;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -118,6 +118,63 @@ export const SURFACE_APP = Object.freeze({
   }),
 });
 
+export const AGREEMENT = Object.freeze({
+  PLANE: Object.freeze({
+    ACTION_AUTHORITY: "actionAuthority",
+    ACCESS_AUTHORITY: "accessAuthority",
+    DELIVERY_WITNESS: "deliveryWitness",
+    MATERIALIZATION: "materialization",
+  }),
+  ACTION_GRANT_STATE: Object.freeze({
+    REQUESTED: "requested",
+    ACCEPTED: "accepted",
+    APPLIED: "applied",
+    REJECTED: "rejected",
+    BLOCKED: "blocked",
+    EXPIRED: "expired",
+    REVOKED: "revoked",
+  }),
+  ROOT_OPERATION: Object.freeze({
+    ADD_ROOT: "addRoot",
+    REFRESH_ROOT: "refreshRoot",
+    ROTATE_ROOT: "rotateRoot",
+    REVOKE_ROOT: "revokeRoot",
+    ENROLL_DEVICE: "enrollDevice",
+    REVOKE_DEVICE: "revokeDevice",
+  }),
+  ACCESS_EPOCH_CHANGE: Object.freeze({
+    CREATE: "create",
+    ADD_MEMBER: "addMember",
+    REMOVE_MEMBER: "removeMember",
+    ROTATE_KEY: "rotateKey",
+    REVOKE_MEMBER: "revokeMember",
+    PARTITION_SPLIT: "partitionSplit",
+    PARTITION_MERGE: "partitionMerge",
+    PURPOSE_KEY: "purposeKey",
+  }),
+  CONTENT_CLASS: Object.freeze({
+    SAFE_FACTS: "safeFacts",
+    SAFE_INDEX: "safeIndex",
+    UI_PROJECTION: "uiProjection",
+    ENCRYPTED_DETAIL: "encryptedDetail",
+    ENCRYPTED_RAW: "encryptedRaw",
+    MEDIA_REFERENCE: "mediaReference",
+    DIAGNOSTIC_DETAIL: "diagnosticDetail",
+  }),
+  PRIVACY_TIER: Object.freeze({
+    PUBLIC_SAFE: "publicSafe",
+    DOMAIN_SAFE: "domainSafe",
+    DOMAIN_ENCRYPTED: "domainEncrypted",
+    PRIVATE_ENCRYPTED: "privateEncrypted",
+  }),
+  SAFE_FACT_POLICY: Object.freeze({
+    NONE: "none",
+    MINIMAL: "minimal",
+    INDEX_ONLY: "indexOnly",
+    PROJECTION_SAFE: "projectionSafe",
+  }),
+});
+
 export const STORAGE = Object.freeze({
   OBJECT_HASH_ALG: "sha256-ciphertext-v1",
   CHUNK_HASH_ALG: "sha256-ciphertext-v1",
@@ -1137,6 +1194,14 @@ export const SWARM = Object.freeze({
     SWARM_ACTIVATION: "swarm.activation",
     SWARM_RELEASE: "swarm.release",
     SWARM_REVOCATION: "swarm.revocation",
+    AUTHORITY_ROOT_OPERATION: "authority.root.operation",
+    AUTHORITY_ACTION_GRANT: "authority.action.grant",
+    AUTHORITY_ACTION_EXERCISE: "authority.action.exercise",
+    AUTHORITY_GRANT_REVOCATION_POSTURE: "authority.grant.revocationPosture",
+    ACCESS_GROUP: "access.group",
+    ACCESS_EPOCH: "access.epoch",
+    PRIVATE_CONTENT_ENVELOPE: "private.content.envelope",
+    EVENT_FABRIC_ACCESS_CLASS: "event.fabric.accessClass",
     PARTICIPANT_RUNLEVEL: "participant.runlevel",
     PARTICIPANT_SELF_CAPABILITY: "participant.selfCapability",
     INGRESS_LANE_POSTURE: "ingress.lane.posture",
@@ -1182,6 +1247,14 @@ export const SWARM = Object.freeze({
     SWARM_ACTIVATION: "swarm.activation",
     SWARM_RELEASE: "swarm.release",
     SWARM_REVOCATION: "swarm.revocation",
+    AUTHORITY_ROOT_OPERATION: "authority.root.operation",
+    AUTHORITY_ACTION_GRANT: "authority.action.grant",
+    AUTHORITY_ACTION_EXERCISE: "authority.action.exercise",
+    AUTHORITY_GRANT_REVOCATION_POSTURE: "authority.grant.revocationPosture",
+    ACCESS_GROUP: "access.group",
+    ACCESS_EPOCH: "access.epoch",
+    PRIVATE_CONTENT_ENVELOPE: "private.content.envelope",
+    EVENT_FABRIC_ACCESS_CLASS: "event.fabric.accessClass",
     PARTICIPANT_RUNLEVEL: "participant.runlevel",
     PARTICIPANT_SELF_CAPABILITY: "participant.selfCapability",
     INGRESS_LANE_POSTURE: "ingress.lane.posture",
@@ -3730,6 +3803,294 @@ export function assertSwarmRevocation(record) {
   requireString(record.reasonCode, "swarm revocation reasonCode");
   if (!Number(record.issuedAt || 0)) throw new Error("swarm revocation missing issuedAt");
   return record;
+}
+
+const PRIVATE_CONTENT_FORBIDDEN_FIELDS = new Set([
+  "plaintext",
+  "cleartext",
+  "body",
+  "payload",
+  "contents",
+  "content",
+  "value",
+  "ciphertext",
+  "sealedPayload",
+  "wrappedKey",
+  "key",
+  "secret",
+  "password",
+  "token",
+  "privateKey",
+  "secretKey",
+]);
+
+function assertAgreementPlaneName(value, name = "agreement plane") {
+  const plane = requireString(value, name);
+  if (!Object.values(AGREEMENT.PLANE).includes(plane)) throw new Error(`unsupported ${name}`);
+  return plane;
+}
+
+function assertActionGrantStateName(value, name = "action grant state") {
+  const state = requireString(value, name);
+  if (!Object.values(AGREEMENT.ACTION_GRANT_STATE).includes(state)) throw new Error(`unsupported ${name}`);
+  return state;
+}
+
+function assertRootOperationName(value, name = "root operation") {
+  const operation = requireString(value, name);
+  if (!Object.values(AGREEMENT.ROOT_OPERATION).includes(operation)) throw new Error(`unsupported ${name}`);
+  return operation;
+}
+
+function assertAccessEpochChangeName(value, name = "access epoch change") {
+  const change = requireString(value, name);
+  if (!Object.values(AGREEMENT.ACCESS_EPOCH_CHANGE).includes(change)) throw new Error(`unsupported ${name}`);
+  return change;
+}
+
+function assertContentClassName(value, name = "content class") {
+  const contentClass = requireString(value, name);
+  if (!Object.values(AGREEMENT.CONTENT_CLASS).includes(contentClass)) throw new Error(`unsupported ${name}`);
+  return contentClass;
+}
+
+function assertAgreementPrivacyTier(value, name = "privacy tier") {
+  const privacyTier = requireString(value, name);
+  if (!Object.values(AGREEMENT.PRIVACY_TIER).includes(privacyTier)) throw new Error(`unsupported ${name}`);
+  return privacyTier;
+}
+
+function assertSafeFactPolicyName(value, name = "safe fact policy") {
+  const policy = requireString(value, name);
+  if (!Object.values(AGREEMENT.SAFE_FACT_POLICY).includes(policy)) throw new Error(`unsupported ${name}`);
+  return policy;
+}
+
+function assertNoPrivateContentFields(record, context) {
+  rejectForbiddenKeys(record, PRIVATE_CONTENT_FORBIDDEN_FIELDS, context);
+  rejectMediaByteFields(record, context);
+}
+
+export function assertAuthorityRootOperation(record) {
+  if (!isObject(record)) throw new Error("authority root operation must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.AUTHORITY_ROOT_OPERATION, "authority root operation");
+  requireString(record.operationId, "authority root operation operationId");
+  assertRootOperationName(record.operation);
+  requireString(record.identityRef, "authority root operation identityRef");
+  requireString(record.actorRef, "authority root operation actorRef");
+  requireString(record.targetRef, "authority root operation targetRef");
+  const adminGrantRefs = assertReferenceList(record.adminGrantRefs, "authority root operation adminGrantRefs");
+  const rootRefs = assertOptionalReferenceList(record.rootRefs, "authority root operation rootRefs");
+  assertOptionalReferenceList(record.deviceRefs, "authority root operation deviceRefs");
+  assertOptionalReferenceList(record.notificationRefs, "authority root operation notificationRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "authority root operation evidenceRefs");
+  const state = assertActionGrantStateName(record.state, "authority root operation state");
+  const blockedReason = String(record.blockedReason || "").trim();
+  if ([AGREEMENT.ACTION_GRANT_STATE.BLOCKED, AGREEMENT.ACTION_GRANT_STATE.REJECTED].includes(state) && !blockedReason) {
+    throw new Error("blocked or rejected authority root operation requires blockedReason");
+  }
+  if (adminGrantRefs.length === 0) throw new Error("authority root operation requires adminGrantRefs");
+  if ([AGREEMENT.ROOT_OPERATION.ROTATE_ROOT, AGREEMENT.ROOT_OPERATION.REVOKE_ROOT, AGREEMENT.ROOT_OPERATION.ADD_ROOT].includes(record.operation) && rootRefs.length === 0) {
+    throw new Error("root-changing authority operation requires rootRefs");
+  }
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "authority root operation safeFacts");
+  if (!Number(record.issuedAt || 0)) throw new Error("authority root operation missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt) <= Number(record.issuedAt)) {
+    throw new Error("authority root operation expiresAt must be after issuedAt");
+  }
+  return { ...record, plane: AGREEMENT.PLANE.ACTION_AUTHORITY, state };
+}
+
+export function assertActionAuthorityGrant(record) {
+  if (!isObject(record)) throw new Error("action authority grant must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.AUTHORITY_ACTION_GRANT, "action authority grant");
+  requireString(record.grantId, "action authority grant grantId");
+  const plane = assertAgreementPlaneName(record.plane || AGREEMENT.PLANE.ACTION_AUTHORITY, "action authority grant plane");
+  if (plane !== AGREEMENT.PLANE.ACTION_AUTHORITY) throw new Error("action authority grant plane must be actionAuthority");
+  requireString(record.issuerRef, "action authority grant issuerRef");
+  requireString(record.subjectRef, "action authority grant subjectRef");
+  assertReferenceList(record.audienceRefs, "action authority grant audienceRefs");
+  assertAuthorityDomain(record.authorityDomain, "action authority grant authorityDomain");
+  requireString(record.resourceRef, "action authority grant resourceRef");
+  requireString(record.action, "action authority grant action");
+  const state = assertActionGrantStateName(record.state || AGREEMENT.ACTION_GRANT_STATE.ACCEPTED, "action authority grant state");
+  if (record.scope !== undefined) assertSafeObject(record.scope, "action authority grant scope");
+  assertOptionalCapabilityList(record.capabilityRefs, "action authority grant capabilityRefs");
+  assertOptionalReferenceList(record.parentGrantRefs, "action authority grant parentGrantRefs");
+  assertOptionalReferenceList(record.revocationRefs, "action authority grant revocationRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "action authority grant evidenceRefs");
+  const rootRefs = assertOptionalReferenceList(record.rootRefs, "action authority grant rootRefs");
+  if (record.elevated === true && rootRefs.length === 0) throw new Error("elevated action authority grant requires rootRefs");
+  if (record.delegation !== undefined) {
+    const delegation = assertOptionalObject(record.delegation, "action authority grant delegation");
+    if (delegation.allowed !== undefined && typeof delegation.allowed !== "boolean") throw new Error("action authority grant delegation.allowed must be boolean");
+    if (delegation.maxDepth !== undefined && (!Number.isInteger(Number(delegation.maxDepth)) || Number(delegation.maxDepth) < 0)) {
+      throw new Error("action authority grant delegation.maxDepth must be non-negative integer");
+    }
+    assertOptionalReferenceList(delegation.inheritedFrom, "action authority grant delegation inheritedFrom");
+  }
+  const blockedReason = String(record.blockedReason || "").trim();
+  if ([AGREEMENT.ACTION_GRANT_STATE.BLOCKED, AGREEMENT.ACTION_GRANT_STATE.REJECTED].includes(state) && !blockedReason) {
+    throw new Error("blocked or rejected action authority grant requires blockedReason");
+  }
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "action authority grant safeFacts");
+  assertPrivateRefList(record.privateRefs, "action authority grant privateRefs");
+  if (!Number(record.issuedAt || 0)) throw new Error("action authority grant missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt) <= Number(record.issuedAt)) {
+    throw new Error("action authority grant expiresAt must be after issuedAt");
+  }
+  return { ...record, plane, state };
+}
+
+export function assertActionAuthorityExercise(record) {
+  if (!isObject(record)) throw new Error("action authority exercise must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.AUTHORITY_ACTION_EXERCISE, "action authority exercise");
+  requireString(record.exerciseId, "action authority exercise exerciseId");
+  requireString(record.grantId, "action authority exercise grantId");
+  requireString(record.actorRef, "action authority exercise actorRef");
+  requireString(record.subjectRef, "action authority exercise subjectRef");
+  requireString(record.resourceRef, "action authority exercise resourceRef");
+  requireString(record.action, "action authority exercise action");
+  const state = assertActionGrantStateName(record.state, "action authority exercise state");
+  assertOptionalReferenceList(record.evidenceRefs, "action authority exercise evidenceRefs");
+  assertOptionalReferenceList(record.resultRefs, "action authority exercise resultRefs");
+  const blockedReason = String(record.blockedReason || "").trim();
+  if ([AGREEMENT.ACTION_GRANT_STATE.BLOCKED, AGREEMENT.ACTION_GRANT_STATE.REJECTED, AGREEMENT.ACTION_GRANT_STATE.EXPIRED, AGREEMENT.ACTION_GRANT_STATE.REVOKED].includes(state) && !blockedReason) {
+    throw new Error("blocked/rejected/expired/revoked action authority exercise requires blockedReason");
+  }
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "action authority exercise safeFacts");
+  if (!Number(record.issuedAt || 0)) throw new Error("action authority exercise missing issuedAt");
+  if (record.observedAt !== undefined && Number(record.observedAt) < Number(record.issuedAt)) {
+    throw new Error("action authority exercise observedAt must not be before issuedAt");
+  }
+  return { ...record, plane: AGREEMENT.PLANE.ACTION_AUTHORITY, state };
+}
+
+export function assertAuthorityGrantRevocationPosture(record) {
+  if (!isObject(record)) throw new Error("authority grant revocation posture must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.AUTHORITY_GRANT_REVOCATION_POSTURE, "authority grant revocation posture");
+  requireString(record.revocationId, "authority grant revocation posture revocationId");
+  requireString(record.targetGrantRef, "authority grant revocation posture targetGrantRef");
+  requireString(record.issuerRef, "authority grant revocation posture issuerRef");
+  assertAuthorityDomain(record.authorityDomain, "authority grant revocation posture authorityDomain");
+  assertReferenceList(record.affectedGrantRefs, "authority grant revocation posture affectedGrantRefs");
+  assertOptionalReferenceList(record.affectedAccessGroupRefs, "authority grant revocation posture affectedAccessGroupRefs");
+  assertOptionalReferenceList(record.inheritedScopeRefs, "authority grant revocation posture inheritedScopeRefs");
+  const state = assertActionGrantStateName(record.state, "authority grant revocation posture state");
+  requireString(record.reasonCode, "authority grant revocation posture reasonCode");
+  assertOptionalReferenceList(record.evidenceRefs, "authority grant revocation posture evidenceRefs");
+  if (!Number(record.issuedAt || 0)) throw new Error("authority grant revocation posture missing issuedAt");
+  if (record.effectiveAt !== undefined && Number(record.effectiveAt) < Number(record.issuedAt)) {
+    throw new Error("authority grant revocation posture effectiveAt must not be before issuedAt");
+  }
+  return { ...record, plane: AGREEMENT.PLANE.ACTION_AUTHORITY, state };
+}
+
+export function assertAccessGroup(record) {
+  if (!isObject(record)) throw new Error("access group must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.ACCESS_GROUP, "access group");
+  requireString(record.groupId, "access group groupId");
+  requireString(record.ownerRef, "access group ownerRef");
+  requireString(record.subjectRef, "access group subjectRef");
+  const contentClasses = requireNonEmptyArray(record.contentClasses, "access group contentClasses").map((entry) => assertContentClassName(entry, "access group contentClass"));
+  assertReferenceList(record.memberRefs, "access group memberRefs");
+  assertReferenceList(record.adminRefs, "access group adminRefs");
+  requireString(record.currentEpochId, "access group currentEpochId");
+  assertOptionalReferenceList(record.partitionRefs, "access group partitionRefs");
+  assertOptionalReferenceList(record.policyRefs, "access group policyRefs");
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "access group safeFacts");
+  if (!Number(record.issuedAt || 0)) throw new Error("access group missing issuedAt");
+  return { ...record, plane: AGREEMENT.PLANE.ACCESS_AUTHORITY, contentClasses };
+}
+
+export function assertAccessEpoch(record) {
+  if (!isObject(record)) throw new Error("access epoch must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.ACCESS_EPOCH, "access epoch");
+  requireString(record.epochId, "access epoch epochId");
+  requireString(record.groupId, "access epoch groupId");
+  const sequence = Number(record.sequence);
+  if (!Number.isInteger(sequence) || sequence < 1) throw new Error("access epoch sequence must be positive integer");
+  const changeKind = assertAccessEpochChangeName(record.changeKind, "access epoch changeKind");
+  if (record.previousEpochId !== undefined) requireString(record.previousEpochId, "access epoch previousEpochId");
+  assertReferenceList(record.memberRefs, "access epoch memberRefs");
+  const addedMemberRefs = assertOptionalReferenceList(record.addedMemberRefs, "access epoch addedMemberRefs");
+  const removedMemberRefs = assertOptionalReferenceList(record.removedMemberRefs, "access epoch removedMemberRefs");
+  assertOptionalReferenceList(record.partitionRefs, "access epoch partitionRefs");
+  requireString(record.keyRef, "access epoch keyRef");
+  const proofRefs = assertReferenceList(record.proofRefs, "access epoch proofRefs");
+  if ([AGREEMENT.ACCESS_EPOCH_CHANGE.REMOVE_MEMBER, AGREEMENT.ACCESS_EPOCH_CHANGE.REVOKE_MEMBER, AGREEMENT.ACCESS_EPOCH_CHANGE.ROTATE_KEY].includes(changeKind) && !String(record.previousEpochId || "").trim()) {
+    throw new Error("revoking or rotating access epoch requires previousEpochId");
+  }
+  if ([AGREEMENT.ACCESS_EPOCH_CHANGE.REMOVE_MEMBER, AGREEMENT.ACCESS_EPOCH_CHANGE.REVOKE_MEMBER].includes(changeKind) && removedMemberRefs.length === 0) {
+    throw new Error("member removal access epoch requires removedMemberRefs");
+  }
+  if (changeKind === AGREEMENT.ACCESS_EPOCH_CHANGE.ADD_MEMBER && addedMemberRefs.length === 0) {
+    throw new Error("member addition access epoch requires addedMemberRefs");
+  }
+  if (proofRefs.length === 0) throw new Error("access epoch requires proofRefs");
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "access epoch safeFacts");
+  assertNoPrivateContentFields(record.safeFacts || {}, "access epoch safeFacts");
+  if (!Number(record.issuedAt || 0)) throw new Error("access epoch missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt) <= Number(record.issuedAt)) {
+    throw new Error("access epoch expiresAt must be after issuedAt");
+  }
+  return { ...record, plane: AGREEMENT.PLANE.ACCESS_AUTHORITY, sequence, changeKind, addedMemberRefs, removedMemberRefs };
+}
+
+export function assertPrivateContentEnvelope(record) {
+  if (!isObject(record)) throw new Error("private content envelope must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.PRIVATE_CONTENT_ENVELOPE, "private content envelope");
+  assertNoPrivateContentFields(record, "private content envelope");
+  requireString(record.envelopeId, "private content envelope envelopeId");
+  const contentClass = assertContentClassName(record.contentClass, "private content envelope contentClass");
+  if (![AGREEMENT.CONTENT_CLASS.ENCRYPTED_DETAIL, AGREEMENT.CONTENT_CLASS.ENCRYPTED_RAW, AGREEMENT.CONTENT_CLASS.MEDIA_REFERENCE, AGREEMENT.CONTENT_CLASS.DIAGNOSTIC_DETAIL].includes(contentClass)) {
+    throw new Error("private content envelope requires encrypted/detail/media content class");
+  }
+  requireString(record.accessGroupRef, "private content envelope accessGroupRef");
+  requireString(record.epochId, "private content envelope epochId");
+  requireString(record.subjectRef, "private content envelope subjectRef");
+  requireString(record.issuerRef, "private content envelope issuerRef");
+  const bodyRefs = [
+    record.ciphertextRef,
+    record.storageObjectRef,
+    record.detailRef,
+    record.mediaObjectRef,
+    record.caacEnvelopeRef,
+  ].map((value) => String(value || "").trim()).filter(Boolean);
+  if (bodyRefs.length === 0) throw new Error("private content envelope requires a content reference");
+  assertOptionalReferenceList(record.recipientRefs, "private content envelope recipientRefs");
+  if (record.keyRef !== undefined) requireString(record.keyRef, "private content envelope keyRef");
+  if (record.summarySafeFacts !== undefined) {
+    assertSafeObject(record.summarySafeFacts, "private content envelope summarySafeFacts");
+    assertNoPrivateContentFields(record.summarySafeFacts, "private content envelope summarySafeFacts");
+  }
+  assertOptionalReferenceList(record.evidenceRefs, "private content envelope evidenceRefs");
+  if (!Number(record.issuedAt || 0)) throw new Error("private content envelope missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt) <= Number(record.issuedAt)) {
+    throw new Error("private content envelope expiresAt must be after issuedAt");
+  }
+  return { ...record, plane: AGREEMENT.PLANE.ACCESS_AUTHORITY, contentClass };
+}
+
+export function assertEventFabricAccessClass(record) {
+  if (!isObject(record)) throw new Error("event fabric access class must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.EVENT_FABRIC_ACCESS_CLASS, "event fabric access class");
+  requireString(record.classId, "event fabric access class classId");
+  const contentClass = assertContentClassName(record.contentClass, "event fabric access class contentClass");
+  const privacyTier = assertAgreementPrivacyTier(record.privacyTier, "event fabric access class privacyTier");
+  requireNonEmptyArray(record.eventClasses, "event fabric access class eventClasses").forEach((entry) => requireString(entry, "event fabric access class eventClass"));
+  assertReferenceList(record.accessGroupRefs, "event fabric access class accessGroupRefs");
+  assertOptionalReferenceList(record.processorRoleRefs, "event fabric access class processorRoleRefs");
+  requireString(record.storageClass, "event fabric access class storageClass");
+  requireString(record.retentionClass, "event fabric access class retentionClass");
+  assertSafeFactPolicyName(record.safeFactPolicy, "event fabric access class safeFactPolicy");
+  if (record.indexPolicy !== undefined) assertSafeObject(record.indexPolicy, "event fabric access class indexPolicy");
+  if ([AGREEMENT.CONTENT_CLASS.ENCRYPTED_DETAIL, AGREEMENT.CONTENT_CLASS.ENCRYPTED_RAW, AGREEMENT.CONTENT_CLASS.DIAGNOSTIC_DETAIL].includes(contentClass) && privacyTier === AGREEMENT.PRIVACY_TIER.PUBLIC_SAFE) {
+    throw new Error("encrypted event fabric access class must not use publicSafe privacy tier");
+  }
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "event fabric access class safeFacts");
+  if (!Number(record.issuedAt || 0)) throw new Error("event fabric access class missing issuedAt");
+  return { ...record, plane: AGREEMENT.PLANE.MATERIALIZATION, contentClass, privacyTier };
 }
 
 export function assertSwarmIdentityGraph(records) {

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -40,6 +40,18 @@ pub const STREAM_CANDIDATE_ROLE_SERVICE: &str = "service";
 pub const STREAM_CANDIDATE_ACTIONABILITY_USABLE: &str = "usable";
 pub const STREAM_CANDIDATE_ACTIONABILITY_BLOCKED: &str = "blocked";
 
+pub const AGREEMENT_PLANE_ACTION_AUTHORITY: &str = "actionAuthority";
+pub const AGREEMENT_PLANE_ACCESS_AUTHORITY: &str = "accessAuthority";
+pub const AGREEMENT_PLANE_DELIVERY_WITNESS: &str = "deliveryWitness";
+pub const AGREEMENT_PLANE_MATERIALIZATION: &str = "materialization";
+pub const AGREEMENT_STATE_REQUESTED: &str = "requested";
+pub const AGREEMENT_STATE_ACCEPTED: &str = "accepted";
+pub const AGREEMENT_STATE_APPLIED: &str = "applied";
+pub const AGREEMENT_STATE_REJECTED: &str = "rejected";
+pub const AGREEMENT_STATE_BLOCKED: &str = "blocked";
+pub const AGREEMENT_STATE_EXPIRED: &str = "expired";
+pub const AGREEMENT_STATE_REVOKED: &str = "revoked";
+
 pub const RECORD_NODE_CAPABILITY: &str = "node.capability";
 pub const RECORD_RUNTIME_ACTIVATION_REQUEST: &str = "runtime.activation.request";
 pub const RECORD_ROUTE_PROMISE: &str = "route.promise";
@@ -62,6 +74,14 @@ pub const RECORD_SWARM_INTERACTION: &str = "swarm.interaction";
 pub const RECORD_SWARM_ACTIVATION: &str = "swarm.activation";
 pub const RECORD_SWARM_RELEASE: &str = "swarm.release";
 pub const RECORD_SWARM_REVOCATION: &str = "swarm.revocation";
+pub const RECORD_AUTHORITY_ROOT_OPERATION: &str = "authority.root.operation";
+pub const RECORD_AUTHORITY_ACTION_GRANT: &str = "authority.action.grant";
+pub const RECORD_AUTHORITY_ACTION_EXERCISE: &str = "authority.action.exercise";
+pub const RECORD_AUTHORITY_GRANT_REVOCATION_POSTURE: &str = "authority.grant.revocationPosture";
+pub const RECORD_ACCESS_GROUP: &str = "access.group";
+pub const RECORD_ACCESS_EPOCH: &str = "access.epoch";
+pub const RECORD_PRIVATE_CONTENT_ENVELOPE: &str = "private.content.envelope";
+pub const RECORD_EVENT_FABRIC_ACCESS_CLASS: &str = "event.fabric.accessClass";
 pub const RECORD_PARTICIPANT_RUNLEVEL: &str = "participant.runlevel";
 pub const RECORD_PARTICIPANT_SELF_CAPABILITY: &str = "participant.selfCapability";
 pub const RECORD_EVENT_ADMISSION: &str = "event.admission";
@@ -1321,6 +1341,240 @@ pub struct SwarmRevocationRecord {
     pub issued_at: u64,
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorityRootOperationRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub operation_id: String,
+    pub operation: String,
+    pub identity_ref: String,
+    pub actor_ref: String,
+    pub target_ref: String,
+    #[serde(default)]
+    pub admin_grant_refs: Vec<String>,
+    #[serde(default)]
+    pub root_refs: Vec<String>,
+    #[serde(default)]
+    pub device_refs: Vec<String>,
+    #[serde(default)]
+    pub notification_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocked_reason: Option<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ActionAuthorityGrantRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub grant_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plane: Option<String>,
+    pub issuer_ref: String,
+    pub subject_ref: String,
+    #[serde(default)]
+    pub audience_refs: Vec<String>,
+    pub authority_domain: String,
+    pub resource_ref: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    #[serde(default)]
+    pub scope: Value,
+    #[serde(default)]
+    pub capability_refs: Vec<String>,
+    #[serde(default)]
+    pub parent_grant_refs: Vec<String>,
+    #[serde(default)]
+    pub revocation_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub elevated: bool,
+    #[serde(default)]
+    pub root_refs: Vec<String>,
+    #[serde(default)]
+    pub delegation: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocked_reason: Option<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    #[serde(default)]
+    pub private_refs: Vec<Value>,
+    pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ActionAuthorityExerciseRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub exercise_id: String,
+    pub grant_id: String,
+    pub actor_ref: String,
+    pub subject_ref: String,
+    pub resource_ref: String,
+    pub action: String,
+    pub state: String,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub result_refs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub blocked_reason: Option<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observed_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthorityGrantRevocationPostureRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub revocation_id: String,
+    pub target_grant_ref: String,
+    pub issuer_ref: String,
+    pub authority_domain: String,
+    #[serde(default)]
+    pub affected_grant_refs: Vec<String>,
+    #[serde(default)]
+    pub affected_access_group_refs: Vec<String>,
+    #[serde(default)]
+    pub inherited_scope_refs: Vec<String>,
+    pub state: String,
+    pub reason_code: String,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AccessGroupRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub group_id: String,
+    pub owner_ref: String,
+    pub subject_ref: String,
+    #[serde(default)]
+    pub content_classes: Vec<String>,
+    #[serde(default)]
+    pub member_refs: Vec<String>,
+    #[serde(default)]
+    pub admin_refs: Vec<String>,
+    pub current_epoch_id: String,
+    #[serde(default)]
+    pub partition_refs: Vec<String>,
+    #[serde(default)]
+    pub policy_refs: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub issued_at: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AccessEpochRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub epoch_id: String,
+    pub group_id: String,
+    pub sequence: u64,
+    pub change_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_epoch_id: Option<String>,
+    #[serde(default)]
+    pub member_refs: Vec<String>,
+    #[serde(default)]
+    pub added_member_refs: Vec<String>,
+    #[serde(default)]
+    pub removed_member_refs: Vec<String>,
+    #[serde(default)]
+    pub partition_refs: Vec<String>,
+    pub key_ref: String,
+    #[serde(default)]
+    pub proof_refs: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct PrivateContentEnvelopeRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub envelope_id: String,
+    pub content_class: String,
+    pub access_group_ref: String,
+    pub epoch_id: String,
+    pub subject_ref: String,
+    pub issuer_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ciphertext_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub storage_object_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_object_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub caac_envelope_ref: Option<String>,
+    #[serde(default)]
+    pub recipient_refs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub key_ref: Option<String>,
+    #[serde(default)]
+    pub summary_safe_facts: Value,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct EventFabricAccessClassRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub class_id: String,
+    pub content_class: String,
+    pub privacy_tier: String,
+    #[serde(default)]
+    pub event_classes: Vec<String>,
+    #[serde(default)]
+    pub access_group_refs: Vec<String>,
+    #[serde(default)]
+    pub processor_role_refs: Vec<String>,
+    pub storage_class: String,
+    pub retention_class: String,
+    pub safe_fact_policy: String,
+    #[serde(default)]
+    pub index_policy: Value,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub issued_at: u64,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CaacValidationMode {
     Structural,
@@ -2518,6 +2772,460 @@ pub fn validate_swarm_revocation(record: &SwarmRevocationRecord) -> Result<()> {
     Ok(())
 }
 
+pub fn validate_authority_root_operation(record: &AuthorityRootOperationRecord) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_AUTHORITY_ROOT_OPERATION,
+        "authority root operation",
+    )?;
+    require_non_empty(
+        &record.operation_id,
+        "authority root operation missing operationId",
+    )?;
+    validate_root_operation(&record.operation)?;
+    require_non_empty(
+        &record.identity_ref,
+        "authority root operation missing identityRef",
+    )?;
+    require_non_empty(
+        &record.actor_ref,
+        "authority root operation missing actorRef",
+    )?;
+    require_non_empty(
+        &record.target_ref,
+        "authority root operation missing targetRef",
+    )?;
+    require_non_empty_vec(
+        &record.admin_grant_refs,
+        "authority root operation requires adminGrantRefs",
+    )?;
+    for reference in &record.root_refs {
+        require_non_empty(reference, "authority root operation missing rootRef")?;
+    }
+    for reference in &record.device_refs {
+        require_non_empty(reference, "authority root operation missing deviceRef")?;
+    }
+    validate_action_grant_state(&record.state)?;
+    if matches!(
+        record.state.as_str(),
+        AGREEMENT_STATE_BLOCKED | AGREEMENT_STATE_REJECTED
+    ) && record
+        .blocked_reason
+        .as_deref()
+        .unwrap_or_default()
+        .trim()
+        .is_empty()
+    {
+        return Err(anyhow!(
+            "blocked or rejected authority root operation requires blockedReason"
+        ));
+    }
+    if matches!(
+        record.operation.as_str(),
+        "rotateRoot" | "revokeRoot" | "addRoot"
+    ) && record.root_refs.is_empty()
+    {
+        return Err(anyhow!(
+            "root-changing authority operation requires rootRefs"
+        ));
+    }
+    validate_safe_facts(&record.safe_facts, "authority root operation safeFacts")?;
+    if record.issued_at == 0 {
+        return Err(anyhow!("authority root operation missing issuedAt"));
+    }
+    if record
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= record.issued_at)
+    {
+        return Err(anyhow!(
+            "authority root operation expiresAt must be after issuedAt"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_action_authority_grant(record: &ActionAuthorityGrantRecord) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_AUTHORITY_ACTION_GRANT,
+        "action authority grant",
+    )?;
+    require_non_empty(&record.grant_id, "action authority grant missing grantId")?;
+    let plane = record
+        .plane
+        .as_deref()
+        .unwrap_or(AGREEMENT_PLANE_ACTION_AUTHORITY);
+    validate_agreement_plane(plane)?;
+    if plane != AGREEMENT_PLANE_ACTION_AUTHORITY {
+        return Err(anyhow!(
+            "action authority grant plane must be actionAuthority"
+        ));
+    }
+    require_non_empty(
+        &record.issuer_ref,
+        "action authority grant missing issuerRef",
+    )?;
+    require_non_empty(
+        &record.subject_ref,
+        "action authority grant missing subjectRef",
+    )?;
+    require_non_empty_vec(
+        &record.audience_refs,
+        "action authority grant missing audienceRefs",
+    )?;
+    validate_authority_domain(&record.authority_domain)?;
+    require_non_empty(
+        &record.resource_ref,
+        "action authority grant missing resourceRef",
+    )?;
+    require_non_empty(&record.action, "action authority grant missing action")?;
+    let state = record.state.as_deref().unwrap_or(AGREEMENT_STATE_ACCEPTED);
+    validate_action_grant_state(state)?;
+    if matches!(state, AGREEMENT_STATE_BLOCKED | AGREEMENT_STATE_REJECTED)
+        && record
+            .blocked_reason
+            .as_deref()
+            .unwrap_or_default()
+            .trim()
+            .is_empty()
+    {
+        return Err(anyhow!(
+            "blocked or rejected action authority grant requires blockedReason"
+        ));
+    }
+    validate_capability_names(&record.capability_refs)?;
+    if record.elevated {
+        require_non_empty_vec(
+            &record.root_refs,
+            "elevated action authority grant requires rootRefs",
+        )?;
+    }
+    if !record.scope.is_null() {
+        validate_safe_facts(&record.scope, "action authority grant scope")?;
+    }
+    if !record.delegation.is_null() && !record.delegation.is_object() {
+        return Err(anyhow!(
+            "action authority grant delegation must be an object"
+        ));
+    }
+    validate_safe_facts(&record.safe_facts, "action authority grant safeFacts")?;
+    validate_private_refs(&record.private_refs, "action authority grant privateRefs")?;
+    if record.issued_at == 0 {
+        return Err(anyhow!("action authority grant missing issuedAt"));
+    }
+    if record
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= record.issued_at)
+    {
+        return Err(anyhow!(
+            "action authority grant expiresAt must be after issuedAt"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_action_authority_exercise(record: &ActionAuthorityExerciseRecord) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_AUTHORITY_ACTION_EXERCISE,
+        "action authority exercise",
+    )?;
+    require_non_empty(
+        &record.exercise_id,
+        "action authority exercise missing exerciseId",
+    )?;
+    require_non_empty(
+        &record.grant_id,
+        "action authority exercise missing grantId",
+    )?;
+    require_non_empty(
+        &record.actor_ref,
+        "action authority exercise missing actorRef",
+    )?;
+    require_non_empty(
+        &record.subject_ref,
+        "action authority exercise missing subjectRef",
+    )?;
+    require_non_empty(
+        &record.resource_ref,
+        "action authority exercise missing resourceRef",
+    )?;
+    require_non_empty(&record.action, "action authority exercise missing action")?;
+    validate_action_grant_state(&record.state)?;
+    if matches!(
+        record.state.as_str(),
+        AGREEMENT_STATE_BLOCKED
+            | AGREEMENT_STATE_REJECTED
+            | AGREEMENT_STATE_EXPIRED
+            | AGREEMENT_STATE_REVOKED
+    ) && record
+        .blocked_reason
+        .as_deref()
+        .unwrap_or_default()
+        .trim()
+        .is_empty()
+    {
+        return Err(anyhow!(
+            "blocked/rejected/expired/revoked action authority exercise requires blockedReason"
+        ));
+    }
+    validate_safe_facts(&record.safe_facts, "action authority exercise safeFacts")?;
+    if record.issued_at == 0 {
+        return Err(anyhow!("action authority exercise missing issuedAt"));
+    }
+    if record
+        .observed_at
+        .is_some_and(|observed_at| observed_at < record.issued_at)
+    {
+        return Err(anyhow!(
+            "action authority exercise observedAt must not be before issuedAt"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_authority_grant_revocation_posture(
+    record: &AuthorityGrantRevocationPostureRecord,
+) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_AUTHORITY_GRANT_REVOCATION_POSTURE,
+        "authority grant revocation posture",
+    )?;
+    require_non_empty(
+        &record.revocation_id,
+        "authority grant revocation posture missing revocationId",
+    )?;
+    require_non_empty(
+        &record.target_grant_ref,
+        "authority grant revocation posture missing targetGrantRef",
+    )?;
+    require_non_empty(
+        &record.issuer_ref,
+        "authority grant revocation posture missing issuerRef",
+    )?;
+    validate_authority_domain(&record.authority_domain)?;
+    require_non_empty_vec(
+        &record.affected_grant_refs,
+        "authority grant revocation posture missing affectedGrantRefs",
+    )?;
+    validate_action_grant_state(&record.state)?;
+    require_non_empty(
+        &record.reason_code,
+        "authority grant revocation posture missing reasonCode",
+    )?;
+    if record.issued_at == 0 {
+        return Err(anyhow!(
+            "authority grant revocation posture missing issuedAt"
+        ));
+    }
+    if record
+        .effective_at
+        .is_some_and(|effective_at| effective_at < record.issued_at)
+    {
+        return Err(anyhow!(
+            "authority grant revocation posture effectiveAt must not be before issuedAt"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_access_group(record: &AccessGroupRecord) -> Result<()> {
+    validate_optional_kind(&record.kind, RECORD_ACCESS_GROUP, "access group")?;
+    require_non_empty(&record.group_id, "access group missing groupId")?;
+    require_non_empty(&record.owner_ref, "access group missing ownerRef")?;
+    require_non_empty(&record.subject_ref, "access group missing subjectRef")?;
+    require_non_empty_vec(
+        &record.content_classes,
+        "access group missing contentClasses",
+    )?;
+    for content_class in &record.content_classes {
+        validate_content_class(content_class)?;
+    }
+    require_non_empty_vec(&record.member_refs, "access group missing memberRefs")?;
+    require_non_empty_vec(&record.admin_refs, "access group missing adminRefs")?;
+    require_non_empty(
+        &record.current_epoch_id,
+        "access group missing currentEpochId",
+    )?;
+    validate_safe_facts(&record.safe_facts, "access group safeFacts")?;
+    if record.issued_at == 0 {
+        return Err(anyhow!("access group missing issuedAt"));
+    }
+    Ok(())
+}
+
+pub fn validate_access_epoch(record: &AccessEpochRecord) -> Result<()> {
+    validate_optional_kind(&record.kind, RECORD_ACCESS_EPOCH, "access epoch")?;
+    require_non_empty(&record.epoch_id, "access epoch missing epochId")?;
+    require_non_empty(&record.group_id, "access epoch missing groupId")?;
+    if record.sequence == 0 {
+        return Err(anyhow!("access epoch sequence must be positive integer"));
+    }
+    validate_access_epoch_change(&record.change_kind)?;
+    require_non_empty_vec(&record.member_refs, "access epoch missing memberRefs")?;
+    require_non_empty(&record.key_ref, "access epoch missing keyRef")?;
+    require_non_empty_vec(&record.proof_refs, "access epoch missing proofRefs")?;
+    if matches!(
+        record.change_kind.as_str(),
+        "removeMember" | "revokeMember" | "rotateKey"
+    ) && record
+        .previous_epoch_id
+        .as_deref()
+        .unwrap_or_default()
+        .trim()
+        .is_empty()
+    {
+        return Err(anyhow!(
+            "revoking or rotating access epoch requires previousEpochId"
+        ));
+    }
+    if matches!(record.change_kind.as_str(), "removeMember" | "revokeMember")
+        && record.removed_member_refs.is_empty()
+    {
+        return Err(anyhow!(
+            "member removal access epoch requires removedMemberRefs"
+        ));
+    }
+    if record.change_kind == "addMember" && record.added_member_refs.is_empty() {
+        return Err(anyhow!(
+            "member addition access epoch requires addedMemberRefs"
+        ));
+    }
+    validate_safe_facts(&record.safe_facts, "access epoch safeFacts")?;
+    reject_private_content_fields(&record.safe_facts, "access epoch safeFacts")?;
+    if record.issued_at == 0 {
+        return Err(anyhow!("access epoch missing issuedAt"));
+    }
+    if record
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= record.issued_at)
+    {
+        return Err(anyhow!("access epoch expiresAt must be after issuedAt"));
+    }
+    Ok(())
+}
+
+pub fn validate_private_content_envelope(record: &PrivateContentEnvelopeRecord) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_PRIVATE_CONTENT_ENVELOPE,
+        "private content envelope",
+    )?;
+    reject_private_content_fields(&serde_json::to_value(record)?, "private content envelope")?;
+    require_non_empty(
+        &record.envelope_id,
+        "private content envelope missing envelopeId",
+    )?;
+    validate_content_class(&record.content_class)?;
+    if !matches!(
+        record.content_class.as_str(),
+        "encryptedDetail" | "encryptedRaw" | "mediaReference" | "diagnosticDetail"
+    ) {
+        return Err(anyhow!(
+            "private content envelope requires encrypted/detail/media content class"
+        ));
+    }
+    require_non_empty(
+        &record.access_group_ref,
+        "private content envelope missing accessGroupRef",
+    )?;
+    require_non_empty(&record.epoch_id, "private content envelope missing epochId")?;
+    require_non_empty(
+        &record.subject_ref,
+        "private content envelope missing subjectRef",
+    )?;
+    require_non_empty(
+        &record.issuer_ref,
+        "private content envelope missing issuerRef",
+    )?;
+    let body_refs = [
+        record.ciphertext_ref.as_deref(),
+        record.storage_object_ref.as_deref(),
+        record.detail_ref.as_deref(),
+        record.media_object_ref.as_deref(),
+        record.caac_envelope_ref.as_deref(),
+    ];
+    if !body_refs
+        .iter()
+        .flatten()
+        .any(|reference| !reference.trim().is_empty())
+    {
+        return Err(anyhow!(
+            "private content envelope requires a content reference"
+        ));
+    }
+    validate_safe_facts(
+        &record.summary_safe_facts,
+        "private content envelope summarySafeFacts",
+    )?;
+    reject_private_content_fields(
+        &record.summary_safe_facts,
+        "private content envelope summarySafeFacts",
+    )?;
+    if record.issued_at == 0 {
+        return Err(anyhow!("private content envelope missing issuedAt"));
+    }
+    if record
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= record.issued_at)
+    {
+        return Err(anyhow!(
+            "private content envelope expiresAt must be after issuedAt"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_event_fabric_access_class(record: &EventFabricAccessClassRecord) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_EVENT_FABRIC_ACCESS_CLASS,
+        "event fabric access class",
+    )?;
+    require_non_empty(
+        &record.class_id,
+        "event fabric access class missing classId",
+    )?;
+    validate_content_class(&record.content_class)?;
+    validate_agreement_privacy_tier(&record.privacy_tier)?;
+    require_non_empty_vec(
+        &record.event_classes,
+        "event fabric access class missing eventClasses",
+    )?;
+    require_non_empty_vec(
+        &record.access_group_refs,
+        "event fabric access class missing accessGroupRefs",
+    )?;
+    require_non_empty(
+        &record.storage_class,
+        "event fabric access class missing storageClass",
+    )?;
+    require_non_empty(
+        &record.retention_class,
+        "event fabric access class missing retentionClass",
+    )?;
+    validate_safe_fact_policy(&record.safe_fact_policy)?;
+    if matches!(
+        record.content_class.as_str(),
+        "encryptedDetail" | "encryptedRaw" | "diagnosticDetail"
+    ) && record.privacy_tier == "publicSafe"
+    {
+        return Err(anyhow!(
+            "encrypted event fabric access class must not use publicSafe privacy tier"
+        ));
+    }
+    validate_safe_facts(
+        &record.index_policy,
+        "event fabric access class indexPolicy",
+    )?;
+    validate_safe_facts(&record.safe_facts, "event fabric access class safeFacts")?;
+    if record.issued_at == 0 {
+        return Err(anyhow!("event fabric access class missing issuedAt"));
+    }
+    Ok(())
+}
+
 pub fn validate_swarm_identity_graph(records: &[Value]) -> Result<()> {
     for record in records {
         let Some(object) = record.as_object() else {
@@ -3421,6 +4129,102 @@ fn validate_authority_domain(domain: &str) -> Result<()> {
         Ok(())
     } else {
         Err(anyhow!("unsupported authority domain"))
+    }
+}
+
+fn validate_agreement_plane(plane: &str) -> Result<()> {
+    if matches!(
+        plane,
+        AGREEMENT_PLANE_ACTION_AUTHORITY
+            | AGREEMENT_PLANE_ACCESS_AUTHORITY
+            | AGREEMENT_PLANE_DELIVERY_WITNESS
+            | AGREEMENT_PLANE_MATERIALIZATION
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported agreement plane"))
+    }
+}
+
+fn validate_action_grant_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        AGREEMENT_STATE_REQUESTED
+            | AGREEMENT_STATE_ACCEPTED
+            | AGREEMENT_STATE_APPLIED
+            | AGREEMENT_STATE_REJECTED
+            | AGREEMENT_STATE_BLOCKED
+            | AGREEMENT_STATE_EXPIRED
+            | AGREEMENT_STATE_REVOKED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported action grant state"))
+    }
+}
+
+fn validate_root_operation(operation: &str) -> Result<()> {
+    if matches!(
+        operation,
+        "addRoot" | "refreshRoot" | "rotateRoot" | "revokeRoot" | "enrollDevice" | "revokeDevice"
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported root operation"))
+    }
+}
+
+fn validate_access_epoch_change(change: &str) -> Result<()> {
+    if matches!(
+        change,
+        "create"
+            | "addMember"
+            | "removeMember"
+            | "rotateKey"
+            | "revokeMember"
+            | "partitionSplit"
+            | "partitionMerge"
+            | "purposeKey"
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported access epoch change"))
+    }
+}
+
+fn validate_content_class(content_class: &str) -> Result<()> {
+    if matches!(
+        content_class,
+        "safeFacts"
+            | "safeIndex"
+            | "uiProjection"
+            | "encryptedDetail"
+            | "encryptedRaw"
+            | "mediaReference"
+            | "diagnosticDetail"
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported content class"))
+    }
+}
+
+fn validate_agreement_privacy_tier(privacy_tier: &str) -> Result<()> {
+    if matches!(
+        privacy_tier,
+        "publicSafe" | "domainSafe" | "domainEncrypted" | "privateEncrypted"
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported agreement privacy tier"))
+    }
+}
+
+fn validate_safe_fact_policy(policy: &str) -> Result<()> {
+    if matches!(policy, "none" | "minimal" | "indexOnly" | "projectionSafe") {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported safe fact policy"))
     }
 }
 
@@ -4844,6 +5648,51 @@ fn reject_unsafe_safe_fact_fields(value: &Value, context: &str) -> Result<()> {
     }
 }
 
+fn reject_private_content_fields(value: &Value, context: &str) -> Result<()> {
+    match value {
+        Value::Object(map) => {
+            for (key, child) in map {
+                if is_private_content_field(key) {
+                    return Err(anyhow!(
+                        "{context} contains forbidden private content field: {key}"
+                    ));
+                }
+                reject_private_content_fields(child, context)?;
+            }
+            Ok(())
+        }
+        Value::Array(items) => {
+            for item in items {
+                reject_private_content_fields(item, context)?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn is_private_content_field(key: &str) -> bool {
+    matches!(
+        key,
+        "plaintext"
+            | "cleartext"
+            | "body"
+            | "payload"
+            | "contents"
+            | "content"
+            | "value"
+            | "ciphertext"
+            | "sealedPayload"
+            | "wrappedKey"
+            | "key"
+            | "secret"
+            | "password"
+            | "token"
+            | "privateKey"
+            | "secretKey"
+    )
+}
+
 fn is_unsafe_safe_fact_key(key: &str) -> bool {
     matches!(
         key,
@@ -5135,6 +5984,7 @@ mod tests {
 
     const ISSUER_SK: &str = "0000000000000000000000000000000000000000000000000000000000000001";
     const GATEWAY_SK: &str = "0000000000000000000000000000000000000000000000000000000000000002";
+    const SERVICE_SK: &str = "0000000000000000000000000000000000000000000000000000000000000003";
     const BROWSER_SK: &str = "0000000000000000000000000000000000000000000000000000000000000004";
 
     fn zone_scope() -> ZoneScope {
@@ -6149,6 +6999,194 @@ mod tests {
         let mut live_graph = vector.identity_graph.clone();
         live_graph.push(serde_json::to_value(vector.activation).expect("activation json"));
         assert!(validate_swarm_identity_graph(&live_graph).is_err());
+    }
+
+    #[test]
+    fn validates_agreement_authority_access_and_private_content_records() {
+        let issuer_ref = format!(
+            "identity:{}",
+            pubkey_from_sk_hex(ISSUER_SK).expect("issuer pk")
+        );
+        let browser_member = format!(
+            "member:{}",
+            pubkey_from_sk_hex(BROWSER_SK).expect("browser pk")
+        );
+        let service_member = format!(
+            "member:{}",
+            pubkey_from_sk_hex(SERVICE_SK).expect("service pk")
+        );
+
+        let grant = ActionAuthorityGrantRecord {
+            kind: Some(RECORD_AUTHORITY_ACTION_GRANT.to_string()),
+            grant_id: "grant:logging:writer".to_string(),
+            plane: Some(AGREEMENT_PLANE_ACTION_AUTHORITY.to_string()),
+            issuer_ref: issuer_ref.clone(),
+            subject_ref: browser_member.clone(),
+            audience_refs: vec![service_member.clone()],
+            authority_domain: "identity".to_string(),
+            resource_ref: "contract:logging.default".to_string(),
+            action: "logging.event.write".to_string(),
+            state: Some(AGREEMENT_STATE_ACCEPTED.to_string()),
+            scope: json!({ "contractRef": "contract:logging.default", "retentionClass": "rolling" }),
+            capability_refs: vec![CAPABILITY_LOGGING_EVENTS_OBSERVE.to_string()],
+            parent_grant_refs: vec!["grant:root:logging".to_string()],
+            revocation_refs: vec![],
+            evidence_refs: vec!["sig:grant:logging:writer".to_string()],
+            elevated: false,
+            root_refs: vec![],
+            delegation: json!({ "allowed": true, "maxDepth": 1 }),
+            blocked_reason: None,
+            safe_facts: Value::Null,
+            private_refs: vec![],
+            issued_at: 1_700_000_010,
+            expires_at: Some(1_700_000_610),
+        };
+        validate_action_authority_grant(&grant).expect("valid action grant");
+
+        let mut wrong_plane = grant.clone();
+        wrong_plane.plane = Some(AGREEMENT_PLANE_ACCESS_AUTHORITY.to_string());
+        assert!(validate_action_authority_grant(&wrong_plane).is_err());
+
+        let root_operation = AuthorityRootOperationRecord {
+            kind: Some(RECORD_AUTHORITY_ROOT_OPERATION.to_string()),
+            operation_id: "root-op:enroll-aux".to_string(),
+            operation: "enrollDevice".to_string(),
+            identity_ref: issuer_ref.clone(),
+            actor_ref: format!("root:{}", pubkey_from_sk_hex(ISSUER_SK).expect("issuer pk")),
+            target_ref: format!(
+                "device:{}",
+                pubkey_from_sk_hex(BROWSER_SK).expect("browser pk")
+            ),
+            admin_grant_refs: vec!["grant:root:admin".to_string()],
+            root_refs: vec![],
+            device_refs: vec![format!(
+                "device:{}",
+                pubkey_from_sk_hex(BROWSER_SK).expect("browser pk")
+            )],
+            notification_refs: vec!["notification:root-enroll".to_string()],
+            evidence_refs: vec!["sig:root-op:enroll-aux".to_string()],
+            state: AGREEMENT_STATE_APPLIED.to_string(),
+            blocked_reason: None,
+            safe_facts: Value::Null,
+            issued_at: 1_700_000_030,
+            expires_at: None,
+        };
+        validate_authority_root_operation(&root_operation).expect("valid root operation");
+
+        let mut bad_root_rotation = root_operation.clone();
+        bad_root_rotation.operation = "rotateRoot".to_string();
+        bad_root_rotation.root_refs.clear();
+        assert!(validate_authority_root_operation(&bad_root_rotation).is_err());
+
+        let group = AccessGroupRecord {
+            kind: Some(RECORD_ACCESS_GROUP.to_string()),
+            group_id: "access-group:logging-secure".to_string(),
+            owner_ref: issuer_ref.clone(),
+            subject_ref: "contract:logging.default".to_string(),
+            content_classes: vec![
+                "encryptedDetail".to_string(),
+                "diagnosticDetail".to_string(),
+            ],
+            member_refs: vec![service_member.clone(), browser_member.clone()],
+            admin_refs: vec![format!(
+                "root:{}",
+                pubkey_from_sk_hex(ISSUER_SK).expect("issuer pk")
+            )],
+            current_epoch_id: "access-epoch:logging-secure:2".to_string(),
+            partition_refs: vec!["partition:identity:logging".to_string()],
+            policy_refs: vec![],
+            safe_facts: Value::Null,
+            issued_at: 1_700_000_040,
+        };
+        validate_access_group(&group).expect("valid access group");
+
+        let epoch = AccessEpochRecord {
+            kind: Some(RECORD_ACCESS_EPOCH.to_string()),
+            epoch_id: "access-epoch:logging-secure:2".to_string(),
+            group_id: group.group_id.clone(),
+            sequence: 2,
+            change_kind: "removeMember".to_string(),
+            previous_epoch_id: Some("access-epoch:logging-secure:1".to_string()),
+            member_refs: vec![service_member.clone()],
+            added_member_refs: vec![],
+            removed_member_refs: vec![browser_member.clone()],
+            partition_refs: vec![],
+            key_ref: "key-ref:logging-secure:2".to_string(),
+            proof_refs: vec!["sig:epoch:2".to_string()],
+            safe_facts: Value::Null,
+            issued_at: 1_700_000_050,
+            expires_at: None,
+        };
+        validate_access_epoch(&epoch).expect("valid access epoch");
+        let mut bad_epoch = epoch.clone();
+        bad_epoch.previous_epoch_id = None;
+        assert!(validate_access_epoch(&bad_epoch).is_err());
+
+        let envelope = PrivateContentEnvelopeRecord {
+            kind: Some(RECORD_PRIVATE_CONTENT_ENVELOPE.to_string()),
+            envelope_id: "private-envelope:logging-event-1".to_string(),
+            content_class: "encryptedDetail".to_string(),
+            access_group_ref: group.group_id.clone(),
+            epoch_id: epoch.epoch_id.clone(),
+            subject_ref: "event:runtime:1".to_string(),
+            issuer_ref: service_member.clone(),
+            ciphertext_ref: None,
+            storage_object_ref: Some("storage-object:log-event-1".to_string()),
+            detail_ref: None,
+            media_object_ref: None,
+            caac_envelope_ref: Some("caac:log-event-1".to_string()),
+            recipient_refs: vec![service_member.clone()],
+            key_ref: Some("key-ref:logging-secure:2".to_string()),
+            summary_safe_facts: json!({ "eventClass": "runtimeDiagnostic", "severity": "warning" }),
+            evidence_refs: vec!["storage:pin:log-event-1".to_string()],
+            issued_at: 1_700_000_060,
+            expires_at: None,
+        };
+        validate_private_content_envelope(&envelope).expect("valid private envelope");
+        let mut bad_envelope = envelope.clone();
+        bad_envelope.summary_safe_facts = json!({ "ciphertext": "raw-ciphertext-body" });
+        assert!(validate_private_content_envelope(&bad_envelope).is_err());
+
+        let event_class = EventFabricAccessClassRecord {
+            kind: Some(RECORD_EVENT_FABRIC_ACCESS_CLASS.to_string()),
+            class_id: "event-class:security-runtime".to_string(),
+            content_class: "encryptedDetail".to_string(),
+            privacy_tier: "domainEncrypted".to_string(),
+            event_classes: vec!["runtimeDiagnostic".to_string(), "securityAudit".to_string()],
+            access_group_refs: vec![group.group_id.clone()],
+            processor_role_refs: vec!["role:logging".to_string(), "role:security".to_string()],
+            storage_class: "storage:rolling-secure".to_string(),
+            retention_class: "rolling".to_string(),
+            safe_fact_policy: "indexOnly".to_string(),
+            index_policy: json!({ "cardinality": "bounded", "safeKeys": ["eventClass", "severity"] }),
+            safe_facts: Value::Null,
+            issued_at: 1_700_000_070,
+        };
+        validate_event_fabric_access_class(&event_class).expect("valid event access class");
+        let mut bad_event_class = event_class.clone();
+        bad_event_class.privacy_tier = "publicSafe".to_string();
+        assert!(validate_event_fabric_access_class(&bad_event_class).is_err());
+
+        let revocation = AuthorityGrantRevocationPostureRecord {
+            kind: Some(RECORD_AUTHORITY_GRANT_REVOCATION_POSTURE.to_string()),
+            revocation_id: "revocation:logging:writer".to_string(),
+            target_grant_ref: grant.grant_id,
+            issuer_ref,
+            authority_domain: "identity".to_string(),
+            affected_grant_refs: vec![
+                "grant:logging:writer".to_string(),
+                "grant:logging:writer:delegated".to_string(),
+            ],
+            affected_access_group_refs: vec![group.group_id],
+            inherited_scope_refs: vec!["contract:logging.default".to_string()],
+            state: AGREEMENT_STATE_REVOKED.to_string(),
+            reason_code: "operatorRevoked".to_string(),
+            evidence_refs: vec!["sig:revocation:logging:writer".to_string()],
+            issued_at: 1_700_000_080,
+            effective_at: Some(1_700_000_081),
+        };
+        validate_authority_grant_revocation_posture(&revocation)
+            .expect("valid grant revocation posture");
     }
 
     #[test]

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -81,6 +81,8 @@ import {
   assertMediaTransportPath,
   assertMediaTransportObservation,
   assertServiceManagerPosture,
+  assertServiceManagerOperationPosture,
+  assertServiceManagerProofDigest,
   assertSurfaceAppBootstrapPosture,
   assertSurfaceAppContract,
   assertSurfaceModuleClaim,
@@ -734,6 +736,118 @@ test("surface bootstrap contracts gate service manager release and secret postur
     },
     issuedAt,
   }), /forbidden protocol field/);
+});
+
+test("service manager operations and proof digests validate release train evidence", () => {
+  const requestedAt = 1700000000;
+  const operation = assertServiceManagerOperationPosture({
+    kind: SWARM.RECORD_KIND.SERVICE_MANAGER_OPERATION_POSTURE,
+    operationId: "operation:gateway:promote:2026-05-17",
+    managerId: "manager:lab-gateway",
+    subjectRef: "service:gateway",
+    managerRef: "member:gateway-manager",
+    requesterRef: "identity:operator",
+    operation: SURFACE_APP.SERVICE_MANAGER_OPERATION.PROMOTE,
+    state: SURFACE_APP.SERVICE_MANAGER_OPERATION_STATE.SUCCEEDED,
+    serviceRefs: ["service:gateway"],
+    capabilityRefs: ["service.manage"],
+    authorityRefs: ["identity:operator"],
+    releaseRef: "release:gateway:2026-05-17",
+    evidenceRefs: ["ci:gateway:linux", "ci:gateway:windows"],
+    proofRefs: ["proof:gateway:smoke"],
+    safeFacts: {
+      ci: "passed",
+      architecture: "surface-bootstrap",
+    },
+    requestedAt,
+    acceptedAt: requestedAt + 10,
+    startedAt: requestedAt + 20,
+    completedAt: requestedAt + 60,
+    expiresAt: requestedAt + 3600,
+  });
+  assert.equal(operation.operation, SURFACE_APP.SERVICE_MANAGER_OPERATION.PROMOTE);
+
+  const digest = assertServiceManagerProofDigest({
+    kind: SWARM.RECORD_KIND.SERVICE_MANAGER_PROOF_DIGEST,
+    digestId: "proof-digest:gateway:2026-05-17",
+    operationId: operation.operationId,
+    managerId: operation.managerId,
+    subjectRef: operation.subjectRef,
+    state: SURFACE_APP.SERVICE_MANAGER_PROOF_STATE.PROVED,
+    trainRef: "train:runtime-product:2026-05-17",
+    releaseRef: "release:gateway:2026-05-17",
+    commitRefs: ["git:gateway:4c9a49c"],
+    artifactRefs: ["artifact:gateway:ci"],
+    proofRefs: ["proof:gateway:linux", "proof:gateway:windows"],
+    metricsRefs: ["metrics:spine:service-manager"],
+    environmentRefs: ["env:github-actions"],
+    serviceRefs: ["service:gateway"],
+    safeFacts: {
+      linux: "passed",
+      windows: "passed",
+    },
+    observedAt: requestedAt + 80,
+    expiresAt: requestedAt + 7200,
+  });
+  assert.equal(digest.state, SURFACE_APP.SERVICE_MANAGER_PROOF_STATE.PROVED);
+
+  const serviceManager = assertServiceManagerPosture({
+    kind: SWARM.RECORD_KIND.SERVICE_MANAGER_POSTURE,
+    managerId: "manager:lab-gateway",
+    subjectRef: "service:gateway",
+    managerRef: "member:gateway-manager",
+    state: SURFACE_APP.SERVICE_MANAGER_POSTURE.READY,
+    serviceRefs: ["service:gateway"],
+    operationRefs: [operation.operationId],
+    proofDigestRefs: [digest.digestId],
+    issuedAt: requestedAt,
+  });
+  assert.deepEqual(serviceManager.operationRefs, [operation.operationId]);
+
+  assert.throws(() => assertServiceManagerOperationPosture({
+    kind: SWARM.RECORD_KIND.SERVICE_MANAGER_OPERATION_POSTURE,
+    operationId: "operation:bad",
+    managerId: "manager:lab-gateway",
+    subjectRef: "service:gateway",
+    managerRef: "member:gateway-manager",
+    requesterRef: "identity:operator",
+    operation: SURFACE_APP.SERVICE_MANAGER_OPERATION.ROLLBACK,
+    state: SURFACE_APP.SERVICE_MANAGER_OPERATION_STATE.REQUESTED,
+    requestedAt,
+  }), /rollback operation requires rollbackRef/);
+  assert.throws(() => assertServiceManagerOperationPosture({
+    kind: SWARM.RECORD_KIND.SERVICE_MANAGER_OPERATION_POSTURE,
+    operationId: "operation:blocked",
+    managerId: "manager:lab-gateway",
+    subjectRef: "service:gateway",
+    managerRef: "member:gateway-manager",
+    requesterRef: "identity:operator",
+    operation: SURFACE_APP.SERVICE_MANAGER_OPERATION.UPDATE,
+    state: SURFACE_APP.SERVICE_MANAGER_OPERATION_STATE.BLOCKED,
+    requestedAt,
+  }), /blocked or failed operation requires blockedReasons/);
+  assert.throws(() => assertServiceManagerProofDigest({
+    kind: SWARM.RECORD_KIND.SERVICE_MANAGER_PROOF_DIGEST,
+    digestId: "proof-digest:empty",
+    operationId: operation.operationId,
+    managerId: operation.managerId,
+    subjectRef: operation.subjectRef,
+    state: SURFACE_APP.SERVICE_MANAGER_PROOF_STATE.PROVED,
+    observedAt: requestedAt + 80,
+  }), /proved proof digest requires artifactRefs or proofRefs/);
+  assert.throws(() => assertServiceManagerProofDigest({
+    kind: SWARM.RECORD_KIND.SERVICE_MANAGER_PROOF_DIGEST,
+    digestId: "proof-digest:leaky",
+    operationId: operation.operationId,
+    managerId: operation.managerId,
+    subjectRef: operation.subjectRef,
+    state: SURFACE_APP.SERVICE_MANAGER_PROOF_STATE.BLOCKED,
+    blockedReasons: ["secret-boundary"],
+    safeFacts: {
+      token: "inline-secret",
+    },
+    observedAt: requestedAt + 80,
+  }), /unsafe safe fact key|forbidden protocol field/);
 });
 
 test("storage manifest helpers validate ciphertext-addressed objects", () => {

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   BROKER,
   DIAGNOSTICS,
+  AGREEMENT,
   LOGGING,
   PROJECTION,
   ReplayCache,
@@ -86,8 +87,16 @@ import {
   assertSurfaceAppBootstrapPosture,
   assertSurfaceAppContract,
   assertSurfaceModuleClaim,
+  assertAccessEpoch,
+  assertAccessGroup,
+  assertActionAuthorityExercise,
+  assertActionAuthorityGrant,
+  assertAuthorityGrantRevocationPosture,
+  assertAuthorityRootOperation,
   assertConsumerFloor,
   assertContributionLifecycle,
+  assertEventFabricAccessClass,
+  assertPrivateContentEnvelope,
   assertSwarmActivation,
   assertSwarmDevice,
   assertSwarmEdgeAccept,
@@ -1799,6 +1808,177 @@ test("swarm authority records validate identity, grant, interaction, and recover
   const liveGraph = structuredClone(vector.identityGraph);
   liveGraph.push(vector.activation);
   assert.throws(() => assertSwarmIdentityGraph(liveGraph), /live lease or activation state/);
+});
+
+test("agreement grammar separates action authority, access epochs, private readability, and materialization", () => {
+  const identityRef = `identity:${pubkeyFromSecretKey(ISSUER_SK)}`;
+  const grant = {
+    kind: "authority.action.grant",
+    grantId: "grant:logging:writer",
+    issuerRef: identityRef,
+    subjectRef: `member:${BROWSER_PK}`,
+    audienceRefs: [`service:${SERVICE_PK}`],
+    authorityDomain: SWARM.AUTHORITY_DOMAIN.IDENTITY,
+    resourceRef: "contract:logging.default",
+    action: "logging.event.write",
+    state: AGREEMENT.ACTION_GRANT_STATE.ACCEPTED,
+    scope: { contractRef: "contract:logging.default", retentionClass: "rolling" },
+    capabilityRefs: ["logging.events.observe"],
+    delegation: { allowed: true, maxDepth: 1, inheritedFrom: ["grant:root:logging"] },
+    evidenceRefs: ["sig:grant:logging:writer"],
+    issuedAt: 1700000010,
+    expiresAt: 1700000610,
+  };
+
+  assert.equal(assertActionAuthorityGrant(grant).plane, AGREEMENT.PLANE.ACTION_AUTHORITY);
+  assert.throws(() => assertActionAuthorityGrant({ ...grant, plane: AGREEMENT.PLANE.ACCESS_AUTHORITY }), /plane/);
+  assert.throws(() => assertActionAuthorityGrant({ ...grant, state: AGREEMENT.ACTION_GRANT_STATE.BLOCKED, blockedReason: "" }), /blockedReason/);
+
+  assert.equal(assertActionAuthorityExercise({
+    kind: "authority.action.exercise",
+    exerciseId: "exercise:logging:writer:1",
+    grantId: grant.grantId,
+    actorRef: `member:${BROWSER_PK}`,
+    subjectRef: "event:runtime:1",
+    resourceRef: "contract:logging.default",
+    action: "logging.event.write",
+    state: AGREEMENT.ACTION_GRANT_STATE.APPLIED,
+    evidenceRefs: ["event:runtime:1"],
+    issuedAt: 1700000020,
+    observedAt: 1700000025,
+  }).state, AGREEMENT.ACTION_GRANT_STATE.APPLIED);
+
+  assert.equal(assertAuthorityRootOperation({
+    kind: "authority.root.operation",
+    operationId: "root-op:enroll-aux",
+    operation: AGREEMENT.ROOT_OPERATION.ENROLL_DEVICE,
+    identityRef,
+    actorRef: `root:${pubkeyFromSecretKey(ISSUER_SK)}`,
+    targetRef: `device:${BROWSER_PK}`,
+    adminGrantRefs: ["grant:root:admin"],
+    deviceRefs: [`device:${BROWSER_PK}`],
+    notificationRefs: ["notification:root-enroll"],
+    evidenceRefs: ["sig:root-op:enroll-aux"],
+    state: AGREEMENT.ACTION_GRANT_STATE.APPLIED,
+    issuedAt: 1700000030,
+  }).plane, AGREEMENT.PLANE.ACTION_AUTHORITY);
+  assert.throws(() => assertAuthorityRootOperation({
+    kind: "authority.root.operation",
+    operationId: "root-op:rotate-bad",
+    operation: AGREEMENT.ROOT_OPERATION.ROTATE_ROOT,
+    identityRef,
+    actorRef: `root:${pubkeyFromSecretKey(ISSUER_SK)}`,
+    targetRef: `root:${GATEWAY_PK}`,
+    adminGrantRefs: ["grant:root:admin"],
+    state: AGREEMENT.ACTION_GRANT_STATE.APPLIED,
+    issuedAt: 1700000031,
+  }), /rootRefs/);
+
+  const group = assertAccessGroup({
+    kind: "access.group",
+    groupId: "access-group:logging-secure",
+    ownerRef: identityRef,
+    subjectRef: "contract:logging.default",
+    contentClasses: [AGREEMENT.CONTENT_CLASS.ENCRYPTED_DETAIL, AGREEMENT.CONTENT_CLASS.DIAGNOSTIC_DETAIL],
+    memberRefs: [`member:${SERVICE_PK}`, `member:${BROWSER_PK}`],
+    adminRefs: [`root:${pubkeyFromSecretKey(ISSUER_SK)}`],
+    currentEpochId: "access-epoch:logging-secure:2",
+    partitionRefs: ["partition:identity:logging"],
+    issuedAt: 1700000040,
+  });
+  assert.equal(group.plane, AGREEMENT.PLANE.ACCESS_AUTHORITY);
+
+  assert.equal(assertAccessEpoch({
+    kind: "access.epoch",
+    epochId: "access-epoch:logging-secure:2",
+    groupId: group.groupId,
+    sequence: 2,
+    previousEpochId: "access-epoch:logging-secure:1",
+    changeKind: AGREEMENT.ACCESS_EPOCH_CHANGE.REMOVE_MEMBER,
+    memberRefs: [`member:${SERVICE_PK}`],
+    removedMemberRefs: [`member:${BROWSER_PK}`],
+    keyRef: "key-ref:logging-secure:2",
+    proofRefs: ["sig:epoch:2"],
+    issuedAt: 1700000050,
+  }).changeKind, AGREEMENT.ACCESS_EPOCH_CHANGE.REMOVE_MEMBER);
+  assert.throws(() => assertAccessEpoch({
+    kind: "access.epoch",
+    epochId: "access-epoch:logging-secure:bad",
+    groupId: group.groupId,
+    sequence: 2,
+    changeKind: AGREEMENT.ACCESS_EPOCH_CHANGE.REMOVE_MEMBER,
+    memberRefs: [`member:${SERVICE_PK}`],
+    removedMemberRefs: [`member:${BROWSER_PK}`],
+    keyRef: "key-ref:logging-secure:bad",
+    proofRefs: ["sig:epoch:bad"],
+    issuedAt: 1700000051,
+  }), /previousEpochId/);
+
+  const envelope = assertPrivateContentEnvelope({
+    kind: "private.content.envelope",
+    envelopeId: "private-envelope:logging-event-1",
+    contentClass: AGREEMENT.CONTENT_CLASS.ENCRYPTED_DETAIL,
+    accessGroupRef: group.groupId,
+    epochId: "access-epoch:logging-secure:2",
+    subjectRef: "event:runtime:1",
+    issuerRef: `member:${SERVICE_PK}`,
+    storageObjectRef: "storage-object:log-event-1",
+    caacEnvelopeRef: "caac:log-event-1",
+    recipientRefs: [`member:${SERVICE_PK}`],
+    keyRef: "key-ref:logging-secure:2",
+    summarySafeFacts: { eventClass: "runtimeDiagnostic", severity: "warning" },
+    evidenceRefs: ["storage:pin:log-event-1"],
+    issuedAt: 1700000060,
+  });
+  assert.equal(envelope.contentClass, AGREEMENT.CONTENT_CLASS.ENCRYPTED_DETAIL);
+  assert.throws(() => assertPrivateContentEnvelope({
+    ...envelope,
+    envelopeId: "private-envelope:bad",
+    ciphertext: "raw-ciphertext-body",
+  }), /forbidden protocol field/);
+
+  assert.equal(assertEventFabricAccessClass({
+    kind: "event.fabric.accessClass",
+    classId: "event-class:security-runtime",
+    contentClass: AGREEMENT.CONTENT_CLASS.ENCRYPTED_DETAIL,
+    privacyTier: AGREEMENT.PRIVACY_TIER.DOMAIN_ENCRYPTED,
+    eventClasses: ["runtimeDiagnostic", "securityAudit"],
+    accessGroupRefs: [group.groupId],
+    processorRoleRefs: ["role:logging", "role:security"],
+    storageClass: "storage:rolling-secure",
+    retentionClass: "rolling",
+    safeFactPolicy: AGREEMENT.SAFE_FACT_POLICY.INDEX_ONLY,
+    indexPolicy: { cardinality: "bounded", safeKeys: ["eventClass", "severity"] },
+    issuedAt: 1700000070,
+  }).plane, AGREEMENT.PLANE.MATERIALIZATION);
+  assert.throws(() => assertEventFabricAccessClass({
+    kind: "event.fabric.accessClass",
+    classId: "event-class:bad-public",
+    contentClass: AGREEMENT.CONTENT_CLASS.ENCRYPTED_RAW,
+    privacyTier: AGREEMENT.PRIVACY_TIER.PUBLIC_SAFE,
+    eventClasses: ["securityAudit"],
+    accessGroupRefs: [group.groupId],
+    storageClass: "storage:raw",
+    retentionClass: "short",
+    safeFactPolicy: AGREEMENT.SAFE_FACT_POLICY.NONE,
+    issuedAt: 1700000071,
+  }), /publicSafe/);
+
+  assert.equal(assertAuthorityGrantRevocationPosture({
+    kind: "authority.grant.revocationPosture",
+    revocationId: "revocation:logging:writer",
+    targetGrantRef: grant.grantId,
+    issuerRef: identityRef,
+    authorityDomain: SWARM.AUTHORITY_DOMAIN.IDENTITY,
+    affectedGrantRefs: [grant.grantId, "grant:logging:writer:delegated"],
+    affectedAccessGroupRefs: [group.groupId],
+    inheritedScopeRefs: ["contract:logging.default"],
+    state: AGREEMENT.ACTION_GRANT_STATE.REVOKED,
+    reasonCode: "operatorRevoked",
+    evidenceRefs: ["sig:revocation:logging:writer"],
+    issuedAt: 1700000080,
+    effectiveAt: 1700000081,
+  }).plane, AGREEMENT.PLANE.ACTION_AUTHORITY);
 });
 
 test("swarm frame IDs canonicalize absent CAAC body fields like Rust validators", () => {


### PR DESCRIPTION
## Summary
- Add protocol validation for service-manager operations and proof digest posture.
- Add shared agreement authority/access grammar for root operations, action grants, access groups, access epochs, private content envelopes, revocation posture, and event-fabric access classes.

## Checks
- Protocol JS tests passed locally.
- Protocol Rust tests passed locally.
- Root check:all passed locally.