### PR TITLE
Add swarm app and authority contract grammar

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1792,6 +1792,17 @@ export type RunnerOperationState =
   | "cancelled"
   | "released"
   | "superseded";
+export type AppRunnerFulfillmentState =
+  | "requested"
+  | "accepted"
+  | "running"
+  | "succeeded"
+  | "released"
+  | "rolledBack"
+  | "blocked"
+  | "failed"
+  | "rejected"
+  | "cancelled";
 
 export type SurfaceModuleClaim = {
   moduleRef: string;
@@ -2351,6 +2362,46 @@ export type RunnerOperationRecord = {
   expiresAt?: number;
 };
 
+export type AppRunnerFulfillmentReport = {
+  kind?: "app.runner.fulfillment.report";
+  reportId: string;
+  runnerId: string;
+  runnerRef: string;
+  hostRef: string;
+  runnerOperationId: string;
+  operation: RunnerOperation;
+  state: AppRunnerFulfillmentState;
+  requesterRef: string;
+  subjectRef: string;
+  contractRef: string;
+  appContractRef?: string;
+  appId?: string;
+  version?: string;
+  manifestRef?: string;
+  sourceMode: SurfaceModuleFulfillmentMode;
+  sourceRefs?: string[];
+  grantRefs: string[];
+  capabilityRefs?: string[];
+  inputRefs?: string[];
+  outputRefs?: string[];
+  evidenceRefs?: string[];
+  proofRefs?: string[];
+  releaseRefs?: string[];
+  resourceBudget: Record<string, unknown>;
+  resourcePosture?: ResourcePosture | null;
+  secretBoundary?: SurfaceSecretBoundary;
+  releasePosture?: SurfaceReleasePosture | null;
+  rollbackPosture?: SurfaceReleasePosture | null;
+  releaseRef?: string;
+  rollbackRef?: string;
+  operationPosture: Record<string, unknown>;
+  fulfillmentPosture: Record<string, unknown>;
+  safeFacts?: Record<string, unknown>;
+  blockedReasons?: string[];
+  observedAt: number;
+  expiresAt?: number;
+};
+
 export function bytesToHex(bytes: Uint8Array): string;
 export function hexToBytes(hex: string): Uint8Array;
 export function utf8ToBytes(value: string): Uint8Array;
@@ -2555,3 +2606,4 @@ export function assertSurfaceAppBootstrapPosture(record: unknown): SurfaceAppBoo
 export function assertAppRecipe(record: unknown): AppRecipe;
 export function assertAppRunnerAdvertisement(record: unknown): AppRunnerAdvertisement;
 export function assertRunnerOperation(record: unknown): RunnerOperationRecord;
+export function assertAppRunnerFulfillmentReport(record: unknown): AppRunnerFulfillmentReport;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1834,6 +1834,12 @@ export type SurfaceAppContract = {
   serviceRef?: string;
   serviceRouteRefs?: string[];
   hostRefs?: string[];
+  rootRefs?: string[];
+  deviceRefs?: string[];
+  grantRefs?: string[];
+  accessGroupRefs?: string[];
+  requiredContentClasses?: AgreementContentClass[];
+  revocationRefs?: string[];
   appRef?: string;
   surfaceRef?: string;
   requiredPrimitives?: string[];
@@ -2203,6 +2209,34 @@ export type SurfaceAppFulfillmentIdentityPosture = {
   expiresAt?: number;
 };
 
+export type SurfaceAppAuthorityAccessPosture = {
+  kind?: "surface.app.authority.access.posture";
+  postureId: string;
+  state: SurfaceAppReadinessState;
+  appContractRef: string;
+  appId: string;
+  actionRequired?: boolean;
+  accessRequired?: boolean;
+  rootRefs?: string[];
+  deviceRefs?: string[];
+  grantRefs?: string[];
+  authorityRefs?: string[];
+  accessGroupRefs?: string[];
+  requiredContentClasses?: AgreementContentClass[];
+  revocationRefs?: string[];
+  exerciseRefs?: string[];
+  evidenceRefs?: string[];
+  actionPosture?: Record<string, unknown>;
+  accessPosture?: Record<string, unknown>;
+  revocationPosture?: Record<string, unknown>;
+  expiryPosture?: Record<string, unknown>;
+  revocationState?: string;
+  safeFacts?: Record<string, unknown>;
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
 export type SurfaceModuleRolePosture = {
   kind?: "surface.module.role.posture";
   state: "ready" | "blocked";
@@ -2300,6 +2334,7 @@ export type SurfaceAppRuntimeSelectionPosture = {
   runnerReadiness?: Record<string, unknown>;
   serviceManagerReadiness?: Record<string, unknown>;
   fulfillmentIdentityPosture?: SurfaceAppFulfillmentIdentityPosture | null;
+  authorityAccessPosture?: SurfaceAppAuthorityAccessPosture | null;
   manifestSelection: SurfaceAppManifestSelection;
   manifestRunnerPlan: SurfaceAppManifestRunnerPlan;
   runnerPlan?: SurfaceAppRunnerPlan | null;
@@ -2334,6 +2369,7 @@ export type SurfaceAppInstancePosture = {
   runnerReadiness?: Record<string, unknown> | null;
   serviceManagerReadiness?: Record<string, unknown> | null;
   fulfillmentIdentityPosture?: SurfaceAppFulfillmentIdentityPosture | null;
+  authorityAccessPosture?: SurfaceAppAuthorityAccessPosture | null;
   runnerPlanRef?: string;
   bootstrapContractRef?: string;
   bootstrapPosture?: SurfaceAppBootstrapPosture | null;
@@ -2625,6 +2661,7 @@ export function assertSurfaceAppManifestRunnerPlan(record: unknown): SurfaceAppM
 export function assertSurfaceAppRuntimeSelectionPosture(record: unknown): SurfaceAppRuntimeSelectionPosture;
 export function assertSurfaceAppInstancePosture(record: unknown): SurfaceAppInstancePosture;
 export function assertSurfaceAppFulfillmentIdentityPosture(record: unknown): SurfaceAppFulfillmentIdentityPosture;
+export function assertSurfaceAppAuthorityAccessPosture(record: unknown): SurfaceAppAuthorityAccessPosture;
 export function assertSurfaceAppRunnerPlan(record: unknown): SurfaceAppRunnerPlan;
 export function assertSurfaceModuleRolePosture(record: unknown): SurfaceModuleRolePosture;
 export function assertSurfaceAppModuleBindingPosture(record: unknown): SurfaceAppModuleBindingPosture;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,6 +6,7 @@ export const DEFAULT_REQUEST_TTL_SECONDS: number;
 export const BROKER: Readonly<Record<string, string>>;
 export const SERVICE_SURFACE: Readonly<Record<string, unknown>>;
 export const SURFACE_APP: Readonly<Record<string, unknown>>;
+export const RUNNER: Readonly<Record<string, unknown>>;
 export const AGREEMENT: Readonly<Record<string, unknown>>;
 export const SERVICE_REGISTRY: Readonly<Record<string, unknown>>;
 export const STORAGE: Readonly<Record<string, string>>;
@@ -1777,6 +1778,18 @@ export type ServiceManagerProofProfile =
   | "loggingPressure"
   | "directEdge"
   | "nativeChecks";
+export type RunnerOperation = "prepare" | "execute" | "healthCheck" | "release" | "rollback" | "cancel";
+export type RunnerOperationState =
+  | "requested"
+  | "accepted"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "blocked"
+  | "rejected"
+  | "cancelled"
+  | "released"
+  | "superseded";
 
 export type SurfaceModuleClaim = {
   moduleRef: string;
@@ -2099,6 +2112,41 @@ export type AppRunnerAdvertisement = {
   health: Record<string, unknown>;
 };
 
+export type RunnerOperationRecord = {
+  kind?: "runner.operation";
+  operationId: string;
+  runnerId: string;
+  runnerRef: string;
+  hostRef: string;
+  requesterRef: string;
+  subjectRef: string;
+  contractRef: string;
+  operation: RunnerOperation;
+  state: RunnerOperationState;
+  grantRefs: string[];
+  capabilityRefs?: string[];
+  inputRefs?: string[];
+  outputRefs?: string[];
+  evidenceRefs?: string[];
+  proofRefs?: string[];
+  releaseRefs?: string[];
+  resourceBudget: Record<string, unknown>;
+  resourcePosture?: ResourcePosture;
+  secretBoundary?: SurfaceSecretBoundary;
+  releasePosture?: SurfaceReleasePosture;
+  rollbackPosture?: SurfaceReleasePosture;
+  releaseRef?: string;
+  rollbackRef?: string;
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+  requestedAt: number;
+  acceptedAt?: number;
+  startedAt?: number;
+  completedAt?: number;
+  observedAt?: number;
+  expiresAt?: number;
+};
+
 export function bytesToHex(bytes: Uint8Array): string;
 export function hexToBytes(hex: string): Uint8Array;
 export function utf8ToBytes(value: string): Uint8Array;
@@ -2293,3 +2341,4 @@ export function assertSurfaceAppBootstrapContract(record: unknown): SurfaceAppBo
 export function assertSurfaceAppBootstrapPosture(record: unknown): SurfaceAppBootstrapPosture;
 export function assertAppRecipe(record: unknown): AppRecipe;
 export function assertAppRunnerAdvertisement(record: unknown): AppRunnerAdvertisement;
+export function assertRunnerOperation(record: unknown): RunnerOperationRecord;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2159,6 +2159,147 @@ export type SurfaceAppBootstrapPosture = {
   expiresAt?: number;
 };
 
+export type SurfaceAppReadinessState = "ready" | "degraded" | "blocked" | "unknown" | "unchecked";
+
+export type SurfaceModuleRolePosture = {
+  kind?: "surface.module.role.posture";
+  state: "ready" | "blocked";
+  blockedReason?: string;
+  role: SurfaceModuleRole;
+  moduleRef?: string;
+  primitiveRef?: string;
+  moduleCount: number;
+  modules?: SurfaceModuleClaim[];
+};
+
+export type SurfaceAppModuleBindingPosture = {
+  kind?: "surface.app.module.binding.posture";
+  state: "ready" | "blocked";
+  roles?: string[];
+  keys?: string[];
+  moduleRefs?: string[];
+  implementationRefs?: string[];
+  blockedReasons?: string[];
+};
+
+export type SurfaceAppManifestSelection = {
+  kind?: "surface.app.manifest.selection";
+  manifestId: string;
+  appId: string;
+  state: "ready" | "blocked";
+  appContractRef: string;
+  version: string;
+  sourceMode: SurfaceModuleFulfillmentMode;
+  claimState?: string;
+  requiredModuleRoles?: SurfaceModuleRole[];
+  bundledSourceRefs?: string[];
+  remoteSourceRefs?: string[];
+  grantRefs?: string[];
+  runnerRequirementRefs?: string[];
+  serviceManagerRequirementRefs?: string[];
+  compatibilityWindow?: SurfaceAppCompatibilityWindow;
+  compatibilityRefs?: string[];
+  bootstrapContractRef?: string;
+  releaseContractRef?: string;
+  bundledContractAvailable?: boolean;
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  claim?: SurfaceAppManifestVersion | null;
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type SurfaceAppRunnerPlan = {
+  kind?: "surface.app.runner.plan";
+  planId: string;
+  contractId: string;
+  appId: string;
+  state: "ready" | "blocked";
+  sourceMode: SurfaceModuleFulfillmentMode;
+  attachContext?: Record<string, unknown>;
+  modulePostures?: SurfaceModuleRolePosture[];
+  secretBoundary?: SurfaceSecretBoundary;
+  releaseContract?: ServiceManagerReleaseContract | null;
+  bootstrapContract?: SurfaceAppBootstrapContract;
+  labProof?: ServiceManagerLabProof | null;
+  proofDigest?: ServiceManagerProofDigest | null;
+  trainDigest?: ServiceManagerTrainDigest | null;
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type SurfaceAppManifestRunnerPlan = {
+  kind?: "surface.app.manifest.runner.plan";
+  planId: string;
+  state: "ready" | "blocked";
+  manifestSelection: SurfaceAppManifestSelection;
+  runnerPlan: SurfaceAppRunnerPlan | null;
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type SurfaceAppRuntimeSelectionPosture = {
+  kind?: "surface.app.runtime.selection.posture";
+  selectionId: string;
+  state: "ready" | "degraded" | "blocked";
+  requestedAppRef?: string;
+  requestedVersion?: string;
+  manifestId?: string;
+  appId: string;
+  pinnedAppContractRef: string;
+  pinnedVersion: string;
+  sourceMode: SurfaceModuleFulfillmentMode;
+  requiredModuleRoles?: SurfaceModuleRole[];
+  compatibilityResult?: Record<string, unknown>;
+  sourceTrustResult?: Record<string, unknown>;
+  modulePostures?: SurfaceModuleRolePosture[];
+  runnerReadiness?: Record<string, unknown>;
+  serviceManagerReadiness?: Record<string, unknown>;
+  manifestSelection: SurfaceAppManifestSelection;
+  manifestRunnerPlan: SurfaceAppManifestRunnerPlan;
+  runnerPlan?: SurfaceAppRunnerPlan | null;
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type SurfaceAppInstancePosture = {
+  kind?: "surface.app.instance.posture";
+  instanceId: string;
+  state: "ready" | "degraded" | "blocked";
+  contractId: string;
+  appId: string;
+  appRef?: string;
+  serviceRef?: string;
+  surfaceRef?: string;
+  displayName?: string;
+  version: string;
+  manifestId?: string;
+  pinnedAppContractRef?: string;
+  pinnedVersion?: string;
+  sourceMode?: SurfaceModuleFulfillmentMode;
+  sourceTrustResult?: Record<string, unknown> | null;
+  compatibilityResult?: Record<string, unknown> | null;
+  requiredModuleRoles?: SurfaceModuleRole[];
+  moduleRefs?: string[];
+  modulePostures?: SurfaceModuleRolePosture[];
+  moduleBindingPosture?: SurfaceAppModuleBindingPosture | null;
+  materializationBudgetRefs?: string[];
+  runtimeSelectionPosture?: SurfaceAppRuntimeSelectionPosture | null;
+  runnerReadiness?: Record<string, unknown> | null;
+  serviceManagerReadiness?: Record<string, unknown> | null;
+  runnerPlanRef?: string;
+  bootstrapContractRef?: string;
+  bootstrapPosture?: SurfaceAppBootstrapPosture | null;
+  serviceManagerOperationRef?: string;
+  serviceManagerProofRef?: string;
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
 export type AppRecipe = {
   recipeId: string;
   name: string;
@@ -2395,6 +2536,13 @@ export function assertSurfaceAppContract(record: unknown): SurfaceAppContract;
 export function assertSurfaceAppManifest(record: unknown): SurfaceAppManifest;
 export function assertSurfaceAppDistributionPosture(record: unknown): SurfaceAppDistributionPosture;
 export function assertSurfaceAppSchemaPosture(record: unknown): SurfaceAppSchemaPosture;
+export function assertSurfaceAppManifestSelection(record: unknown): SurfaceAppManifestSelection;
+export function assertSurfaceAppManifestRunnerPlan(record: unknown): SurfaceAppManifestRunnerPlan;
+export function assertSurfaceAppRuntimeSelectionPosture(record: unknown): SurfaceAppRuntimeSelectionPosture;
+export function assertSurfaceAppInstancePosture(record: unknown): SurfaceAppInstancePosture;
+export function assertSurfaceAppRunnerPlan(record: unknown): SurfaceAppRunnerPlan;
+export function assertSurfaceModuleRolePosture(record: unknown): SurfaceModuleRolePosture;
+export function assertSurfaceAppModuleBindingPosture(record: unknown): SurfaceAppModuleBindingPosture;
 export function assertServiceManagerPosture(record: unknown): ServiceManagerPosture;
 export function assertServiceManagerSecretBoundary(record: unknown): ServiceManagerSecretBoundary;
 export function assertServiceManagerReleaseContract(record: unknown): ServiceManagerReleaseContract;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1976,6 +1976,13 @@ export type SurfaceAppManifestVersion = {
   version: string;
   state: SurfaceAppManifestVersionState;
   sourceMode?: SurfaceModuleFulfillmentMode;
+  requiredModuleRoles?: SurfaceModuleRole[];
+  compatibilityWindow?: SurfaceAppCompatibilityWindow;
+  bundledSourceRefs?: string[];
+  remoteSourceRefs?: string[];
+  grantRefs?: string[];
+  runnerRequirementRefs?: string[];
+  serviceManagerRequirementRefs?: string[];
   moduleRefs?: string[];
   compatibilityRefs?: string[];
   bootstrapContractRef?: string;
@@ -1983,6 +1990,14 @@ export type SurfaceAppManifestVersion = {
   authorityRefs?: string[];
   evidenceRefs?: string[];
   blockedReasons?: string[];
+};
+
+export type SurfaceAppCompatibilityWindow = {
+  minVersion?: string;
+  maxVersion?: string;
+  protocolRef?: string;
+  compatibilityRefs?: string[];
+  schemaRefs?: string[];
 };
 
 export type SurfaceAppManifest = {
@@ -1995,6 +2010,13 @@ export type SurfaceAppManifest = {
   defaultSourceMode?: SurfaceModuleFulfillmentMode;
   versions: SurfaceAppManifestVersion[];
   appContractRefs?: string[];
+  requiredModuleRoles?: SurfaceModuleRole[];
+  compatibilityWindow?: SurfaceAppCompatibilityWindow;
+  bundledSourceRefs?: string[];
+  remoteSourceRefs?: string[];
+  grantRefs?: string[];
+  runnerRequirementRefs?: string[];
+  serviceManagerRequirementRefs?: string[];
   compatibilityRefs?: string[];
   bootstrapContractRefs?: string[];
   releaseContractRefs?: string[];

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1747,6 +1747,8 @@ export type SurfaceModuleParticipantSide = "window" | "runtime" | "service" | "o
 export type SurfaceModuleFulfillmentMode = "bundled" | "swarmPackage" | "storageObject" | "nativeInstalled" | "devOverlay";
 export type SurfaceAppUpdatePostureState = "static" | "compatible" | "updateAvailable" | "blocked";
 export type SurfaceAppManifestVersionState = "current" | "compatible" | "updateAvailable" | "blocked" | "superseded";
+export type SurfaceAppDistributionPostureState = "pending" | "retained" | "degraded" | "blocked" | "superseded" | "ignored";
+export type SurfaceAppSchemaPostureState = "compatible" | "migrationRequired" | "ignore" | "blocked";
 export type SurfaceAppBootstrapPostureState = "static" | "ready" | "degraded" | "blocked" | "unavailable";
 export type ServiceManagerPostureState = "manual" | "ready" | "degraded" | "blocked" | "unavailable";
 export type ServiceManagerOperation =
@@ -1854,6 +1856,35 @@ export type SurfaceReleasePosture = {
   rollbackRef?: string;
   evidenceRefs?: string[];
   blockedReasons?: string[];
+  [key: string]: unknown;
+};
+
+export type SurfaceAppSchemaPosture = {
+  state: SurfaceAppSchemaPostureState;
+  schemaRefs?: string[];
+  migrationRefs?: string[];
+  compatibilityRefs?: string[];
+  ignoredRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type SurfaceAppDistributionPosture = {
+  state: SurfaceAppDistributionPostureState;
+  sourceMode?: SurfaceModuleFulfillmentMode;
+  sourceRefs?: string[];
+  storageRefs?: string[];
+  pinIntentRefs?: string[];
+  pinProjectionRefs?: string[];
+  releaseContractRefs?: string[];
+  retentionRefs?: string[];
+  retentionClass?: string;
+  schemaPosture?: SurfaceAppSchemaPosture;
+  releasePosture?: SurfaceReleasePosture;
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
   [key: string]: unknown;
 };
 
@@ -1990,6 +2021,7 @@ export type SurfaceAppManifestVersion = {
   authorityRefs?: string[];
   evidenceRefs?: string[];
   blockedReasons?: string[];
+  distributionPosture?: SurfaceAppDistributionPosture;
 };
 
 export type SurfaceAppCompatibilityWindow = {
@@ -2025,6 +2057,7 @@ export type SurfaceAppManifest = {
   blockedReasons?: string[];
   secretBoundary?: SurfaceSecretBoundary;
   releasePosture?: SurfaceReleasePosture;
+  distributionPosture?: SurfaceAppDistributionPosture;
   safeFacts?: Record<string, unknown>;
   issuedAt: number;
   expiresAt?: number;
@@ -2360,6 +2393,8 @@ export function assertMediaTransportObservation(record: unknown): MediaTransport
 export function assertSurfaceModuleClaim(record: unknown): SurfaceModuleClaim;
 export function assertSurfaceAppContract(record: unknown): SurfaceAppContract;
 export function assertSurfaceAppManifest(record: unknown): SurfaceAppManifest;
+export function assertSurfaceAppDistributionPosture(record: unknown): SurfaceAppDistributionPosture;
+export function assertSurfaceAppSchemaPosture(record: unknown): SurfaceAppSchemaPosture;
 export function assertServiceManagerPosture(record: unknown): ServiceManagerPosture;
 export function assertServiceManagerSecretBoundary(record: unknown): ServiceManagerSecretBoundary;
 export function assertServiceManagerReleaseContract(record: unknown): ServiceManagerReleaseContract;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2039,9 +2039,17 @@ export type ServiceManagerOperationPosture = {
   serviceRefs?: string[];
   capabilityRefs?: string[];
   authorityRefs?: string[];
+  grantRefs?: string[];
+  runnerOperationRef?: string;
+  runnerRef?: string;
+  hostRef?: string;
   releaseRef?: string;
   rollbackRef?: string;
   secretBoundary?: SurfaceSecretBoundary;
+  releasePosture?: SurfaceReleasePosture;
+  rollbackPosture?: SurfaceReleasePosture;
+  resourceBudget?: Record<string, unknown>;
+  resourcePosture?: ResourcePosture;
   evidenceRefs?: string[];
   proofRefs?: string[];
   blockedReasons?: string[];

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1830,7 +1830,10 @@ export type SurfaceAppContract = {
   appId: string;
   version: string;
   displayName: string;
+  serviceContractRef?: string;
   serviceRef?: string;
+  serviceRouteRefs?: string[];
+  hostRefs?: string[];
   appRef?: string;
   surfaceRef?: string;
   requiredPrimitives?: string[];
@@ -2172,6 +2175,34 @@ export type SurfaceAppBootstrapPosture = {
 
 export type SurfaceAppReadinessState = "ready" | "degraded" | "blocked" | "unknown" | "unchecked";
 
+export type SurfaceAppFulfillmentIdentityPosture = {
+  kind?: "surface.app.fulfillment.identity.posture";
+  identityId: string;
+  state: SurfaceAppReadinessState;
+  appContractRef: string;
+  appId: string;
+  version?: string;
+  surfaceRef?: string;
+  serviceRequired?: boolean;
+  serviceContractRef?: string;
+  serviceRef?: string;
+  serviceRouteRefs?: string[];
+  routeRefs?: string[];
+  hostRefs?: string[];
+  managerRefs?: string[];
+  runnerRefs?: string[];
+  memberRefs?: string[];
+  capabilityRefs?: string[];
+  grantRefs?: string[];
+  authorityRefs?: string[];
+  evidenceRefs?: string[];
+  identityPosture?: Record<string, unknown>;
+  safeFacts?: Record<string, unknown>;
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
 export type SurfaceModuleRolePosture = {
   kind?: "surface.module.role.posture";
   state: "ready" | "blocked";
@@ -2268,6 +2299,7 @@ export type SurfaceAppRuntimeSelectionPosture = {
   modulePostures?: SurfaceModuleRolePosture[];
   runnerReadiness?: Record<string, unknown>;
   serviceManagerReadiness?: Record<string, unknown>;
+  fulfillmentIdentityPosture?: SurfaceAppFulfillmentIdentityPosture | null;
   manifestSelection: SurfaceAppManifestSelection;
   manifestRunnerPlan: SurfaceAppManifestRunnerPlan;
   runnerPlan?: SurfaceAppRunnerPlan | null;
@@ -2301,6 +2333,7 @@ export type SurfaceAppInstancePosture = {
   runtimeSelectionPosture?: SurfaceAppRuntimeSelectionPosture | null;
   runnerReadiness?: Record<string, unknown> | null;
   serviceManagerReadiness?: Record<string, unknown> | null;
+  fulfillmentIdentityPosture?: SurfaceAppFulfillmentIdentityPosture | null;
   runnerPlanRef?: string;
   bootstrapContractRef?: string;
   bootstrapPosture?: SurfaceAppBootstrapPosture | null;
@@ -2591,6 +2624,7 @@ export function assertSurfaceAppManifestSelection(record: unknown): SurfaceAppMa
 export function assertSurfaceAppManifestRunnerPlan(record: unknown): SurfaceAppManifestRunnerPlan;
 export function assertSurfaceAppRuntimeSelectionPosture(record: unknown): SurfaceAppRuntimeSelectionPosture;
 export function assertSurfaceAppInstancePosture(record: unknown): SurfaceAppInstancePosture;
+export function assertSurfaceAppFulfillmentIdentityPosture(record: unknown): SurfaceAppFulfillmentIdentityPosture;
 export function assertSurfaceAppRunnerPlan(record: unknown): SurfaceAppRunnerPlan;
 export function assertSurfaceModuleRolePosture(record: unknown): SurfaceModuleRolePosture;
 export function assertSurfaceAppModuleBindingPosture(record: unknown): SurfaceAppModuleBindingPosture;

--- a/src/index.js
+++ b/src/index.js
@@ -4854,14 +4854,23 @@ export function assertServiceManagerOperationPosture(record) {
   assertOptionalReferenceList(record.serviceRefs, "service manager operation posture serviceRefs");
   assertOptionalCapabilityList(record.capabilityRefs, "service manager operation posture capabilityRefs");
   assertOptionalReferenceList(record.authorityRefs, "service manager operation posture authorityRefs");
+  assertOptionalReferenceList(record.grantRefs, "service manager operation posture grantRefs");
   assertOptionalReferenceList(record.evidenceRefs, "service manager operation posture evidenceRefs");
   assertOptionalReferenceList(record.proofRefs, "service manager operation posture proofRefs");
+  if (record.runnerOperationRef !== undefined) requireString(record.runnerOperationRef, "service manager operation posture runnerOperationRef");
+  if (record.runnerRef !== undefined) assertResolvedMemberRef(record.runnerRef, "service manager operation posture runnerRef");
+  if (record.hostRef !== undefined) requireString(record.hostRef, "service manager operation posture hostRef");
   if (record.releaseRef !== undefined) requireString(record.releaseRef, "service manager operation posture releaseRef");
   if (record.rollbackRef !== undefined) requireString(record.rollbackRef, "service manager operation posture rollbackRef");
   if (operation === SURFACE_APP.SERVICE_MANAGER_OPERATION.ROLLBACK && !String(record.rollbackRef || "").trim()) {
     throw new Error("service manager rollback operation requires rollbackRef");
   }
   if (record.secretBoundary !== undefined) assertSurfaceSecretBoundary(record.secretBoundary, "service manager operation secretBoundary");
+  if (record.releasePosture !== undefined) assertSurfaceReleasePosture(record.releasePosture, "service manager operation releasePosture");
+  if (record.rollbackPosture !== undefined) assertSurfaceReleasePosture(record.rollbackPosture, "service manager operation rollbackPosture");
+  if (record.resourceBudget !== undefined && !isObject(record.resourceBudget)) throw new Error("service manager operation posture resourceBudget must be an object");
+  if (record.resourceBudget !== undefined) assertSafeObject(record.resourceBudget, "service manager operation posture resourceBudget");
+  if (record.resourcePosture !== undefined) assertResourcePosture(record.resourcePosture);
   const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "service manager operation posture blockedReasons");
   if ([SURFACE_APP.SERVICE_MANAGER_OPERATION_STATE.BLOCKED, SURFACE_APP.SERVICE_MANAGER_OPERATION_STATE.FAILED].includes(state) && blockedReasons.length === 0) {
     throw new Error("service manager blocked or failed operation requires blockedReasons");

--- a/src/index.js
+++ b/src/index.js
@@ -68,6 +68,20 @@ export const SURFACE_APP = Object.freeze({
     BLOCKED: "blocked",
     SUPERSEDED: "superseded",
   }),
+  DISTRIBUTION_POSTURE: Object.freeze({
+    PENDING: "pending",
+    RETAINED: "retained",
+    DEGRADED: "degraded",
+    BLOCKED: "blocked",
+    SUPERSEDED: "superseded",
+    IGNORED: "ignored",
+  }),
+  SCHEMA_POSTURE: Object.freeze({
+    COMPATIBLE: "compatible",
+    MIGRATION_REQUIRED: "migrationRequired",
+    IGNORE: "ignore",
+    BLOCKED: "blocked",
+  }),
   BOOTSTRAP_POSTURE: Object.freeze({
     STATIC: "static",
     READY: "ready",
@@ -4525,6 +4539,62 @@ function assertSurfaceReleasePosture(record, name = "surface release posture") {
   return posture;
 }
 
+export function assertSurfaceAppSchemaPosture(record, name = "surface app schema posture") {
+  const posture = assertOptionalObject(record, name);
+  if (!Object.keys(posture).length) return posture;
+  const state = requireString(posture.state, `${name} state`);
+  if (!Object.values(SURFACE_APP.SCHEMA_POSTURE).includes(state)) throw new Error(`invalid ${name} state`);
+  assertOptionalReferenceList(posture.schemaRefs, `${name} schemaRefs`);
+  const migrationRefs = assertOptionalReferenceList(posture.migrationRefs, `${name} migrationRefs`);
+  assertOptionalReferenceList(posture.compatibilityRefs, `${name} compatibilityRefs`);
+  assertOptionalReferenceList(posture.ignoredRefs, `${name} ignoredRefs`);
+  const blockedReasons = assertOptionalReferenceList(posture.blockedReasons, `${name} blockedReasons`);
+  if ([SURFACE_APP.SCHEMA_POSTURE.IGNORE, SURFACE_APP.SCHEMA_POSTURE.BLOCKED].includes(state) && blockedReasons.length === 0) {
+    throw new Error(`${name} ignored or blocked state requires blockedReasons`);
+  }
+  if (state === SURFACE_APP.SCHEMA_POSTURE.MIGRATION_REQUIRED && migrationRefs.length === 0 && blockedReasons.length === 0) {
+    throw new Error(`${name} migrationRequired state requires migrationRefs or blockedReasons`);
+  }
+  if (posture.safeFacts !== undefined) assertSafeObject(posture.safeFacts, `${name} safeFacts`);
+  assertSurfaceManagerSensitiveBoundary(posture, name);
+  return posture;
+}
+
+export function assertSurfaceAppDistributionPosture(record, name = "surface app distribution posture") {
+  const posture = assertOptionalObject(record, name);
+  if (!Object.keys(posture).length) return posture;
+  const state = requireString(posture.state, `${name} state`);
+  if (!Object.values(SURFACE_APP.DISTRIBUTION_POSTURE).includes(state)) throw new Error(`invalid ${name} state`);
+  if (posture.sourceMode !== undefined && !Object.values(SURFACE_APP.FULFILLMENT_MODE).includes(posture.sourceMode)) {
+    throw new Error(`invalid ${name} sourceMode`);
+  }
+  const sourceRefs = assertOptionalReferenceList(posture.sourceRefs, `${name} sourceRefs`);
+  const storageRefs = assertOptionalReferenceList(posture.storageRefs, `${name} storageRefs`);
+  const pinIntentRefs = assertOptionalReferenceList(posture.pinIntentRefs, `${name} pinIntentRefs`);
+  const pinProjectionRefs = assertOptionalReferenceList(posture.pinProjectionRefs, `${name} pinProjectionRefs`);
+  assertOptionalReferenceList(posture.releaseContractRefs, `${name} releaseContractRefs`);
+  assertOptionalReferenceList(posture.retentionRefs, `${name} retentionRefs`);
+  assertOptionalReferenceList(posture.evidenceRefs, `${name} evidenceRefs`);
+  const blockedReasons = assertOptionalReferenceList(posture.blockedReasons, `${name} blockedReasons`);
+  if (posture.retentionClass !== undefined) requireString(posture.retentionClass, `${name} retentionClass`);
+  if (posture.schemaPosture !== undefined) assertSurfaceAppSchemaPosture(posture.schemaPosture, `${name} schemaPosture`);
+  if (posture.releasePosture !== undefined) assertSurfaceReleasePosture(posture.releasePosture, `${name} releasePosture`);
+  if (state === SURFACE_APP.DISTRIBUTION_POSTURE.RETAINED) {
+    if (sourceRefs.length === 0 && storageRefs.length === 0) {
+      throw new Error(`${name} retained state requires sourceRefs or storageRefs`);
+    }
+    if (pinIntentRefs.length === 0 && pinProjectionRefs.length === 0) {
+      throw new Error(`${name} retained state requires pinIntentRefs or pinProjectionRefs`);
+    }
+  }
+  if ([SURFACE_APP.DISTRIBUTION_POSTURE.BLOCKED, SURFACE_APP.DISTRIBUTION_POSTURE.IGNORED].includes(state) && blockedReasons.length === 0) {
+    throw new Error(`${name} blocked or ignored state requires blockedReasons`);
+  }
+  if (posture.safeFacts !== undefined) assertSafeObject(posture.safeFacts, `${name} safeFacts`);
+  assertSurfaceManagerSensitiveBoundary(posture, name);
+  return posture;
+}
+
 export function assertServiceManagerPosture(record) {
   if (!isObject(record)) throw new Error("service manager posture must be an object");
   assertRecordKind(record, SWARM.RECORD_KIND.SERVICE_MANAGER_POSTURE, "service manager posture");
@@ -4797,6 +4867,7 @@ function assertSurfaceAppManifestVersion(record, context = "surface app manifest
   assertOptionalReferenceList(record.authorityRefs, `${context} authorityRefs`);
   assertOptionalReferenceList(record.evidenceRefs, `${context} evidenceRefs`);
   const blockedReasons = assertOptionalReferenceList(record.blockedReasons, `${context} blockedReasons`);
+  if (record.distributionPosture !== undefined) assertSurfaceAppDistributionPosture(record.distributionPosture, `${context} distributionPosture`);
   if (state === SURFACE_APP.MANIFEST_VERSION_STATE.BLOCKED && blockedReasons.length === 0) {
     throw new Error(`${context} blocked state requires blockedReasons`);
   }
@@ -4862,6 +4933,7 @@ export function assertSurfaceAppManifest(record) {
   }
   if (record.secretBoundary !== undefined) assertSurfaceSecretBoundary(record.secretBoundary, "surface app manifest secretBoundary");
   if (record.releasePosture !== undefined) assertSurfaceReleasePosture(record.releasePosture, "surface app manifest releasePosture");
+  if (record.distributionPosture !== undefined) assertSurfaceAppDistributionPosture(record.distributionPosture, "surface app manifest distributionPosture");
   if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "surface app manifest safeFacts");
   assertSurfaceManagerSensitiveBoundary(record, "surface app manifest");
   if (!Number(record.issuedAt || 0)) throw new Error("surface app manifest missing issuedAt");

--- a/src/index.js
+++ b/src/index.js
@@ -1302,8 +1302,15 @@ export const SWARM = Object.freeze({
     SERVICE_MANAGER_TRAIN_DIGEST: "service.manager.train.digest",
     SERVICE_MANAGER_LAB_PROOF: "service.manager.labProof",
     SURFACE_APP_MANIFEST: "surface.app.manifest",
+    SURFACE_APP_MANIFEST_SELECTION: "surface.app.manifest.selection",
+    SURFACE_APP_MANIFEST_RUNNER_PLAN: "surface.app.manifest.runner.plan",
+    SURFACE_APP_RUNTIME_SELECTION_POSTURE: "surface.app.runtime.selection.posture",
+    SURFACE_APP_INSTANCE_POSTURE: "surface.app.instance.posture",
+    SURFACE_APP_RUNNER_PLAN: "surface.app.runner.plan",
     SURFACE_APP_BOOTSTRAP_CONTRACT: "surface.app.bootstrap.contract",
     SURFACE_APP_BOOTSTRAP_POSTURE: "surface.app.bootstrap.posture",
+    SURFACE_MODULE_ROLE_POSTURE: "surface.module.role.posture",
+    SURFACE_APP_MODULE_BINDING_POSTURE: "surface.app.module.binding.posture",
     RUNNER_OPERATION: "runner.operation",
   }),
   RECORD_KIND: Object.freeze({
@@ -1365,8 +1372,15 @@ export const SWARM = Object.freeze({
     SERVICE_MANAGER_TRAIN_DIGEST: "service.manager.train.digest",
     SERVICE_MANAGER_LAB_PROOF: "service.manager.labProof",
     SURFACE_APP_MANIFEST: "surface.app.manifest",
+    SURFACE_APP_MANIFEST_SELECTION: "surface.app.manifest.selection",
+    SURFACE_APP_MANIFEST_RUNNER_PLAN: "surface.app.manifest.runner.plan",
+    SURFACE_APP_RUNTIME_SELECTION_POSTURE: "surface.app.runtime.selection.posture",
+    SURFACE_APP_INSTANCE_POSTURE: "surface.app.instance.posture",
+    SURFACE_APP_RUNNER_PLAN: "surface.app.runner.plan",
     SURFACE_APP_BOOTSTRAP_CONTRACT: "surface.app.bootstrap.contract",
     SURFACE_APP_BOOTSTRAP_POSTURE: "surface.app.bootstrap.posture",
+    SURFACE_MODULE_ROLE_POSTURE: "surface.module.role.posture",
+    SURFACE_APP_MODULE_BINDING_POSTURE: "surface.app.module.binding.posture",
     RUNNER_OPERATION: "runner.operation",
   }),
   AUTHORITY_DOMAIN: Object.freeze({
@@ -5083,6 +5097,205 @@ export function assertSurfaceAppContract(record) {
   if (record.bootstrapPosture !== undefined) assertSurfaceAppBootstrapPosture(record.bootstrapPosture);
   if (!Number(record.issuedAt || 0)) throw new Error("surface app contract missing issuedAt");
   if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) throw new Error("surface app contract expires before issuedAt");
+  return record;
+}
+
+function assertSurfaceAppRecordState(record, context, states = ["ready", "degraded", "blocked"]) {
+  const state = requireString(record.state, `${context} state`);
+  if (!states.includes(state)) throw new Error(`invalid ${context} state`);
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, `${context} blockedReasons`);
+  if (state === "blocked" && blockedReasons.length === 0) throw new Error(`${context} blocked state requires blockedReasons`);
+  return state;
+}
+
+function assertNoEnumerableImplementationFields(record, context) {
+  for (const field of ["surfaceApp", "contract", "implementation", "implementationRecord"]) {
+    if (Object.prototype.propertyIsEnumerable.call(record, field)) {
+      throw new Error(`${context} must not expose enumerable ${field}`);
+    }
+  }
+}
+
+function assertSurfaceAppReadiness(record, context) {
+  if (!isObject(record)) throw new Error(`${context} must be an object`);
+  requireString(record.kind, `${context} kind`);
+  assertSurfaceAppRecordState(record, context, ["ready", "degraded", "blocked", "unknown", "unchecked"]);
+  assertOptionalReferenceList(record.blockedReasons, `${context} blockedReasons`);
+  assertNoEnumerableImplementationFields(record, context);
+  return record;
+}
+
+export function assertSurfaceModuleRolePosture(record) {
+  if (!isObject(record)) throw new Error("surface module role posture must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.SURFACE_MODULE_ROLE_POSTURE, "surface module role posture");
+  const state = assertSurfaceAppRecordState(record, "surface module role posture", ["ready", "blocked"]);
+  const role = requireString(record.role, "surface module role posture role");
+  if (!Object.values(SURFACE_APP.MODULE_ROLE).includes(role)) throw new Error("invalid surface module role posture role");
+  if (String(record.blockedReason || "").trim()) requireString(record.blockedReason, "surface module role posture blockedReason");
+  if (state === "blocked" && !String(record.blockedReason || "").trim()) {
+    throw new Error("surface module blocked posture requires blockedReason");
+  }
+  if (String(record.moduleRef || "").trim()) requireString(record.moduleRef, "surface module role posture moduleRef");
+  if (String(record.primitiveRef || "").trim()) requireString(record.primitiveRef, "surface module role posture primitiveRef");
+  const moduleCount = Number(record.moduleCount ?? 0);
+  if (!Number.isFinite(moduleCount) || moduleCount < 0) throw new Error("surface module role posture moduleCount must be non-negative");
+  requireArray(record.modules || [], "surface module role posture modules").forEach(assertSurfaceModuleClaim);
+  assertNoEnumerableImplementationFields(record, "surface module role posture");
+  return record;
+}
+
+export function assertSurfaceAppModuleBindingPosture(record) {
+  if (!isObject(record)) throw new Error("surface app module binding posture must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.SURFACE_APP_MODULE_BINDING_POSTURE, "surface app module binding posture");
+  assertSurfaceAppRecordState(record, "surface app module binding posture", ["ready", "blocked"]);
+  assertOptionalReferenceList(record.roles, "surface app module binding posture roles");
+  assertOptionalReferenceList(record.keys, "surface app module binding posture keys");
+  assertOptionalReferenceList(record.moduleRefs, "surface app module binding posture moduleRefs");
+  assertOptionalReferenceList(record.implementationRefs, "surface app module binding posture implementationRefs");
+  assertNoEnumerableImplementationFields(record, "surface app module binding posture");
+  return record;
+}
+
+export function assertSurfaceAppManifestSelection(record) {
+  if (!isObject(record)) throw new Error("surface app manifest selection must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.SURFACE_APP_MANIFEST_SELECTION, "surface app manifest selection");
+  const state = assertSurfaceAppRecordState(record, "surface app manifest selection", ["ready", "blocked"]);
+  requireString(record.manifestId, "surface app manifest selection manifestId");
+  requireString(record.appId, "surface app manifest selection appId");
+  requireString(record.appContractRef, "surface app manifest selection appContractRef");
+  requireString(record.version, "surface app manifest selection version");
+  const sourceMode = requireString(record.sourceMode, "surface app manifest selection sourceMode");
+  if (!Object.values(SURFACE_APP.FULFILLMENT_MODE).includes(sourceMode)) throw new Error("invalid surface app manifest selection sourceMode");
+  assertOptionalReferenceList(record.requiredModuleRoles, "surface app manifest selection requiredModuleRoles");
+  assertOptionalReferenceList(record.bundledSourceRefs, "surface app manifest selection bundledSourceRefs");
+  assertOptionalReferenceList(record.remoteSourceRefs, "surface app manifest selection remoteSourceRefs");
+  assertOptionalReferenceList(record.grantRefs, "surface app manifest selection grantRefs");
+  assertOptionalReferenceList(record.runnerRequirementRefs, "surface app manifest selection runnerRequirementRefs");
+  assertOptionalReferenceList(record.serviceManagerRequirementRefs, "surface app manifest selection serviceManagerRequirementRefs");
+  assertOptionalReferenceList(record.compatibilityRefs, "surface app manifest selection compatibilityRefs");
+  if (record.compatibilityWindow !== undefined) assertSurfaceAppCompatibilityWindow(record.compatibilityWindow, "surface app manifest selection compatibilityWindow");
+  if (String(record.bootstrapContractRef || "").trim()) requireString(record.bootstrapContractRef, "surface app manifest selection bootstrapContractRef");
+  if (String(record.releaseContractRef || "").trim()) requireString(record.releaseContractRef, "surface app manifest selection releaseContractRef");
+  if (record.claim !== undefined && record.claim !== null) assertSurfaceAppManifestVersion(record.claim, "surface app manifest selection claim");
+  if (state === "ready" && sourceMode !== SURFACE_APP.FULFILLMENT_MODE.BUNDLED) {
+    if (!String(record.releaseContractRef || "").trim()) throw new Error("surface app ready remote selection requires releaseContractRef");
+    if (!assertOptionalReferenceList(record.remoteSourceRefs, "surface app manifest selection remoteSourceRefs").length) {
+      throw new Error("surface app ready remote selection requires remoteSourceRefs");
+    }
+  }
+  assertOptionalReferenceList(record.evidenceRefs, "surface app manifest selection evidenceRefs");
+  if (!Number(record.issuedAt || 0)) throw new Error("surface app manifest selection missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) {
+    throw new Error("surface app manifest selection expires before issuedAt");
+  }
+  assertNoEnumerableImplementationFields(record, "surface app manifest selection");
+  return record;
+}
+
+export function assertSurfaceAppRunnerPlan(record) {
+  if (!isObject(record)) throw new Error("surface app runner plan must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.SURFACE_APP_RUNNER_PLAN, "surface app runner plan");
+  assertSurfaceAppRecordState(record, "surface app runner plan", ["ready", "blocked"]);
+  requireString(record.planId, "surface app runner plan planId");
+  requireString(record.contractId, "surface app runner plan contractId");
+  requireString(record.appId, "surface app runner plan appId");
+  const sourceMode = requireString(record.sourceMode, "surface app runner plan sourceMode");
+  if (!Object.values(SURFACE_APP.FULFILLMENT_MODE).includes(sourceMode)) throw new Error("invalid surface app runner plan sourceMode");
+  if (record.attachContext !== undefined && !isObject(record.attachContext)) throw new Error("surface app runner plan attachContext must be an object");
+  requireArray(record.modulePostures || [], "surface app runner plan modulePostures").forEach(assertSurfaceModuleRolePosture);
+  if (record.secretBoundary !== undefined) assertSurfaceSecretBoundary(record.secretBoundary, "surface app runner plan secretBoundary");
+  if (record.releaseContract !== undefined && record.releaseContract !== null) assertServiceManagerReleaseContract(record.releaseContract);
+  if (record.bootstrapContract !== undefined) assertSurfaceAppBootstrapContract(record.bootstrapContract);
+  if (record.labProof !== undefined && record.labProof !== null) assertServiceManagerLabProof(record.labProof);
+  if (record.proofDigest !== undefined && record.proofDigest !== null) assertServiceManagerProofDigest(record.proofDigest);
+  if (record.trainDigest !== undefined && record.trainDigest !== null) assertServiceManagerTrainDigest(record.trainDigest);
+  if (!Number(record.issuedAt || 0)) throw new Error("surface app runner plan missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) throw new Error("surface app runner plan expires before issuedAt");
+  assertNoEnumerableImplementationFields(record, "surface app runner plan");
+  return record;
+}
+
+export function assertSurfaceAppManifestRunnerPlan(record) {
+  if (!isObject(record)) throw new Error("surface app manifest runner plan must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.SURFACE_APP_MANIFEST_RUNNER_PLAN, "surface app manifest runner plan");
+  const state = assertSurfaceAppRecordState(record, "surface app manifest runner plan", ["ready", "blocked"]);
+  requireString(record.planId, "surface app manifest runner plan planId");
+  assertSurfaceAppManifestSelection(record.manifestSelection);
+  if (state === "ready") assertSurfaceAppRunnerPlan(record.runnerPlan);
+  if (state === "blocked" && record.runnerPlan !== null) throw new Error("surface app blocked manifest runner plan cannot carry runnerPlan");
+  if (!Number(record.issuedAt || 0)) throw new Error("surface app manifest runner plan missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) {
+    throw new Error("surface app manifest runner plan expires before issuedAt");
+  }
+  assertNoEnumerableImplementationFields(record, "surface app manifest runner plan");
+  return record;
+}
+
+export function assertSurfaceAppRuntimeSelectionPosture(record) {
+  if (!isObject(record)) throw new Error("surface app runtime selection posture must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.SURFACE_APP_RUNTIME_SELECTION_POSTURE, "surface app runtime selection posture");
+  assertSurfaceAppRecordState(record, "surface app runtime selection posture", ["ready", "degraded", "blocked"]);
+  requireString(record.selectionId, "surface app runtime selection posture selectionId");
+  requireString(record.appId, "surface app runtime selection posture appId");
+  requireString(record.pinnedAppContractRef, "surface app runtime selection posture pinnedAppContractRef");
+  requireString(record.pinnedVersion, "surface app runtime selection posture pinnedVersion");
+  const sourceMode = requireString(record.sourceMode, "surface app runtime selection posture sourceMode");
+  if (!Object.values(SURFACE_APP.FULFILLMENT_MODE).includes(sourceMode)) throw new Error("invalid surface app runtime selection posture sourceMode");
+  assertOptionalReferenceList(record.requiredModuleRoles, "surface app runtime selection posture requiredModuleRoles");
+  if (record.compatibilityResult !== undefined) assertSurfaceAppReadiness(record.compatibilityResult, "surface app runtime compatibility result");
+  if (record.sourceTrustResult !== undefined) assertSurfaceAppReadiness(record.sourceTrustResult, "surface app runtime source trust result");
+  requireArray(record.modulePostures || [], "surface app runtime selection posture modulePostures").forEach(assertSurfaceModuleRolePosture);
+  if (record.runnerReadiness !== undefined) assertSurfaceAppReadiness(record.runnerReadiness, "surface app runtime runner readiness");
+  if (record.serviceManagerReadiness !== undefined) assertSurfaceAppReadiness(record.serviceManagerReadiness, "surface app runtime service manager readiness");
+  assertSurfaceAppManifestSelection(record.manifestSelection);
+  assertSurfaceAppManifestRunnerPlan(record.manifestRunnerPlan);
+  if (record.runnerPlan !== undefined && record.runnerPlan !== null) assertSurfaceAppRunnerPlan(record.runnerPlan);
+  if (!Number(record.issuedAt || 0)) throw new Error("surface app runtime selection posture missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) {
+    throw new Error("surface app runtime selection posture expires before issuedAt");
+  }
+  assertNoEnumerableImplementationFields(record, "surface app runtime selection posture");
+  return record;
+}
+
+export function assertSurfaceAppInstancePosture(record) {
+  if (!isObject(record)) throw new Error("surface app instance posture must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.SURFACE_APP_INSTANCE_POSTURE, "surface app instance posture");
+  assertSurfaceAppRecordState(record, "surface app instance posture", ["ready", "degraded", "blocked"]);
+  requireString(record.instanceId, "surface app instance posture instanceId");
+  requireString(record.contractId, "surface app instance posture contractId");
+  requireString(record.appId, "surface app instance posture appId");
+  requireString(record.version, "surface app instance posture version");
+  if (String(record.manifestId || "").trim()) requireString(record.manifestId, "surface app instance posture manifestId");
+  if (String(record.pinnedAppContractRef || "").trim()) requireString(record.pinnedAppContractRef, "surface app instance posture pinnedAppContractRef");
+  if (String(record.pinnedVersion || "").trim()) requireString(record.pinnedVersion, "surface app instance posture pinnedVersion");
+  if (record.sourceMode !== undefined && !Object.values(SURFACE_APP.FULFILLMENT_MODE).includes(record.sourceMode)) {
+    throw new Error("invalid surface app instance posture sourceMode");
+  }
+  assertOptionalReferenceList(record.requiredModuleRoles, "surface app instance posture requiredModuleRoles");
+  assertOptionalReferenceList(record.moduleRefs, "surface app instance posture moduleRefs");
+  requireArray(record.modulePostures || [], "surface app instance posture modulePostures").forEach(assertSurfaceModuleRolePosture);
+  if (record.moduleBindingPosture !== undefined && record.moduleBindingPosture !== null) {
+    assertSurfaceAppModuleBindingPosture(record.moduleBindingPosture);
+  }
+  assertOptionalReferenceList(record.materializationBudgetRefs, "surface app instance posture materializationBudgetRefs");
+  if (record.runtimeSelectionPosture !== undefined && record.runtimeSelectionPosture !== null) {
+    assertSurfaceAppRuntimeSelectionPosture(record.runtimeSelectionPosture);
+  }
+  if (record.runnerReadiness !== undefined && record.runnerReadiness !== null) {
+    assertSurfaceAppReadiness(record.runnerReadiness, "surface app instance runner readiness");
+  }
+  if (record.serviceManagerReadiness !== undefined && record.serviceManagerReadiness !== null) {
+    assertSurfaceAppReadiness(record.serviceManagerReadiness, "surface app instance service manager readiness");
+  }
+  if (record.bootstrapPosture !== undefined && record.bootstrapPosture !== null) assertSurfaceAppBootstrapPosture(record.bootstrapPosture);
+  if (String(record.serviceManagerOperationRef || "").trim()) requireString(record.serviceManagerOperationRef, "surface app instance posture serviceManagerOperationRef");
+  if (String(record.serviceManagerProofRef || "").trim()) requireString(record.serviceManagerProofRef, "surface app instance posture serviceManagerProofRef");
+  if (!Number(record.issuedAt || 0)) throw new Error("surface app instance posture missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) {
+    throw new Error("surface app instance posture expires before issuedAt");
+  }
+  assertNoEnumerableImplementationFields(record, "surface app instance posture");
   return record;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -140,6 +140,29 @@ export const SURFACE_APP = Object.freeze({
   }),
 });
 
+export const RUNNER = Object.freeze({
+  OPERATION: Object.freeze({
+    PREPARE: "prepare",
+    EXECUTE: "execute",
+    HEALTH_CHECK: "healthCheck",
+    RELEASE: "release",
+    ROLLBACK: "rollback",
+    CANCEL: "cancel",
+  }),
+  OPERATION_STATE: Object.freeze({
+    REQUESTED: "requested",
+    ACCEPTED: "accepted",
+    RUNNING: "running",
+    SUCCEEDED: "succeeded",
+    FAILED: "failed",
+    BLOCKED: "blocked",
+    REJECTED: "rejected",
+    CANCELLED: "cancelled",
+    RELEASED: "released",
+    SUPERSEDED: "superseded",
+  }),
+});
+
 export const AGREEMENT = Object.freeze({
   PLANE: Object.freeze({
     ACTION_AUTHORITY: "actionAuthority",
@@ -1267,6 +1290,7 @@ export const SWARM = Object.freeze({
     SURFACE_APP_MANIFEST: "surface.app.manifest",
     SURFACE_APP_BOOTSTRAP_CONTRACT: "surface.app.bootstrap.contract",
     SURFACE_APP_BOOTSTRAP_POSTURE: "surface.app.bootstrap.posture",
+    RUNNER_OPERATION: "runner.operation",
   }),
   RECORD_KIND: Object.freeze({
     NODE_CAPABILITY: "node.capability",
@@ -1329,6 +1353,7 @@ export const SWARM = Object.freeze({
     SURFACE_APP_MANIFEST: "surface.app.manifest",
     SURFACE_APP_BOOTSTRAP_CONTRACT: "surface.app.bootstrap.contract",
     SURFACE_APP_BOOTSTRAP_POSTURE: "surface.app.bootstrap.posture",
+    RUNNER_OPERATION: "runner.operation",
   }),
   AUTHORITY_DOMAIN: Object.freeze({
     IDENTITY: "identity",
@@ -4955,5 +4980,49 @@ export function assertAppRunnerAdvertisement(record) {
   requireString(record.version, "app runner version");
   if (!isObject(record.capacity)) throw new Error("app runner capacity must be an object");
   if (!isObject(record.health)) throw new Error("app runner health must be an object");
+  return record;
+}
+
+export function assertRunnerOperation(record) {
+  if (!isObject(record)) throw new Error("runner operation must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.RUNNER_OPERATION, "runner operation");
+  requireString(record.operationId, "runner operation operationId");
+  requireString(record.runnerId, "runner operation runnerId");
+  assertResolvedMemberRef(record.runnerRef, "runner operation runnerRef");
+  requireString(record.hostRef, "runner operation hostRef");
+  requireString(record.requesterRef, "runner operation requesterRef");
+  requireString(record.subjectRef, "runner operation subjectRef");
+  requireString(record.contractRef, "runner operation contractRef");
+  const operation = requireString(record.operation, "runner operation operation");
+  if (!Object.values(RUNNER.OPERATION).includes(operation)) throw new Error("invalid runner operation");
+  const state = requireString(record.state, "runner operation state");
+  if (!Object.values(RUNNER.OPERATION_STATE).includes(state)) throw new Error("invalid runner operation state");
+  assertReferenceList(record.grantRefs, "runner operation grantRefs");
+  assertOptionalReferenceList(record.capabilityRefs, "runner operation capabilityRefs");
+  assertOptionalReferenceList(record.inputRefs, "runner operation inputRefs");
+  assertOptionalReferenceList(record.outputRefs, "runner operation outputRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "runner operation evidenceRefs");
+  assertOptionalReferenceList(record.proofRefs, "runner operation proofRefs");
+  assertOptionalReferenceList(record.releaseRefs, "runner operation releaseRefs");
+  if (!isObject(record.resourceBudget)) throw new Error("runner operation resourceBudget must be an object");
+  if (record.resourcePosture !== undefined) assertResourcePosture(record.resourcePosture);
+  if (record.secretBoundary !== undefined) assertSurfaceSecretBoundary(record.secretBoundary, "runner operation secretBoundary");
+  if (record.releasePosture !== undefined) assertSurfaceReleasePosture(record.releasePosture, "runner operation releasePosture");
+  if (record.rollbackPosture !== undefined) assertSurfaceReleasePosture(record.rollbackPosture, "runner operation rollbackPosture");
+  if (operation === RUNNER.OPERATION.RELEASE && !String(record.releaseRef || "").trim()) {
+    throw new Error("runner release operation requires releaseRef");
+  }
+  if (operation === RUNNER.OPERATION.ROLLBACK && !String(record.rollbackRef || "").trim()) {
+    throw new Error("runner rollback operation requires rollbackRef");
+  }
+  if (record.releaseRef !== undefined) requireString(record.releaseRef, "runner operation releaseRef");
+  if (record.rollbackRef !== undefined) requireString(record.rollbackRef, "runner operation rollbackRef");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "runner operation blockedReasons");
+  if ([RUNNER.OPERATION_STATE.BLOCKED, RUNNER.OPERATION_STATE.FAILED, RUNNER.OPERATION_STATE.REJECTED].includes(state) && blockedReasons.length === 0) {
+    throw new Error("runner blocked, failed, or rejected operation requires blockedReasons");
+  }
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "runner operation safeFacts");
+  assertSurfaceManagerSensitiveBoundary(record, "runner operation");
+  assertSurfaceOperationTimeline(record, "runner operation", "requestedAt");
   return record;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1318,6 +1318,7 @@ export const SWARM = Object.freeze({
     SURFACE_APP_MANIFEST_RUNNER_PLAN: "surface.app.manifest.runner.plan",
     SURFACE_APP_RUNTIME_SELECTION_POSTURE: "surface.app.runtime.selection.posture",
     SURFACE_APP_INSTANCE_POSTURE: "surface.app.instance.posture",
+    SURFACE_APP_FULFILLMENT_IDENTITY_POSTURE: "surface.app.fulfillment.identity.posture",
     SURFACE_APP_RUNNER_PLAN: "surface.app.runner.plan",
     SURFACE_APP_BOOTSTRAP_CONTRACT: "surface.app.bootstrap.contract",
     SURFACE_APP_BOOTSTRAP_POSTURE: "surface.app.bootstrap.posture",
@@ -1389,6 +1390,7 @@ export const SWARM = Object.freeze({
     SURFACE_APP_MANIFEST_RUNNER_PLAN: "surface.app.manifest.runner.plan",
     SURFACE_APP_RUNTIME_SELECTION_POSTURE: "surface.app.runtime.selection.posture",
     SURFACE_APP_INSTANCE_POSTURE: "surface.app.instance.posture",
+    SURFACE_APP_FULFILLMENT_IDENTITY_POSTURE: "surface.app.fulfillment.identity.posture",
     SURFACE_APP_RUNNER_PLAN: "surface.app.runner.plan",
     SURFACE_APP_BOOTSTRAP_CONTRACT: "surface.app.bootstrap.contract",
     SURFACE_APP_BOOTSTRAP_POSTURE: "surface.app.bootstrap.posture",
@@ -3716,6 +3718,11 @@ function assertOptionalReferenceList(value, name) {
   return requireArray(value, name).map((entry) => requireString(entry, `${name} entry`));
 }
 
+function assertOptionalResolvedMemberRefList(value, name) {
+  if (value === undefined || value === null) return [];
+  return requireArray(value, name).map((entry) => assertResolvedMemberRef(entry, `${name} entry`));
+}
+
 function assertOptionalCapabilityList(value, name) {
   return assertOptionalReferenceList(value, name).map(assertCapabilityName);
 }
@@ -5082,6 +5089,10 @@ export function assertSurfaceAppContract(record) {
   requireString(record.appId, "surface app contract appId");
   requireString(record.version, "surface app contract version");
   requireString(record.displayName, "surface app contract displayName");
+  if (record.serviceContractRef !== undefined) requireString(record.serviceContractRef, "surface app contract serviceContractRef");
+  if (record.serviceRef !== undefined) requireString(record.serviceRef, "surface app contract serviceRef");
+  assertOptionalReferenceList(record.serviceRouteRefs, "surface app contract serviceRouteRefs");
+  assertOptionalReferenceList(record.hostRefs, "surface app contract hostRefs");
   requireArray(record.requiredPrimitives || [], "surface app contract requiredPrimitives");
   const requiredRoles = requireNonEmptyArray(record.requiredModuleRoles, "surface app contract requiredModuleRoles");
   for (const role of requiredRoles) {
@@ -5112,6 +5123,50 @@ export function assertSurfaceAppContract(record) {
   if (!Number(record.issuedAt || 0)) throw new Error("surface app contract missing issuedAt");
   if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) throw new Error("surface app contract expires before issuedAt");
   return record;
+}
+
+export function assertSurfaceAppFulfillmentIdentityPosture(record) {
+  if (!isObject(record)) throw new Error("surface app fulfillment identity posture must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.SURFACE_APP_FULFILLMENT_IDENTITY_POSTURE, "surface app fulfillment identity posture");
+  const state = assertSurfaceAppRecordState(record, "surface app fulfillment identity posture", ["ready", "degraded", "blocked", "unknown", "unchecked"]);
+  requireString(record.identityId, "surface app fulfillment identity posture identityId");
+  requireString(record.appContractRef, "surface app fulfillment identity posture appContractRef");
+  requireString(record.appId, "surface app fulfillment identity posture appId");
+  if (String(record.version || "").trim()) requireString(record.version, "surface app fulfillment identity posture version");
+  if (String(record.surfaceRef || "").trim()) requireString(record.surfaceRef, "surface app fulfillment identity posture surfaceRef");
+  if (record.serviceRequired !== undefined && typeof record.serviceRequired !== "boolean") throw new Error("surface app fulfillment identity posture serviceRequired must be boolean");
+  const serviceContractRef = String(record.serviceContractRef || "").trim();
+  const legacyServiceRef = String(record.serviceRef || "").trim();
+  if (serviceContractRef) requireString(serviceContractRef, "surface app fulfillment identity posture serviceContractRef");
+  if (legacyServiceRef) requireString(legacyServiceRef, "surface app fulfillment identity posture serviceRef");
+  if (serviceContractRef && legacyServiceRef && serviceContractRef !== legacyServiceRef && state !== "blocked") {
+    throw new Error("surface app fulfillment identity posture serviceRef must not differ from serviceContractRef unless blocked");
+  }
+  if (record.serviceRequired === true && !serviceContractRef && state !== "blocked") {
+    throw new Error("surface app fulfillment identity posture ready service requires serviceContractRef");
+  }
+  assertOptionalReferenceList(record.serviceRouteRefs, "surface app fulfillment identity posture serviceRouteRefs");
+  assertOptionalReferenceList(record.routeRefs, "surface app fulfillment identity posture routeRefs");
+  assertOptionalReferenceList(record.hostRefs, "surface app fulfillment identity posture hostRefs");
+  assertOptionalReferenceList(record.managerRefs, "surface app fulfillment identity posture managerRefs");
+  const runnerRefs = assertOptionalResolvedMemberRefList(record.runnerRefs, "surface app fulfillment identity posture runnerRefs");
+  const memberRefs = assertOptionalResolvedMemberRefList(record.memberRefs, "surface app fulfillment identity posture memberRefs");
+  assertOptionalCapabilityList(record.capabilityRefs, "surface app fulfillment identity posture capabilityRefs");
+  assertOptionalReferenceList(record.grantRefs, "surface app fulfillment identity posture grantRefs");
+  assertOptionalReferenceList(record.authorityRefs, "surface app fulfillment identity posture authorityRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "surface app fulfillment identity posture evidenceRefs");
+  if (record.identityPosture !== undefined) assertSafeObject(record.identityPosture, "surface app fulfillment identity posture identityPosture");
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "surface app fulfillment identity posture safeFacts");
+  if (!Number(record.issuedAt || 0)) throw new Error("surface app fulfillment identity posture missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) {
+    throw new Error("surface app fulfillment identity posture expires before issuedAt");
+  }
+  assertNoEnumerableImplementationFields(record, "surface app fulfillment identity posture");
+  return {
+    ...record,
+    runnerRefs,
+    memberRefs,
+  };
 }
 
 function assertSurfaceAppRecordState(record, context, states = ["ready", "degraded", "blocked"]) {
@@ -5261,6 +5316,9 @@ export function assertSurfaceAppRuntimeSelectionPosture(record) {
   requireArray(record.modulePostures || [], "surface app runtime selection posture modulePostures").forEach(assertSurfaceModuleRolePosture);
   if (record.runnerReadiness !== undefined) assertSurfaceAppReadiness(record.runnerReadiness, "surface app runtime runner readiness");
   if (record.serviceManagerReadiness !== undefined) assertSurfaceAppReadiness(record.serviceManagerReadiness, "surface app runtime service manager readiness");
+  if (record.fulfillmentIdentityPosture !== undefined && record.fulfillmentIdentityPosture !== null) {
+    assertSurfaceAppFulfillmentIdentityPosture(record.fulfillmentIdentityPosture);
+  }
   assertSurfaceAppManifestSelection(record.manifestSelection);
   assertSurfaceAppManifestRunnerPlan(record.manifestRunnerPlan);
   if (record.runnerPlan !== undefined && record.runnerPlan !== null) assertSurfaceAppRunnerPlan(record.runnerPlan);
@@ -5301,6 +5359,9 @@ export function assertSurfaceAppInstancePosture(record) {
   }
   if (record.serviceManagerReadiness !== undefined && record.serviceManagerReadiness !== null) {
     assertSurfaceAppReadiness(record.serviceManagerReadiness, "surface app instance service manager readiness");
+  }
+  if (record.fulfillmentIdentityPosture !== undefined && record.fulfillmentIdentityPosture !== null) {
+    assertSurfaceAppFulfillmentIdentityPosture(record.fulfillmentIdentityPosture);
   }
   if (record.bootstrapPosture !== undefined && record.bootstrapPosture !== null) assertSurfaceAppBootstrapPosture(record.bootstrapPosture);
   if (String(record.serviceManagerOperationRef || "").trim()) requireString(record.serviceManagerOperationRef, "surface app instance posture serviceManagerOperationRef");

--- a/src/index.js
+++ b/src/index.js
@@ -4779,6 +4779,17 @@ function assertSurfaceAppManifestVersion(record, context = "surface app manifest
   if (record.sourceMode !== undefined && !Object.values(SURFACE_APP.FULFILLMENT_MODE).includes(record.sourceMode)) {
     throw new Error(`invalid ${context} sourceMode`);
   }
+  if (record.requiredModuleRoles !== undefined) {
+    requireArray(record.requiredModuleRoles, `${context} requiredModuleRoles`).forEach((role) => {
+      if (!Object.values(SURFACE_APP.MODULE_ROLE).includes(role)) throw new Error(`invalid ${context} required module role`);
+    });
+  }
+  if (record.compatibilityWindow !== undefined) assertSurfaceAppCompatibilityWindow(record.compatibilityWindow, `${context} compatibilityWindow`);
+  assertOptionalReferenceList(record.bundledSourceRefs, `${context} bundledSourceRefs`);
+  assertOptionalReferenceList(record.remoteSourceRefs, `${context} remoteSourceRefs`);
+  assertOptionalReferenceList(record.grantRefs, `${context} grantRefs`);
+  assertOptionalReferenceList(record.runnerRequirementRefs, `${context} runnerRequirementRefs`);
+  assertOptionalReferenceList(record.serviceManagerRequirementRefs, `${context} serviceManagerRequirementRefs`);
   assertOptionalReferenceList(record.compatibilityRefs, `${context} compatibilityRefs`);
   assertOptionalReferenceList(record.moduleRefs, `${context} moduleRefs`);
   if (record.bootstrapContractRef !== undefined) requireString(record.bootstrapContractRef, `${context} bootstrapContractRef`);
@@ -4796,6 +4807,16 @@ function assertSurfaceAppManifestVersion(record, context = "surface app manifest
   ) {
     throw new Error(`${context} non-bundled source requires releaseContractRef`);
   }
+  return record;
+}
+
+function assertSurfaceAppCompatibilityWindow(record, context = "surface app compatibilityWindow") {
+  if (!isObject(record)) throw new Error(`${context} must be an object`);
+  if (record.minVersion !== undefined) requireString(record.minVersion, `${context} minVersion`);
+  if (record.maxVersion !== undefined) requireString(record.maxVersion, `${context} maxVersion`);
+  if (record.protocolRef !== undefined) requireString(record.protocolRef, `${context} protocolRef`);
+  assertOptionalReferenceList(record.compatibilityRefs, `${context} compatibilityRefs`);
+  assertOptionalReferenceList(record.schemaRefs, `${context} schemaRefs`);
   return record;
 }
 
@@ -4818,7 +4839,18 @@ export function assertSurfaceAppManifest(record) {
     && String(entry.version) === String(record.currentVersion)
   ));
   if (!current) throw new Error("surface app manifest missing current version claim");
+  if (record.requiredModuleRoles !== undefined) {
+    requireArray(record.requiredModuleRoles, "surface app manifest requiredModuleRoles").forEach((role) => {
+      if (!Object.values(SURFACE_APP.MODULE_ROLE).includes(role)) throw new Error("invalid surface app manifest required module role");
+    });
+  }
+  if (record.compatibilityWindow !== undefined) assertSurfaceAppCompatibilityWindow(record.compatibilityWindow, "surface app manifest compatibilityWindow");
   assertOptionalReferenceList(record.appContractRefs, "surface app manifest appContractRefs");
+  assertOptionalReferenceList(record.bundledSourceRefs, "surface app manifest bundledSourceRefs");
+  assertOptionalReferenceList(record.remoteSourceRefs, "surface app manifest remoteSourceRefs");
+  assertOptionalReferenceList(record.grantRefs, "surface app manifest grantRefs");
+  assertOptionalReferenceList(record.runnerRequirementRefs, "surface app manifest runnerRequirementRefs");
+  assertOptionalReferenceList(record.serviceManagerRequirementRefs, "surface app manifest serviceManagerRequirementRefs");
   assertOptionalReferenceList(record.compatibilityRefs, "surface app manifest compatibilityRefs");
   assertOptionalReferenceList(record.bootstrapContractRefs, "surface app manifest bootstrapContractRefs");
   assertOptionalReferenceList(record.releaseContractRefs, "surface app manifest releaseContractRefs");

--- a/src/index.js
+++ b/src/index.js
@@ -1319,6 +1319,7 @@ export const SWARM = Object.freeze({
     SURFACE_APP_RUNTIME_SELECTION_POSTURE: "surface.app.runtime.selection.posture",
     SURFACE_APP_INSTANCE_POSTURE: "surface.app.instance.posture",
     SURFACE_APP_FULFILLMENT_IDENTITY_POSTURE: "surface.app.fulfillment.identity.posture",
+    SURFACE_APP_AUTHORITY_ACCESS_POSTURE: "surface.app.authority.access.posture",
     SURFACE_APP_RUNNER_PLAN: "surface.app.runner.plan",
     SURFACE_APP_BOOTSTRAP_CONTRACT: "surface.app.bootstrap.contract",
     SURFACE_APP_BOOTSTRAP_POSTURE: "surface.app.bootstrap.posture",
@@ -1391,6 +1392,7 @@ export const SWARM = Object.freeze({
     SURFACE_APP_RUNTIME_SELECTION_POSTURE: "surface.app.runtime.selection.posture",
     SURFACE_APP_INSTANCE_POSTURE: "surface.app.instance.posture",
     SURFACE_APP_FULFILLMENT_IDENTITY_POSTURE: "surface.app.fulfillment.identity.posture",
+    SURFACE_APP_AUTHORITY_ACCESS_POSTURE: "surface.app.authority.access.posture",
     SURFACE_APP_RUNNER_PLAN: "surface.app.runner.plan",
     SURFACE_APP_BOOTSTRAP_CONTRACT: "surface.app.bootstrap.contract",
     SURFACE_APP_BOOTSTRAP_POSTURE: "surface.app.bootstrap.posture",
@@ -3727,6 +3729,11 @@ function assertOptionalCapabilityList(value, name) {
   return assertOptionalReferenceList(value, name).map(assertCapabilityName);
 }
 
+function assertOptionalContentClassList(value, name) {
+  if (value === undefined || value === null) return [];
+  return requireArray(value, name).map((entry) => assertContentClassName(entry, `${name} entry`));
+}
+
 function assertSafeObject(value, name) {
   const object = assertOptionalObject(value, name);
   rejectRouteControlByteFields(object, name);
@@ -5093,6 +5100,12 @@ export function assertSurfaceAppContract(record) {
   if (record.serviceRef !== undefined) requireString(record.serviceRef, "surface app contract serviceRef");
   assertOptionalReferenceList(record.serviceRouteRefs, "surface app contract serviceRouteRefs");
   assertOptionalReferenceList(record.hostRefs, "surface app contract hostRefs");
+  assertOptionalReferenceList(record.rootRefs, "surface app contract rootRefs");
+  assertOptionalReferenceList(record.deviceRefs, "surface app contract deviceRefs");
+  assertOptionalReferenceList(record.grantRefs, "surface app contract grantRefs");
+  assertOptionalReferenceList(record.accessGroupRefs, "surface app contract accessGroupRefs");
+  assertOptionalContentClassList(record.requiredContentClasses, "surface app contract requiredContentClasses");
+  assertOptionalReferenceList(record.revocationRefs, "surface app contract revocationRefs");
   requireArray(record.requiredPrimitives || [], "surface app contract requiredPrimitives");
   const requiredRoles = requireNonEmptyArray(record.requiredModuleRoles, "surface app contract requiredModuleRoles");
   for (const role of requiredRoles) {
@@ -5166,6 +5179,58 @@ export function assertSurfaceAppFulfillmentIdentityPosture(record) {
     ...record,
     runnerRefs,
     memberRefs,
+  };
+}
+
+export function assertSurfaceAppAuthorityAccessPosture(record) {
+  if (!isObject(record)) throw new Error("surface app authority access posture must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.SURFACE_APP_AUTHORITY_ACCESS_POSTURE, "surface app authority access posture");
+  const state = assertSurfaceAppRecordState(record, "surface app authority access posture", ["ready", "degraded", "blocked", "unknown", "unchecked"]);
+  requireString(record.postureId, "surface app authority access posture postureId");
+  requireString(record.appContractRef, "surface app authority access posture appContractRef");
+  requireString(record.appId, "surface app authority access posture appId");
+  if (record.actionRequired !== undefined && typeof record.actionRequired !== "boolean") throw new Error("surface app authority access posture actionRequired must be boolean");
+  if (record.accessRequired !== undefined && typeof record.accessRequired !== "boolean") throw new Error("surface app authority access posture accessRequired must be boolean");
+  assertOptionalReferenceList(record.rootRefs, "surface app authority access posture rootRefs");
+  assertOptionalReferenceList(record.deviceRefs, "surface app authority access posture deviceRefs");
+  const grantRefs = assertOptionalReferenceList(record.grantRefs, "surface app authority access posture grantRefs");
+  const authorityRefs = assertOptionalReferenceList(record.authorityRefs, "surface app authority access posture authorityRefs");
+  const accessGroupRefs = assertOptionalReferenceList(record.accessGroupRefs, "surface app authority access posture accessGroupRefs");
+  const requiredContentClasses = assertOptionalContentClassList(record.requiredContentClasses, "surface app authority access posture requiredContentClasses");
+  assertOptionalReferenceList(record.revocationRefs, "surface app authority access posture revocationRefs");
+  assertOptionalReferenceList(record.exerciseRefs, "surface app authority access posture exerciseRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "surface app authority access posture evidenceRefs");
+  if (record.actionPosture !== undefined) assertSafeObject(record.actionPosture, "surface app authority access posture actionPosture");
+  if (record.accessPosture !== undefined) assertSafeObject(record.accessPosture, "surface app authority access posture accessPosture");
+  if (record.revocationPosture !== undefined) assertSafeObject(record.revocationPosture, "surface app authority access posture revocationPosture");
+  if (record.expiryPosture !== undefined) assertSafeObject(record.expiryPosture, "surface app authority access posture expiryPosture");
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "surface app authority access posture safeFacts");
+  if (record.actionRequired === true && grantRefs.length === 0 && state !== "blocked") {
+    throw new Error("surface app authority access posture action requires grantRefs");
+  }
+  if (record.accessRequired === true && accessGroupRefs.length === 0 && state !== "blocked") {
+    throw new Error("surface app authority access posture access requires accessGroupRefs");
+  }
+  if (record.accessRequired === true && requiredContentClasses.length === 0 && state !== "blocked") {
+    throw new Error("surface app authority access posture access requires requiredContentClasses");
+  }
+  if (String(record.revocationState || "").trim()) {
+    const revocationState = requireString(record.revocationState, "surface app authority access posture revocationState");
+    if (revocationState === "revoked" && state !== "blocked") {
+      throw new Error("surface app authority access posture revoked state must be blocked");
+    }
+  }
+  if (!Number(record.issuedAt || 0)) throw new Error("surface app authority access posture missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) {
+    throw new Error("surface app authority access posture expires before issuedAt");
+  }
+  assertNoEnumerableImplementationFields(record, "surface app authority access posture");
+  return {
+    ...record,
+    grantRefs,
+    authorityRefs,
+    accessGroupRefs,
+    requiredContentClasses,
   };
 }
 
@@ -5319,6 +5384,9 @@ export function assertSurfaceAppRuntimeSelectionPosture(record) {
   if (record.fulfillmentIdentityPosture !== undefined && record.fulfillmentIdentityPosture !== null) {
     assertSurfaceAppFulfillmentIdentityPosture(record.fulfillmentIdentityPosture);
   }
+  if (record.authorityAccessPosture !== undefined && record.authorityAccessPosture !== null) {
+    assertSurfaceAppAuthorityAccessPosture(record.authorityAccessPosture);
+  }
   assertSurfaceAppManifestSelection(record.manifestSelection);
   assertSurfaceAppManifestRunnerPlan(record.manifestRunnerPlan);
   if (record.runnerPlan !== undefined && record.runnerPlan !== null) assertSurfaceAppRunnerPlan(record.runnerPlan);
@@ -5362,6 +5430,9 @@ export function assertSurfaceAppInstancePosture(record) {
   }
   if (record.fulfillmentIdentityPosture !== undefined && record.fulfillmentIdentityPosture !== null) {
     assertSurfaceAppFulfillmentIdentityPosture(record.fulfillmentIdentityPosture);
+  }
+  if (record.authorityAccessPosture !== undefined && record.authorityAccessPosture !== null) {
+    assertSurfaceAppAuthorityAccessPosture(record.authorityAccessPosture);
   }
   if (record.bootstrapPosture !== undefined && record.bootstrapPosture !== null) assertSurfaceAppBootstrapPosture(record.bootstrapPosture);
   if (String(record.serviceManagerOperationRef || "").trim()) requireString(record.serviceManagerOperationRef, "surface app instance posture serviceManagerOperationRef");

--- a/src/index.js
+++ b/src/index.js
@@ -175,6 +175,18 @@ export const RUNNER = Object.freeze({
     RELEASED: "released",
     SUPERSEDED: "superseded",
   }),
+  FULFILLMENT_STATE: Object.freeze({
+    REQUESTED: "requested",
+    ACCEPTED: "accepted",
+    RUNNING: "running",
+    SUCCEEDED: "succeeded",
+    RELEASED: "released",
+    ROLLED_BACK: "rolledBack",
+    BLOCKED: "blocked",
+    FAILED: "failed",
+    REJECTED: "rejected",
+    CANCELLED: "cancelled",
+  }),
 });
 
 export const AGREEMENT = Object.freeze({
@@ -1312,6 +1324,7 @@ export const SWARM = Object.freeze({
     SURFACE_MODULE_ROLE_POSTURE: "surface.module.role.posture",
     SURFACE_APP_MODULE_BINDING_POSTURE: "surface.app.module.binding.posture",
     RUNNER_OPERATION: "runner.operation",
+    APP_RUNNER_FULFILLMENT_REPORT: "app.runner.fulfillment.report",
   }),
   RECORD_KIND: Object.freeze({
     NODE_CAPABILITY: "node.capability",
@@ -1382,6 +1395,7 @@ export const SWARM = Object.freeze({
     SURFACE_MODULE_ROLE_POSTURE: "surface.module.role.posture",
     SURFACE_APP_MODULE_BINDING_POSTURE: "surface.app.module.binding.posture",
     RUNNER_OPERATION: "runner.operation",
+    APP_RUNNER_FULFILLMENT_REPORT: "app.runner.fulfillment.report",
   }),
   AUTHORITY_DOMAIN: Object.freeze({
     IDENTITY: "identity",
@@ -2895,7 +2909,7 @@ const EVENT_PLANE_KIND_RULES = Object.freeze([
   [SWARM.EVENT_PLANE.PROJECTION_REPAIR, /^projection\.repair/],
   [SWARM.EVENT_PLANE.PROJECTION, /^projection\./],
   [SWARM.EVENT_PLANE.CONTRIBUTION, /^contribution\./],
-  [SWARM.EVENT_PLANE.ACTIVATION, /^(service|stream|interaction|media)\./],
+  [SWARM.EVENT_PLANE.ACTIVATION, /^(service|stream|interaction|media|runner|app\.runner)\./],
   [SWARM.EVENT_PLANE.ROUTE, /^(route|frame|adapter\.edge|runtime\.directory)\./],
   [SWARM.EVENT_PLANE.RETENTION, /^(retention|runtime\.retention)\./],
 ]);
@@ -5351,4 +5365,93 @@ export function assertRunnerOperation(record) {
   assertSurfaceManagerSensitiveBoundary(record, "runner operation");
   assertSurfaceOperationTimeline(record, "runner operation", "requestedAt");
   return record;
+}
+
+function assertRunnerFulfillmentState(value, context = "runner fulfillment state") {
+  const state = requireString(value, context);
+  if (!Object.values(RUNNER.FULFILLMENT_STATE).includes(state)) throw new Error("invalid runner fulfillment state");
+  return state;
+}
+
+export function assertAppRunnerFulfillmentReport(record) {
+  if (!isObject(record)) throw new Error("app runner fulfillment report must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.APP_RUNNER_FULFILLMENT_REPORT, "app runner fulfillment report");
+  requireString(record.reportId, "app runner fulfillment report reportId");
+  requireString(record.runnerId, "app runner fulfillment report runnerId");
+  assertResolvedMemberRef(record.runnerRef, "app runner fulfillment report runnerRef");
+  requireString(record.hostRef, "app runner fulfillment report hostRef");
+  requireString(record.runnerOperationId, "app runner fulfillment report runnerOperationId");
+  const operation = requireString(record.operation, "app runner fulfillment report operation");
+  if (!Object.values(RUNNER.OPERATION).includes(operation)) throw new Error("invalid app runner fulfillment operation");
+  const state = assertRunnerFulfillmentState(record.state, "app runner fulfillment report state");
+  requireString(record.requesterRef, "app runner fulfillment report requesterRef");
+  requireString(record.subjectRef, "app runner fulfillment report subjectRef");
+  requireString(record.contractRef, "app runner fulfillment report contractRef");
+  if (record.appContractRef !== undefined) requireString(record.appContractRef, "app runner fulfillment report appContractRef");
+  if (record.appId !== undefined) requireString(record.appId, "app runner fulfillment report appId");
+  if (record.version !== undefined) requireString(record.version, "app runner fulfillment report version");
+  if (record.manifestRef !== undefined) requireString(record.manifestRef, "app runner fulfillment report manifestRef");
+  const sourceMode = requireString(record.sourceMode, "app runner fulfillment report sourceMode");
+  if (!Object.values(SURFACE_APP.FULFILLMENT_MODE).includes(sourceMode)) throw new Error("invalid app runner fulfillment sourceMode");
+  const sourceRefs = assertOptionalReferenceList(record.sourceRefs, "app runner fulfillment report sourceRefs");
+  assertReferenceList(record.grantRefs, "app runner fulfillment report grantRefs");
+  const capabilityRefs = assertOptionalReferenceList(record.capabilityRefs, "app runner fulfillment report capabilityRefs");
+  const inputRefs = assertOptionalReferenceList(record.inputRefs, "app runner fulfillment report inputRefs");
+  const outputRefs = assertOptionalReferenceList(record.outputRefs, "app runner fulfillment report outputRefs");
+  const evidenceRefs = assertOptionalReferenceList(record.evidenceRefs, "app runner fulfillment report evidenceRefs");
+  const proofRefs = assertOptionalReferenceList(record.proofRefs, "app runner fulfillment report proofRefs");
+  const releaseRefs = assertOptionalReferenceList(record.releaseRefs, "app runner fulfillment report releaseRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "app runner fulfillment report blockedReasons");
+  if (!isObject(record.resourceBudget)) throw new Error("app runner fulfillment report resourceBudget must be an object");
+  assertSafeObject(record.resourceBudget, "app runner fulfillment report resourceBudget");
+  if (record.resourcePosture !== undefined && record.resourcePosture !== null) assertResourcePosture(record.resourcePosture);
+  if (record.secretBoundary !== undefined) assertSurfaceSecretBoundary(record.secretBoundary, "app runner fulfillment report secretBoundary");
+  if (record.releasePosture !== undefined && record.releasePosture !== null) assertSurfaceReleasePosture(record.releasePosture, "app runner fulfillment report releasePosture");
+  if (record.rollbackPosture !== undefined && record.rollbackPosture !== null) assertSurfaceReleasePosture(record.rollbackPosture, "app runner fulfillment report rollbackPosture");
+  if (record.releaseRef !== undefined) requireString(record.releaseRef, "app runner fulfillment report releaseRef");
+  if (record.rollbackRef !== undefined) requireString(record.rollbackRef, "app runner fulfillment report rollbackRef");
+  const operationPosture = assertOptionalObject(record.operationPosture, "app runner fulfillment report operationPosture");
+  const fulfillmentPosture = assertOptionalObject(record.fulfillmentPosture, "app runner fulfillment report fulfillmentPosture");
+  if (!Object.keys(operationPosture).length) throw new Error("app runner fulfillment report operationPosture must be an object");
+  if (!Object.keys(fulfillmentPosture).length) throw new Error("app runner fulfillment report fulfillmentPosture must be an object");
+  if (operationPosture.state !== undefined && String(operationPosture.state) !== state) {
+    throw new Error("app runner fulfillment report operationPosture state must match state");
+  }
+  if (fulfillmentPosture.state !== undefined && String(fulfillmentPosture.state) !== state) {
+    throw new Error("app runner fulfillment report fulfillmentPosture state must match state");
+  }
+  assertSafeObject(operationPosture, "app runner fulfillment report operationPosture");
+  assertSafeObject(fulfillmentPosture, "app runner fulfillment report fulfillmentPosture");
+  if ([RUNNER.FULFILLMENT_STATE.BLOCKED, RUNNER.FULFILLMENT_STATE.FAILED, RUNNER.FULFILLMENT_STATE.REJECTED, RUNNER.FULFILLMENT_STATE.CANCELLED].includes(state) && blockedReasons.length === 0) {
+    throw new Error("blocked app runner fulfillment requires blockedReasons");
+  }
+  if (state === RUNNER.FULFILLMENT_STATE.SUCCEEDED && outputRefs.length === 0 && proofRefs.length === 0) {
+    throw new Error("succeeded app runner fulfillment requires outputRefs or proofRefs");
+  }
+  if (state === RUNNER.FULFILLMENT_STATE.SUCCEEDED && sourceRefs.length === 0) {
+    throw new Error("succeeded app runner fulfillment requires sourceRefs");
+  }
+  if (state === RUNNER.FULFILLMENT_STATE.RELEASED && releaseRefs.length === 0 && !String(record.releaseRef || "").trim()) {
+    throw new Error("released app runner fulfillment requires releaseRefs or releaseRef");
+  }
+  if (state === RUNNER.FULFILLMENT_STATE.ROLLED_BACK && !String(record.rollbackRef || "").trim()) {
+    throw new Error("rolledBack app runner fulfillment requires rollbackRef");
+  }
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "app runner fulfillment report safeFacts");
+  assertSurfaceManagerSensitiveBoundary(record, "app runner fulfillment report");
+  if (!Number(record.observedAt || 0)) throw new Error("app runner fulfillment report missing observedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.observedAt || 0)) {
+    throw new Error("app runner fulfillment report expiresAt must be after observedAt");
+  }
+  return {
+    ...record,
+    capabilityRefs,
+    sourceRefs,
+    inputRefs,
+    outputRefs,
+    evidenceRefs,
+    proofRefs,
+    releaseRefs,
+    blockedReasons,
+  };
 }

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -162,6 +162,14 @@ pub const SURFACE_FULFILLMENT_MODE_STORAGE_OBJECT: &str = "storageObject";
 pub const SURFACE_FULFILLMENT_MODE_NATIVE_INSTALLED: &str = "nativeInstalled";
 pub const SURFACE_FULFILLMENT_MODE_DEV_OVERLAY: &str = "devOverlay";
 
+pub const SURFACE_MODULE_ROLE_RUNTIME_CLIENT: &str = "runtimeClient";
+pub const SURFACE_MODULE_ROLE_PROJECTION_MODEL: &str = "projectionModel";
+pub const SURFACE_MODULE_ROLE_PLATFORM_ADAPTER: &str = "platformAdapter";
+pub const SURFACE_MODULE_ROLE_SERVICE_SURFACE_ADAPTER: &str = "serviceSurfaceAdapter";
+pub const SURFACE_MODULE_ROLE_PRODUCT_VIEW: &str = "productView";
+pub const SURFACE_MODULE_ROLE_OPERATOR_HELPER: &str = "operatorHelper";
+pub const SURFACE_MODULE_ROLE_RELEASE_HELPER: &str = "releaseHelper";
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct ZoneScope {
@@ -2008,12 +2016,41 @@ pub struct SurfaceAppBootstrapContractRecord {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+pub struct SurfaceAppCompatibilityWindowRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub protocol_ref: Option<String>,
+    #[serde(default)]
+    pub compatibility_refs: Vec<String>,
+    #[serde(default)]
+    pub schema_refs: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct SurfaceAppManifestVersionRecord {
     pub app_contract_ref: String,
     pub version: String,
     pub state: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_mode: Option<String>,
+    #[serde(default)]
+    pub required_module_roles: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compatibility_window: Option<SurfaceAppCompatibilityWindowRecord>,
+    #[serde(default)]
+    pub bundled_source_refs: Vec<String>,
+    #[serde(default)]
+    pub remote_source_refs: Vec<String>,
+    #[serde(default)]
+    pub grant_refs: Vec<String>,
+    #[serde(default)]
+    pub runner_requirement_refs: Vec<String>,
+    #[serde(default)]
+    pub service_manager_requirement_refs: Vec<String>,
     #[serde(default)]
     pub module_refs: Vec<String>,
     #[serde(default)]
@@ -2046,6 +2083,20 @@ pub struct SurfaceAppManifestRecord {
     pub versions: Vec<SurfaceAppManifestVersionRecord>,
     #[serde(default)]
     pub app_contract_refs: Vec<String>,
+    #[serde(default)]
+    pub required_module_roles: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compatibility_window: Option<SurfaceAppCompatibilityWindowRecord>,
+    #[serde(default)]
+    pub bundled_source_refs: Vec<String>,
+    #[serde(default)]
+    pub remote_source_refs: Vec<String>,
+    #[serde(default)]
+    pub grant_refs: Vec<String>,
+    #[serde(default)]
+    pub runner_requirement_refs: Vec<String>,
+    #[serde(default)]
+    pub service_manager_requirement_refs: Vec<String>,
     #[serde(default)]
     pub compatibility_refs: Vec<String>,
     #[serde(default)]
@@ -4826,6 +4877,58 @@ pub fn validate_surface_app_bootstrap_contract(
     Ok(())
 }
 
+fn validate_surface_module_role(role: &str) -> Result<()> {
+    if matches!(
+        role,
+        SURFACE_MODULE_ROLE_RUNTIME_CLIENT
+            | SURFACE_MODULE_ROLE_PROJECTION_MODEL
+            | SURFACE_MODULE_ROLE_PLATFORM_ADAPTER
+            | SURFACE_MODULE_ROLE_SERVICE_SURFACE_ADAPTER
+            | SURFACE_MODULE_ROLE_PRODUCT_VIEW
+            | SURFACE_MODULE_ROLE_OPERATOR_HELPER
+            | SURFACE_MODULE_ROLE_RELEASE_HELPER
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported surface module role"))
+    }
+}
+
+fn validate_surface_module_roles(roles: &[String], context: &str) -> Result<()> {
+    validate_reference_list(roles, context)?;
+    for role in roles {
+        validate_surface_module_role(role)?;
+    }
+    Ok(())
+}
+
+fn validate_surface_app_compatibility_window(
+    record: &SurfaceAppCompatibilityWindowRecord,
+    context: &str,
+) -> Result<()> {
+    validate_optional_ref(record.protocol_ref.as_deref(), &format!("{context} missing protocolRef"))?;
+    validate_reference_list(
+        &record.compatibility_refs,
+        &format!("{context} missing compatibilityRefs"),
+    )?;
+    validate_reference_list(&record.schema_refs, &format!("{context} missing schemaRefs"))?;
+    if record
+        .min_version
+        .as_deref()
+        .is_some_and(|version| version.trim().is_empty())
+    {
+        return Err(anyhow!("{context} missing minVersion"));
+    }
+    if record
+        .max_version
+        .as_deref()
+        .is_some_and(|version| version.trim().is_empty())
+    {
+        return Err(anyhow!("{context} missing maxVersion"));
+    }
+    Ok(())
+}
+
 fn validate_surface_app_manifest_version(record: &SurfaceAppManifestVersionRecord) -> Result<()> {
     require_non_empty(
         &record.app_contract_ref,
@@ -4860,6 +4963,36 @@ fn validate_surface_app_manifest_version(record: &SurfaceAppManifestVersionRecor
             ));
         }
     }
+    validate_surface_module_roles(
+        &record.required_module_roles,
+        "surface app manifest version missing requiredModuleRoles",
+    )?;
+    if let Some(window) = record.compatibility_window.as_ref() {
+        validate_surface_app_compatibility_window(
+            window,
+            "surface app manifest version compatibilityWindow",
+        )?;
+    }
+    validate_reference_list(
+        &record.bundled_source_refs,
+        "surface app manifest version missing bundledSourceRefs",
+    )?;
+    validate_reference_list(
+        &record.remote_source_refs,
+        "surface app manifest version missing remoteSourceRefs",
+    )?;
+    validate_reference_list(
+        &record.grant_refs,
+        "surface app manifest version missing grantRefs",
+    )?;
+    validate_reference_list(
+        &record.runner_requirement_refs,
+        "surface app manifest version missing runnerRequirementRefs",
+    )?;
+    validate_reference_list(
+        &record.service_manager_requirement_refs,
+        "surface app manifest version missing serviceManagerRequirementRefs",
+    )?;
     validate_reference_list(
         &record.module_refs,
         "surface app manifest version missing moduleRefs",
@@ -4936,9 +5069,36 @@ pub fn validate_surface_app_manifest(record: &SurfaceAppManifestRecord) -> Resul
             "surface app manifest missing current version claim"
         ));
     }
+    validate_surface_module_roles(
+        &record.required_module_roles,
+        "surface app manifest missing requiredModuleRoles",
+    )?;
+    if let Some(window) = record.compatibility_window.as_ref() {
+        validate_surface_app_compatibility_window(
+            window,
+            "surface app manifest compatibilityWindow",
+        )?;
+    }
     validate_reference_list(
         &record.app_contract_refs,
         "surface app manifest missing appContractRefs",
+    )?;
+    validate_reference_list(
+        &record.bundled_source_refs,
+        "surface app manifest missing bundledSourceRefs",
+    )?;
+    validate_reference_list(
+        &record.remote_source_refs,
+        "surface app manifest missing remoteSourceRefs",
+    )?;
+    validate_reference_list(&record.grant_refs, "surface app manifest missing grantRefs")?;
+    validate_reference_list(
+        &record.runner_requirement_refs,
+        "surface app manifest missing runnerRequirementRefs",
+    )?;
+    validate_reference_list(
+        &record.service_manager_requirement_refs,
+        "surface app manifest missing serviceManagerRequirementRefs",
     )?;
     validate_reference_list(
         &record.compatibility_refs,
@@ -9768,6 +9928,19 @@ mod tests {
                 version: "0.1.0".to_string(),
                 state: SURFACE_APP_MANIFEST_VERSION_CURRENT.to_string(),
                 source_mode: Some(SURFACE_FULFILLMENT_MODE_BUNDLED.to_string()),
+                required_module_roles: vec![SURFACE_MODULE_ROLE_RUNTIME_CLIENT.to_string()],
+                compatibility_window: Some(SurfaceAppCompatibilityWindowRecord {
+                    min_version: Some("0.1.0".to_string()),
+                    max_version: Some("0.1.x".to_string()),
+                    protocol_ref: Some("protocol:surface-app:v1".to_string()),
+                    compatibility_refs: vec!["protocol:surface-app:v1".to_string()],
+                    schema_refs: vec!["schema:surface-app-contract:v1".to_string()],
+                }),
+                bundled_source_refs: vec!["bundle:constitute-nvr-ui@0.1.0".to_string()],
+                remote_source_refs: vec![],
+                grant_refs: vec!["grant:app:nvr-ui:run".to_string()],
+                runner_requirement_refs: vec!["runner:req:nvr-ui".to_string()],
+                service_manager_requirement_refs: vec!["service-manager:req:nvr-ui".to_string()],
                 module_refs: vec!["module:runtime-client@0.1.0".to_string()],
                 compatibility_refs: vec!["protocol:surface-app:v1".to_string()],
                 bootstrap_contract_ref: None,
@@ -9777,6 +9950,19 @@ mod tests {
                 blocked_reasons: vec![],
             }],
             app_contract_refs: vec!["surface-app:nvr-ui@0.1.0".to_string()],
+            required_module_roles: vec![SURFACE_MODULE_ROLE_RUNTIME_CLIENT.to_string()],
+            compatibility_window: Some(SurfaceAppCompatibilityWindowRecord {
+                min_version: Some("0.1.0".to_string()),
+                max_version: Some("0.1.x".to_string()),
+                protocol_ref: Some("protocol:surface-app:v1".to_string()),
+                compatibility_refs: vec!["protocol:surface-app:v1".to_string()],
+                schema_refs: vec!["schema:surface-app-contract:v1".to_string()],
+            }),
+            bundled_source_refs: vec!["bundle:constitute-nvr-ui@0.1.0".to_string()],
+            remote_source_refs: vec![],
+            grant_refs: vec!["grant:app:nvr-ui:run".to_string()],
+            runner_requirement_refs: vec!["runner:req:nvr-ui".to_string()],
+            service_manager_requirement_refs: vec!["service-manager:req:nvr-ui".to_string()],
             compatibility_refs: vec!["protocol:surface-app:v1".to_string()],
             bootstrap_contract_refs: vec![],
             release_contract_refs: vec![],
@@ -9801,6 +9987,13 @@ mod tests {
             version: "0.2.0".to_string(),
             state: SURFACE_APP_MANIFEST_VERSION_CURRENT.to_string(),
             source_mode: Some(SURFACE_FULFILLMENT_MODE_SWARM_PACKAGE.to_string()),
+            required_module_roles: vec![],
+            compatibility_window: None,
+            bundled_source_refs: vec![],
+            remote_source_refs: vec!["swarm-package:nvr-ui@0.2.0".to_string()],
+            grant_refs: vec![],
+            runner_requirement_refs: vec![],
+            service_manager_requirement_refs: vec![],
             module_refs: vec![],
             compatibility_refs: vec![],
             bootstrap_contract_ref: None,

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -113,6 +113,8 @@ pub const RECORD_SERVICE_MANAGER_TRAIN_DIGEST: &str = "service.manager.train.dig
 pub const RECORD_SERVICE_MANAGER_LAB_PROOF: &str = "service.manager.labProof";
 pub const RECORD_SURFACE_APP_MANIFEST: &str = "surface.app.manifest";
 pub const RECORD_SURFACE_APP_BOOTSTRAP_CONTRACT: &str = "surface.app.bootstrap.contract";
+pub const RECORD_SURFACE_APP_FULFILLMENT_IDENTITY_POSTURE: &str =
+    "surface.app.fulfillment.identity.posture";
 pub const RECORD_RUNNER_OPERATION: &str = "runner.operation";
 pub const RECORD_APP_RUNNER_FULFILLMENT_REPORT: &str = "app.runner.fulfillment.report";
 
@@ -139,6 +141,12 @@ pub const SURFACE_APP_SCHEMA_COMPATIBLE: &str = "compatible";
 pub const SURFACE_APP_SCHEMA_MIGRATION_REQUIRED: &str = "migrationRequired";
 pub const SURFACE_APP_SCHEMA_IGNORE: &str = "ignore";
 pub const SURFACE_APP_SCHEMA_BLOCKED: &str = "blocked";
+
+pub const SURFACE_APP_FULFILLMENT_IDENTITY_READY: &str = "ready";
+pub const SURFACE_APP_FULFILLMENT_IDENTITY_DEGRADED: &str = "degraded";
+pub const SURFACE_APP_FULFILLMENT_IDENTITY_BLOCKED: &str = "blocked";
+pub const SURFACE_APP_FULFILLMENT_IDENTITY_UNKNOWN: &str = "unknown";
+pub const SURFACE_APP_FULFILLMENT_IDENTITY_UNCHECKED: &str = "unchecked";
 
 pub const SURFACE_SECRET_BOUNDARY_NOT_REQUIRED: &str = "notRequired";
 pub const SURFACE_SECRET_BOUNDARY_RESOLVED: &str = "resolved";
@@ -2188,6 +2196,56 @@ pub struct SurfaceAppManifestRecord {
     pub distribution_posture: Option<SurfaceAppDistributionPostureRecord>,
     #[serde(default)]
     pub safe_facts: Value,
+    pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SurfaceAppFulfillmentIdentityPostureRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub identity_id: String,
+    pub state: String,
+    pub app_contract_ref: String,
+    pub app_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub surface_ref: Option<String>,
+    #[serde(default)]
+    pub service_required: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_contract_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_ref: Option<String>,
+    #[serde(default)]
+    pub service_route_refs: Vec<String>,
+    #[serde(default)]
+    pub route_refs: Vec<String>,
+    #[serde(default)]
+    pub host_refs: Vec<String>,
+    #[serde(default)]
+    pub manager_refs: Vec<String>,
+    #[serde(default)]
+    pub runner_refs: Vec<String>,
+    #[serde(default)]
+    pub member_refs: Vec<String>,
+    #[serde(default)]
+    pub capability_refs: Vec<String>,
+    #[serde(default)]
+    pub grant_refs: Vec<String>,
+    #[serde(default)]
+    pub authority_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub identity_posture: Value,
+    #[serde(default)]
+    pub safe_facts: Value,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
     pub issued_at: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<u64>,
@@ -5046,6 +5104,167 @@ fn validate_surface_module_roles(roles: &[String], context: &str) -> Result<()> 
     Ok(())
 }
 
+fn validate_surface_app_fulfillment_identity_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        SURFACE_APP_FULFILLMENT_IDENTITY_READY
+            | SURFACE_APP_FULFILLMENT_IDENTITY_DEGRADED
+            | SURFACE_APP_FULFILLMENT_IDENTITY_BLOCKED
+            | SURFACE_APP_FULFILLMENT_IDENTITY_UNKNOWN
+            | SURFACE_APP_FULFILLMENT_IDENTITY_UNCHECKED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "unsupported surface app fulfillment identity posture state"
+        ))
+    }
+}
+
+fn validate_resolved_member_ref_list(values: &[String], context: &str) -> Result<()> {
+    for value in values {
+        validate_resolved_member_ref(value, context)?;
+    }
+    Ok(())
+}
+
+pub fn validate_surface_app_fulfillment_identity_posture(
+    record: &SurfaceAppFulfillmentIdentityPostureRecord,
+) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_SURFACE_APP_FULFILLMENT_IDENTITY_POSTURE,
+        "surface app fulfillment identity posture",
+    )?;
+    reject_private_content_fields(
+        &serde_json::to_value(record)?,
+        "surface app fulfillment identity posture",
+    )?;
+    require_non_empty(
+        &record.identity_id,
+        "surface app fulfillment identity posture missing identityId",
+    )?;
+    validate_surface_app_fulfillment_identity_state(&record.state)?;
+    require_non_empty(
+        &record.app_contract_ref,
+        "surface app fulfillment identity posture missing appContractRef",
+    )?;
+    require_non_empty(
+        &record.app_id,
+        "surface app fulfillment identity posture missing appId",
+    )?;
+    if let Some(version) = record.version.as_deref() {
+        require_non_empty(
+            version,
+            "surface app fulfillment identity posture missing version",
+        )?;
+    }
+    validate_optional_ref(
+        record.surface_ref.as_deref(),
+        "surface app fulfillment identity posture missing surfaceRef",
+    )?;
+    validate_optional_ref(
+        record.service_contract_ref.as_deref(),
+        "surface app fulfillment identity posture missing serviceContractRef",
+    )?;
+    validate_optional_ref(
+        record.service_ref.as_deref(),
+        "surface app fulfillment identity posture missing serviceRef",
+    )?;
+    let service_contract_ref = record
+        .service_contract_ref
+        .as_deref()
+        .unwrap_or_default()
+        .trim();
+    let service_ref = record.service_ref.as_deref().unwrap_or_default().trim();
+    if !service_contract_ref.is_empty()
+        && !service_ref.is_empty()
+        && service_contract_ref != service_ref
+        && record.state != SURFACE_APP_FULFILLMENT_IDENTITY_BLOCKED
+    {
+        return Err(anyhow!(
+            "surface app fulfillment identity posture serviceRef must not differ from serviceContractRef unless blocked"
+        ));
+    }
+    if record.service_required
+        && service_contract_ref.is_empty()
+        && record.state != SURFACE_APP_FULFILLMENT_IDENTITY_BLOCKED
+    {
+        return Err(anyhow!(
+            "surface app fulfillment identity posture ready service requires serviceContractRef"
+        ));
+    }
+    validate_reference_list(
+        &record.service_route_refs,
+        "surface app fulfillment identity posture missing serviceRouteRefs",
+    )?;
+    validate_reference_list(
+        &record.route_refs,
+        "surface app fulfillment identity posture missing routeRefs",
+    )?;
+    validate_reference_list(
+        &record.host_refs,
+        "surface app fulfillment identity posture missing hostRefs",
+    )?;
+    validate_reference_list(
+        &record.manager_refs,
+        "surface app fulfillment identity posture missing managerRefs",
+    )?;
+    validate_resolved_member_ref_list(
+        &record.runner_refs,
+        "surface app fulfillment identity posture runnerRefs",
+    )?;
+    validate_resolved_member_ref_list(
+        &record.member_refs,
+        "surface app fulfillment identity posture memberRefs",
+    )?;
+    validate_capability_names(&record.capability_refs)?;
+    validate_reference_list(
+        &record.grant_refs,
+        "surface app fulfillment identity posture missing grantRefs",
+    )?;
+    validate_reference_list(
+        &record.authority_refs,
+        "surface app fulfillment identity posture missing authorityRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "surface app fulfillment identity posture missing evidenceRefs",
+    )?;
+    validate_safe_facts(
+        &record.identity_posture,
+        "surface app fulfillment identity posture identityPosture",
+    )?;
+    validate_safe_facts(
+        &record.safe_facts,
+        "surface app fulfillment identity posture safeFacts",
+    )?;
+    validate_reference_list(
+        &record.blocked_reasons,
+        "surface app fulfillment identity posture missing blockedReasons",
+    )?;
+    if record.state == SURFACE_APP_FULFILLMENT_IDENTITY_BLOCKED && record.blocked_reasons.is_empty()
+    {
+        return Err(anyhow!(
+            "surface app blocked fulfillment identity posture requires blockedReasons"
+        ));
+    }
+    if record.issued_at == 0 {
+        return Err(anyhow!(
+            "surface app fulfillment identity posture missing issuedAt"
+        ));
+    }
+    if record
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= record.issued_at)
+    {
+        return Err(anyhow!(
+            "surface app fulfillment identity posture expiresAt must be after issuedAt"
+        ));
+    }
+    Ok(())
+}
+
 fn validate_surface_app_compatibility_window(
     record: &SurfaceAppCompatibilityWindowRecord,
     context: &str,
@@ -6520,9 +6739,7 @@ pub fn validate_app_runner_fulfillment_report(record: &AppRunnerFulfillmentRepor
         "app runner fulfillment report",
     )?;
     if record.observed_at == 0 {
-        return Err(anyhow!(
-            "app runner fulfillment report missing observedAt"
-        ));
+        return Err(anyhow!("app runner fulfillment report missing observedAt"));
     }
     if record
         .expires_at
@@ -9375,7 +9592,8 @@ mod tests {
         let mut blocked_without_reason_report = fulfillment_report.clone();
         blocked_without_reason_report.report_id = "app-runner:bad:blocked".to_string();
         blocked_without_reason_report.state = RUNNER_FULFILLMENT_STATE_BLOCKED.to_string();
-        blocked_without_reason_report.operation_posture = json!({ "state": RUNNER_FULFILLMENT_STATE_BLOCKED });
+        blocked_without_reason_report.operation_posture =
+            json!({ "state": RUNNER_FULFILLMENT_STATE_BLOCKED });
         blocked_without_reason_report.fulfillment_posture =
             json!({ "state": RUNNER_FULFILLMENT_STATE_BLOCKED });
         assert!(validate_app_runner_fulfillment_report(&blocked_without_reason_report).is_err());
@@ -10760,6 +10978,64 @@ mod tests {
             distribution_posture: None,
         }];
         assert!(validate_surface_app_manifest(&remote_without_release).is_err());
+    }
+
+    #[test]
+    fn validates_surface_app_fulfillment_identity_posture() {
+        let browser_member = pubkey_from_sk_hex(BROWSER_SK).expect("browser pk");
+        let posture = SurfaceAppFulfillmentIdentityPostureRecord {
+            kind: Some(RECORD_SURFACE_APP_FULFILLMENT_IDENTITY_POSTURE.to_string()),
+            identity_id: "identity:surface-app:nvr-ui".to_string(),
+            state: SURFACE_APP_FULFILLMENT_IDENTITY_READY.to_string(),
+            app_contract_ref: "surface-app:nvr-ui@0.2.0".to_string(),
+            app_id: "constitute-nvr-ui".to_string(),
+            version: Some("0.2.0".to_string()),
+            surface_ref: Some("surface:nvr-ui".to_string()),
+            service_required: true,
+            service_contract_ref: Some("service:nvr".to_string()),
+            service_ref: Some("service:nvr".to_string()),
+            service_route_refs: vec!["service:nvr".to_string(), "route:service:nvr".to_string()],
+            route_refs: vec!["route:service:nvr".to_string()],
+            host_refs: vec!["host:lab-gateway".to_string()],
+            manager_refs: vec!["manager:nvr-ui".to_string()],
+            runner_refs: vec![browser_member.clone()],
+            member_refs: vec![browser_member],
+            capability_refs: vec!["service.manage".to_string()],
+            grant_refs: vec!["grant:app:nvr-ui:run".to_string()],
+            authority_refs: vec!["authority:nvr-ui:local".to_string()],
+            evidence_refs: vec!["build:nvr-ui:local".to_string()],
+            identity_posture: json!({
+                "app": "ready",
+                "service": "ready",
+                "route": "ready",
+                "host": "ready"
+            }),
+            safe_facts: json!({
+                "serviceRequired": true,
+                "serviceRouteRefCount": 2,
+                "runnerRefCount": 1
+            }),
+            blocked_reasons: vec![],
+            issued_at: 1_700_000_000,
+            expires_at: Some(1_700_003_600),
+        };
+        validate_surface_app_fulfillment_identity_posture(&posture)
+            .expect("valid fulfillment identity posture");
+
+        let mut bad_service = posture.clone();
+        bad_service.identity_id = "identity:surface-app:nvr-ui:bad-service".to_string();
+        bad_service.service_ref = Some("service:nvr-route-only".to_string());
+        assert!(validate_surface_app_fulfillment_identity_posture(&bad_service).is_err());
+
+        let mut bad_runner = posture.clone();
+        bad_runner.identity_id = "identity:surface-app:nvr-ui:bad-runner".to_string();
+        bad_runner.runner_refs = vec!["member:unresolved".to_string()];
+        assert!(validate_surface_app_fulfillment_identity_posture(&bad_runner).is_err());
+
+        let mut missing_service = posture;
+        missing_service.identity_id = "identity:surface-app:nvr-ui:missing-service".to_string();
+        missing_service.service_contract_ref = None;
+        assert!(validate_surface_app_fulfillment_identity_posture(&missing_service).is_err());
     }
 
     #[test]

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -115,6 +115,8 @@ pub const RECORD_SURFACE_APP_MANIFEST: &str = "surface.app.manifest";
 pub const RECORD_SURFACE_APP_BOOTSTRAP_CONTRACT: &str = "surface.app.bootstrap.contract";
 pub const RECORD_SURFACE_APP_FULFILLMENT_IDENTITY_POSTURE: &str =
     "surface.app.fulfillment.identity.posture";
+pub const RECORD_SURFACE_APP_AUTHORITY_ACCESS_POSTURE: &str =
+    "surface.app.authority.access.posture";
 pub const RECORD_RUNNER_OPERATION: &str = "runner.operation";
 pub const RECORD_APP_RUNNER_FULFILLMENT_REPORT: &str = "app.runner.fulfillment.report";
 
@@ -2242,6 +2244,56 @@ pub struct SurfaceAppFulfillmentIdentityPostureRecord {
     pub evidence_refs: Vec<String>,
     #[serde(default)]
     pub identity_posture: Value,
+    #[serde(default)]
+    pub safe_facts: Value,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SurfaceAppAuthorityAccessPostureRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub posture_id: String,
+    pub state: String,
+    pub app_contract_ref: String,
+    pub app_id: String,
+    #[serde(default)]
+    pub action_required: bool,
+    #[serde(default)]
+    pub access_required: bool,
+    #[serde(default)]
+    pub root_refs: Vec<String>,
+    #[serde(default)]
+    pub device_refs: Vec<String>,
+    #[serde(default)]
+    pub grant_refs: Vec<String>,
+    #[serde(default)]
+    pub authority_refs: Vec<String>,
+    #[serde(default)]
+    pub access_group_refs: Vec<String>,
+    #[serde(default)]
+    pub required_content_classes: Vec<String>,
+    #[serde(default)]
+    pub revocation_refs: Vec<String>,
+    #[serde(default)]
+    pub exercise_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub action_posture: Value,
+    #[serde(default)]
+    pub access_posture: Value,
+    #[serde(default)]
+    pub revocation_posture: Value,
+    #[serde(default)]
+    pub expiry_posture: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revocation_state: Option<String>,
     #[serde(default)]
     pub safe_facts: Value,
     #[serde(default)]
@@ -5260,6 +5312,143 @@ pub fn validate_surface_app_fulfillment_identity_posture(
     {
         return Err(anyhow!(
             "surface app fulfillment identity posture expiresAt must be after issuedAt"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_surface_app_authority_access_posture(
+    record: &SurfaceAppAuthorityAccessPostureRecord,
+) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_SURFACE_APP_AUTHORITY_ACCESS_POSTURE,
+        "surface app authority access posture",
+    )?;
+    reject_private_content_fields(
+        &serde_json::to_value(record)?,
+        "surface app authority access posture",
+    )?;
+    require_non_empty(
+        &record.posture_id,
+        "surface app authority access posture missing postureId",
+    )?;
+    validate_surface_app_fulfillment_identity_state(&record.state)?;
+    require_non_empty(
+        &record.app_contract_ref,
+        "surface app authority access posture missing appContractRef",
+    )?;
+    require_non_empty(
+        &record.app_id,
+        "surface app authority access posture missing appId",
+    )?;
+    validate_reference_list(
+        &record.root_refs,
+        "surface app authority access posture missing rootRefs",
+    )?;
+    validate_reference_list(
+        &record.device_refs,
+        "surface app authority access posture missing deviceRefs",
+    )?;
+    validate_reference_list(
+        &record.grant_refs,
+        "surface app authority access posture missing grantRefs",
+    )?;
+    validate_reference_list(
+        &record.authority_refs,
+        "surface app authority access posture missing authorityRefs",
+    )?;
+    validate_reference_list(
+        &record.access_group_refs,
+        "surface app authority access posture missing accessGroupRefs",
+    )?;
+    for content_class in &record.required_content_classes {
+        validate_content_class(content_class)?;
+    }
+    validate_reference_list(
+        &record.revocation_refs,
+        "surface app authority access posture missing revocationRefs",
+    )?;
+    validate_reference_list(
+        &record.exercise_refs,
+        "surface app authority access posture missing exerciseRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "surface app authority access posture missing evidenceRefs",
+    )?;
+    validate_safe_facts(
+        &record.action_posture,
+        "surface app authority access posture actionPosture",
+    )?;
+    validate_safe_facts(
+        &record.access_posture,
+        "surface app authority access posture accessPosture",
+    )?;
+    validate_safe_facts(
+        &record.revocation_posture,
+        "surface app authority access posture revocationPosture",
+    )?;
+    validate_safe_facts(
+        &record.expiry_posture,
+        "surface app authority access posture expiryPosture",
+    )?;
+    validate_safe_facts(
+        &record.safe_facts,
+        "surface app authority access posture safeFacts",
+    )?;
+    validate_reference_list(
+        &record.blocked_reasons,
+        "surface app authority access posture missing blockedReasons",
+    )?;
+    if record.action_required
+        && record.grant_refs.is_empty()
+        && record.state != SURFACE_APP_FULFILLMENT_IDENTITY_BLOCKED
+    {
+        return Err(anyhow!(
+            "surface app authority access posture action requires grantRefs"
+        ));
+    }
+    if record.access_required
+        && record.access_group_refs.is_empty()
+        && record.state != SURFACE_APP_FULFILLMENT_IDENTITY_BLOCKED
+    {
+        return Err(anyhow!(
+            "surface app authority access posture access requires accessGroupRefs"
+        ));
+    }
+    if record.access_required
+        && record.required_content_classes.is_empty()
+        && record.state != SURFACE_APP_FULFILLMENT_IDENTITY_BLOCKED
+    {
+        return Err(anyhow!(
+            "surface app authority access posture access requires requiredContentClasses"
+        ));
+    }
+    if record.state == SURFACE_APP_FULFILLMENT_IDENTITY_BLOCKED && record.blocked_reasons.is_empty()
+    {
+        return Err(anyhow!(
+            "surface app blocked authority access posture requires blockedReasons"
+        ));
+    }
+    if record.revocation_state.as_deref() == Some("revoked")
+        && record.state != SURFACE_APP_FULFILLMENT_IDENTITY_BLOCKED
+    {
+        return Err(anyhow!(
+            "surface app authority access posture revoked state must be blocked"
+        ));
+    }
+    if record.issued_at == 0 {
+        return Err(anyhow!(
+            "surface app authority access posture missing issuedAt"
+        ));
+    }
+    if record
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= record.issued_at)
+    {
+        return Err(anyhow!(
+            "surface app authority access posture expiresAt must be after issuedAt"
         ));
     }
     Ok(())
@@ -11036,6 +11225,72 @@ mod tests {
         missing_service.identity_id = "identity:surface-app:nvr-ui:missing-service".to_string();
         missing_service.service_contract_ref = None;
         assert!(validate_surface_app_fulfillment_identity_posture(&missing_service).is_err());
+    }
+
+    #[test]
+    fn validates_surface_app_authority_access_posture() {
+        let posture = SurfaceAppAuthorityAccessPostureRecord {
+            kind: Some(RECORD_SURFACE_APP_AUTHORITY_ACCESS_POSTURE.to_string()),
+            posture_id: "authority-access:surface-app:nvr-ui".to_string(),
+            state: SURFACE_APP_FULFILLMENT_IDENTITY_READY.to_string(),
+            app_contract_ref: "surface-app:nvr-ui@0.2.0".to_string(),
+            app_id: "constitute-nvr-ui".to_string(),
+            action_required: true,
+            access_required: true,
+            root_refs: vec!["root:aux".to_string()],
+            device_refs: vec!["device:aux-browser".to_string()],
+            grant_refs: vec!["grant:app:nvr-ui:run".to_string()],
+            authority_refs: vec!["authority:aux-browser".to_string()],
+            access_group_refs: vec!["access-group:nvr-ui:media-preview".to_string()],
+            required_content_classes: vec![
+                "uiProjection".to_string(),
+                "mediaReference".to_string(),
+            ],
+            revocation_refs: vec![],
+            exercise_refs: vec!["exercise:app:nvr-ui:run".to_string()],
+            evidence_refs: vec!["proof:nvr-ui:authority".to_string()],
+            action_posture: json!({
+                "state": "ready",
+                "grantRefCount": 1
+            }),
+            access_posture: json!({
+                "state": "ready",
+                "accessGroupRefCount": 1,
+                "requiredContentClassCount": 2
+            }),
+            revocation_posture: json!({
+                "state": "clear"
+            }),
+            expiry_posture: json!({
+                "state": "fresh"
+            }),
+            revocation_state: None,
+            safe_facts: json!({
+                "actionRequired": true,
+                "accessRequired": true
+            }),
+            blocked_reasons: vec![],
+            issued_at: 1_700_000_000,
+            expires_at: Some(1_700_003_600),
+        };
+        validate_surface_app_authority_access_posture(&posture)
+            .expect("valid authority access posture");
+
+        let mut missing_grant = posture.clone();
+        missing_grant.posture_id = "authority-access:surface-app:nvr-ui:missing-grant".to_string();
+        missing_grant.grant_refs = vec![];
+        assert!(validate_surface_app_authority_access_posture(&missing_grant).is_err());
+
+        let mut missing_access_group = posture.clone();
+        missing_access_group.posture_id =
+            "authority-access:surface-app:nvr-ui:missing-access".to_string();
+        missing_access_group.access_group_refs = vec![];
+        assert!(validate_surface_app_authority_access_posture(&missing_access_group).is_err());
+
+        let mut revoked_ready = posture;
+        revoked_ready.posture_id = "authority-access:surface-app:nvr-ui:revoked".to_string();
+        revoked_ready.revocation_state = Some("revoked".to_string());
+        assert!(validate_surface_app_authority_access_posture(&revoked_ready).is_err());
     }
 
     #[test]

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -127,6 +127,18 @@ pub const SURFACE_APP_MANIFEST_VERSION_UPDATE_AVAILABLE: &str = "updateAvailable
 pub const SURFACE_APP_MANIFEST_VERSION_BLOCKED: &str = "blocked";
 pub const SURFACE_APP_MANIFEST_VERSION_SUPERSEDED: &str = "superseded";
 
+pub const SURFACE_APP_DISTRIBUTION_PENDING: &str = "pending";
+pub const SURFACE_APP_DISTRIBUTION_RETAINED: &str = "retained";
+pub const SURFACE_APP_DISTRIBUTION_DEGRADED: &str = "degraded";
+pub const SURFACE_APP_DISTRIBUTION_BLOCKED: &str = "blocked";
+pub const SURFACE_APP_DISTRIBUTION_SUPERSEDED: &str = "superseded";
+pub const SURFACE_APP_DISTRIBUTION_IGNORED: &str = "ignored";
+
+pub const SURFACE_APP_SCHEMA_COMPATIBLE: &str = "compatible";
+pub const SURFACE_APP_SCHEMA_MIGRATION_REQUIRED: &str = "migrationRequired";
+pub const SURFACE_APP_SCHEMA_IGNORE: &str = "ignore";
+pub const SURFACE_APP_SCHEMA_BLOCKED: &str = "blocked";
+
 pub const SURFACE_SECRET_BOUNDARY_NOT_REQUIRED: &str = "notRequired";
 pub const SURFACE_SECRET_BOUNDARY_RESOLVED: &str = "resolved";
 pub const SURFACE_SECRET_BOUNDARY_BLOCKED: &str = "blocked";
@@ -2031,6 +2043,56 @@ pub struct SurfaceAppCompatibilityWindowRecord {
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
+pub struct SurfaceAppSchemaPostureRecord {
+    pub state: String,
+    #[serde(default)]
+    pub schema_refs: Vec<String>,
+    #[serde(default)]
+    pub migration_refs: Vec<String>,
+    #[serde(default)]
+    pub compatibility_refs: Vec<String>,
+    #[serde(default)]
+    pub ignored_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SurfaceAppDistributionPostureRecord {
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_mode: Option<String>,
+    #[serde(default)]
+    pub source_refs: Vec<String>,
+    #[serde(default)]
+    pub storage_refs: Vec<String>,
+    #[serde(default)]
+    pub pin_intent_refs: Vec<String>,
+    #[serde(default)]
+    pub pin_projection_refs: Vec<String>,
+    #[serde(default)]
+    pub release_contract_refs: Vec<String>,
+    #[serde(default)]
+    pub retention_refs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retention_class: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema_posture: Option<SurfaceAppSchemaPostureRecord>,
+    #[serde(default)]
+    pub release_posture: Value,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct SurfaceAppManifestVersionRecord {
     pub app_contract_ref: String,
     pub version: String,
@@ -2065,6 +2127,8 @@ pub struct SurfaceAppManifestVersionRecord {
     pub evidence_refs: Vec<String>,
     #[serde(default)]
     pub blocked_reasons: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distribution_posture: Option<SurfaceAppDistributionPostureRecord>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -2109,6 +2173,8 @@ pub struct SurfaceAppManifestRecord {
     pub evidence_refs: Vec<String>,
     #[serde(default)]
     pub blocked_reasons: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distribution_posture: Option<SurfaceAppDistributionPostureRecord>,
     #[serde(default)]
     pub safe_facts: Value,
     pub issued_at: u64,
@@ -4906,12 +4972,18 @@ fn validate_surface_app_compatibility_window(
     record: &SurfaceAppCompatibilityWindowRecord,
     context: &str,
 ) -> Result<()> {
-    validate_optional_ref(record.protocol_ref.as_deref(), &format!("{context} missing protocolRef"))?;
+    validate_optional_ref(
+        record.protocol_ref.as_deref(),
+        &format!("{context} missing protocolRef"),
+    )?;
     validate_reference_list(
         &record.compatibility_refs,
         &format!("{context} missing compatibilityRefs"),
     )?;
-    validate_reference_list(&record.schema_refs, &format!("{context} missing schemaRefs"))?;
+    validate_reference_list(
+        &record.schema_refs,
+        &format!("{context} missing schemaRefs"),
+    )?;
     if record
         .min_version
         .as_deref()
@@ -4926,6 +4998,132 @@ fn validate_surface_app_compatibility_window(
     {
         return Err(anyhow!("{context} missing maxVersion"));
     }
+    Ok(())
+}
+
+fn validate_surface_app_schema_posture(
+    record: &SurfaceAppSchemaPostureRecord,
+    context: &str,
+) -> Result<()> {
+    validate_surface_app_schema_posture_state(&record.state)?;
+    validate_reference_list(
+        &record.schema_refs,
+        &format!("{context} missing schemaRefs"),
+    )?;
+    validate_reference_list(
+        &record.migration_refs,
+        &format!("{context} missing migrationRefs"),
+    )?;
+    validate_reference_list(
+        &record.compatibility_refs,
+        &format!("{context} missing compatibilityRefs"),
+    )?;
+    validate_reference_list(
+        &record.ignored_refs,
+        &format!("{context} missing ignoredRefs"),
+    )?;
+    validate_reference_list(
+        &record.blocked_reasons,
+        &format!("{context} missing blockedReasons"),
+    )?;
+    if matches!(
+        record.state.as_str(),
+        SURFACE_APP_SCHEMA_IGNORE | SURFACE_APP_SCHEMA_BLOCKED
+    ) && record.blocked_reasons.is_empty()
+    {
+        return Err(anyhow!(
+            "{context} ignored or blocked state requires blockedReasons"
+        ));
+    }
+    if record.state == SURFACE_APP_SCHEMA_MIGRATION_REQUIRED
+        && record.migration_refs.is_empty()
+        && record.blocked_reasons.is_empty()
+    {
+        return Err(anyhow!(
+            "{context} migrationRequired state requires migrationRefs or blockedReasons"
+        ));
+    }
+    reject_private_content_fields(&serde_json::to_value(record)?, context)?;
+    validate_safe_facts(&record.safe_facts, &format!("{context} safeFacts"))?;
+    Ok(())
+}
+
+fn validate_surface_app_distribution_posture(
+    record: &SurfaceAppDistributionPostureRecord,
+    context: &str,
+) -> Result<()> {
+    validate_surface_app_distribution_posture_state(&record.state)?;
+    if let Some(source_mode) = record.source_mode.as_deref() {
+        validate_surface_fulfillment_mode(source_mode)?;
+    }
+    validate_reference_list(
+        &record.source_refs,
+        &format!("{context} missing sourceRefs"),
+    )?;
+    validate_reference_list(
+        &record.storage_refs,
+        &format!("{context} missing storageRefs"),
+    )?;
+    validate_reference_list(
+        &record.pin_intent_refs,
+        &format!("{context} missing pinIntentRefs"),
+    )?;
+    validate_reference_list(
+        &record.pin_projection_refs,
+        &format!("{context} missing pinProjectionRefs"),
+    )?;
+    validate_reference_list(
+        &record.release_contract_refs,
+        &format!("{context} missing releaseContractRefs"),
+    )?;
+    validate_reference_list(
+        &record.retention_refs,
+        &format!("{context} missing retentionRefs"),
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        &format!("{context} missing evidenceRefs"),
+    )?;
+    validate_reference_list(
+        &record.blocked_reasons,
+        &format!("{context} missing blockedReasons"),
+    )?;
+    validate_optional_ref(
+        record.retention_class.as_deref(),
+        &format!("{context} missing retentionClass"),
+    )?;
+    if let Some(schema_posture) = record.schema_posture.as_ref() {
+        validate_surface_app_schema_posture(schema_posture, &format!("{context} schemaPosture"))?;
+    }
+    if !record.release_posture.is_null() {
+        validate_surface_release_posture_value(
+            &record.release_posture,
+            &format!("{context} releasePosture"),
+        )?;
+    }
+    if record.state == SURFACE_APP_DISTRIBUTION_RETAINED {
+        if record.source_refs.is_empty() && record.storage_refs.is_empty() {
+            return Err(anyhow!(
+                "{context} retained state requires sourceRefs or storageRefs"
+            ));
+        }
+        if record.pin_intent_refs.is_empty() && record.pin_projection_refs.is_empty() {
+            return Err(anyhow!(
+                "{context} retained state requires pinIntentRefs or pinProjectionRefs"
+            ));
+        }
+    }
+    if matches!(
+        record.state.as_str(),
+        SURFACE_APP_DISTRIBUTION_BLOCKED | SURFACE_APP_DISTRIBUTION_IGNORED
+    ) && record.blocked_reasons.is_empty()
+    {
+        return Err(anyhow!(
+            "{context} blocked or ignored state requires blockedReasons"
+        ));
+    }
+    reject_private_content_fields(&serde_json::to_value(record)?, context)?;
+    validate_safe_facts(&record.safe_facts, &format!("{context} safeFacts"))?;
     Ok(())
 }
 
@@ -5026,6 +5224,12 @@ fn validate_surface_app_manifest_version(record: &SurfaceAppManifestVersionRecor
         &record.blocked_reasons,
         "surface app manifest version missing blockedReasons",
     )?;
+    if let Some(distribution_posture) = record.distribution_posture.as_ref() {
+        validate_surface_app_distribution_posture(
+            distribution_posture,
+            "surface app manifest version distributionPosture",
+        )?;
+    }
     Ok(())
 }
 
@@ -5131,6 +5335,12 @@ pub fn validate_surface_app_manifest(record: &SurfaceAppManifestRecord) -> Resul
         &record.blocked_reasons,
         "surface app manifest missing blockedReasons",
     )?;
+    if let Some(distribution_posture) = record.distribution_posture.as_ref() {
+        validate_surface_app_distribution_posture(
+            distribution_posture,
+            "surface app manifest distributionPosture",
+        )?;
+    }
     validate_safe_facts(&record.safe_facts, "surface app manifest safeFacts")?;
     if record.issued_at == 0 {
         return Err(anyhow!("surface app manifest missing issuedAt"));
@@ -6200,6 +6410,38 @@ fn validate_surface_app_manifest_version_state(state: &str) -> Result<()> {
         Ok(())
     } else {
         Err(anyhow!("unsupported surface app manifest version state"))
+    }
+}
+
+fn validate_surface_app_distribution_posture_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        SURFACE_APP_DISTRIBUTION_PENDING
+            | SURFACE_APP_DISTRIBUTION_RETAINED
+            | SURFACE_APP_DISTRIBUTION_DEGRADED
+            | SURFACE_APP_DISTRIBUTION_BLOCKED
+            | SURFACE_APP_DISTRIBUTION_SUPERSEDED
+            | SURFACE_APP_DISTRIBUTION_IGNORED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "unsupported surface app distribution posture state"
+        ))
+    }
+}
+
+fn validate_surface_app_schema_posture_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        SURFACE_APP_SCHEMA_COMPATIBLE
+            | SURFACE_APP_SCHEMA_MIGRATION_REQUIRED
+            | SURFACE_APP_SCHEMA_IGNORE
+            | SURFACE_APP_SCHEMA_BLOCKED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported surface app schema posture state"))
     }
 }
 
@@ -9948,6 +10190,7 @@ mod tests {
                 authority_refs: vec![],
                 evidence_refs: vec![],
                 blocked_reasons: vec![],
+                distribution_posture: None,
             }],
             app_contract_refs: vec!["surface-app:nvr-ui@0.1.0".to_string()],
             required_module_roles: vec![SURFACE_MODULE_ROLE_RUNTIME_CLIENT.to_string()],
@@ -9969,6 +10212,7 @@ mod tests {
             authority_refs: vec![],
             evidence_refs: vec![],
             blocked_reasons: vec![],
+            distribution_posture: None,
             safe_facts: Value::Null,
             issued_at: 1_700_000_000,
             expires_at: Some(1_700_003_600),
@@ -9978,6 +10222,79 @@ mod tests {
         let mut missing_current = manifest.clone();
         missing_current.current_version = "0.2.0".to_string();
         assert!(validate_surface_app_manifest(&missing_current).is_err());
+
+        let distribution_posture = SurfaceAppDistributionPostureRecord {
+            state: SURFACE_APP_DISTRIBUTION_RETAINED.to_string(),
+            source_mode: Some(SURFACE_FULFILLMENT_MODE_STORAGE_OBJECT.to_string()),
+            source_refs: vec!["surface-app-source:nvr-ui@0.2.0".to_string()],
+            storage_refs: vec!["storage:object:surface-app:nvr-ui@0.2.0".to_string()],
+            pin_intent_refs: vec!["storage.pin.intent:surface-app:nvr-ui@0.2.0".to_string()],
+            pin_projection_refs: vec![
+                "storage.pin.projection:surface-app:nvr-ui@0.2.0".to_string(),
+            ],
+            release_contract_refs: vec!["service.manager.release:nvr-ui@0.2.0".to_string()],
+            retention_refs: vec!["retention:surface-app:nvr-ui@0.2.0".to_string()],
+            retention_class: Some("app-release".to_string()),
+            schema_posture: Some(SurfaceAppSchemaPostureRecord {
+                state: SURFACE_APP_SCHEMA_COMPATIBLE.to_string(),
+                schema_refs: vec!["schema:surface-app-contract:v1".to_string()],
+                migration_refs: vec![],
+                compatibility_refs: vec![],
+                ignored_refs: vec![],
+                blocked_reasons: vec![],
+                safe_facts: Value::Null,
+            }),
+            release_posture: json!({
+                "state": "releaseReady",
+                "buildRef": "build:nvr-ui@0.2.0",
+                "releaseRef": "release:nvr-ui@0.2.0"
+            }),
+            evidence_refs: vec!["proof:nvr-ui@0.2.0".to_string()],
+            blocked_reasons: vec![],
+            safe_facts: json!({ "retained": true }),
+        };
+        let mut retained_manifest = manifest.clone();
+        retained_manifest.current_app_contract_ref = "surface-app:nvr-ui@0.2.0".to_string();
+        retained_manifest.current_version = "0.2.0".to_string();
+        retained_manifest.default_source_mode =
+            Some(SURFACE_FULFILLMENT_MODE_STORAGE_OBJECT.to_string());
+        retained_manifest.distribution_posture = Some(distribution_posture.clone());
+        retained_manifest.remote_source_refs = vec!["surface-app-source:nvr-ui@0.2.0".to_string()];
+        retained_manifest.release_contract_refs =
+            vec!["service.manager.release:nvr-ui@0.2.0".to_string()];
+        retained_manifest.versions = vec![SurfaceAppManifestVersionRecord {
+            app_contract_ref: "surface-app:nvr-ui@0.2.0".to_string(),
+            version: "0.2.0".to_string(),
+            state: SURFACE_APP_MANIFEST_VERSION_CURRENT.to_string(),
+            source_mode: Some(SURFACE_FULFILLMENT_MODE_STORAGE_OBJECT.to_string()),
+            required_module_roles: vec![],
+            compatibility_window: None,
+            bundled_source_refs: vec![],
+            remote_source_refs: vec!["surface-app-source:nvr-ui@0.2.0".to_string()],
+            grant_refs: vec![],
+            runner_requirement_refs: vec![],
+            service_manager_requirement_refs: vec![],
+            module_refs: vec![],
+            compatibility_refs: vec![],
+            bootstrap_contract_ref: None,
+            release_contract_ref: Some("service.manager.release:nvr-ui@0.2.0".to_string()),
+            authority_refs: vec![],
+            evidence_refs: vec![],
+            blocked_reasons: vec![],
+            distribution_posture: Some(distribution_posture.clone()),
+        }];
+        validate_surface_app_manifest(&retained_manifest).expect("retained manifest");
+
+        let mut bad_distribution = distribution_posture;
+        bad_distribution.pin_intent_refs = vec![];
+        bad_distribution.pin_projection_refs = vec![];
+        assert!(
+            validate_surface_app_distribution_posture(
+                &bad_distribution,
+                "surface app manifest distributionPosture"
+            )
+            .is_err()
+        );
 
         let mut remote_without_release = manifest;
         remote_without_release.current_app_contract_ref = "surface-app:nvr-ui@0.2.0".to_string();
@@ -10001,6 +10318,7 @@ mod tests {
             authority_refs: vec![],
             evidence_refs: vec![],
             blocked_reasons: vec![],
+            distribution_posture: None,
         }];
         assert!(validate_surface_app_manifest(&remote_without_release).is_err());
     }

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -113,6 +113,7 @@ pub const RECORD_SERVICE_MANAGER_TRAIN_DIGEST: &str = "service.manager.train.dig
 pub const RECORD_SERVICE_MANAGER_LAB_PROOF: &str = "service.manager.labProof";
 pub const RECORD_SURFACE_APP_MANIFEST: &str = "surface.app.manifest";
 pub const RECORD_SURFACE_APP_BOOTSTRAP_CONTRACT: &str = "surface.app.bootstrap.contract";
+pub const RECORD_RUNNER_OPERATION: &str = "runner.operation";
 
 pub const SURFACE_APP_CONTRACT_STATE_DRAFT: &str = "draft";
 pub const SURFACE_APP_CONTRACT_STATE_READY: &str = "ready";
@@ -136,6 +137,24 @@ pub const SERVICE_MANAGER_PROOF_STATE_PROVED: &str = "proved";
 pub const SERVICE_MANAGER_PROOF_STATE_FAILED: &str = "failed";
 pub const SERVICE_MANAGER_PROOF_STATE_BLOCKED: &str = "blocked";
 pub const SERVICE_MANAGER_PROOF_STATE_EXPIRED: &str = "expired";
+
+pub const RUNNER_OPERATION_PREPARE: &str = "prepare";
+pub const RUNNER_OPERATION_EXECUTE: &str = "execute";
+pub const RUNNER_OPERATION_HEALTH_CHECK: &str = "healthCheck";
+pub const RUNNER_OPERATION_RELEASE: &str = "release";
+pub const RUNNER_OPERATION_ROLLBACK: &str = "rollback";
+pub const RUNNER_OPERATION_CANCEL: &str = "cancel";
+
+pub const RUNNER_OPERATION_STATE_REQUESTED: &str = "requested";
+pub const RUNNER_OPERATION_STATE_ACCEPTED: &str = "accepted";
+pub const RUNNER_OPERATION_STATE_RUNNING: &str = "running";
+pub const RUNNER_OPERATION_STATE_SUCCEEDED: &str = "succeeded";
+pub const RUNNER_OPERATION_STATE_FAILED: &str = "failed";
+pub const RUNNER_OPERATION_STATE_BLOCKED: &str = "blocked";
+pub const RUNNER_OPERATION_STATE_REJECTED: &str = "rejected";
+pub const RUNNER_OPERATION_STATE_CANCELLED: &str = "cancelled";
+pub const RUNNER_OPERATION_STATE_RELEASED: &str = "released";
+pub const RUNNER_OPERATION_STATE_SUPERSEDED: &str = "superseded";
 
 pub const SURFACE_FULFILLMENT_MODE_BUNDLED: &str = "bundled";
 pub const SURFACE_FULFILLMENT_MODE_SWARM_PACKAGE: &str = "swarmPackage";
@@ -732,6 +751,8 @@ pub enum SwarmFrameKind {
     NodeCapability,
     #[serde(rename = "runtime.activation.request")]
     RuntimeActivationRequest,
+    #[serde(rename = "runner.operation")]
+    RunnerOperation,
     #[serde(rename = "route.promise")]
     RoutePromise,
     #[serde(rename = "route.observation")]
@@ -2418,6 +2439,65 @@ pub struct AppRunnerAttestation {
     pub recipe_id: String,
     pub status: String,
     pub issued_at: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RunnerOperationRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub operation_id: String,
+    pub runner_id: String,
+    pub runner_ref: String,
+    pub host_ref: String,
+    pub requester_ref: String,
+    pub subject_ref: String,
+    pub contract_ref: String,
+    pub operation: String,
+    pub state: String,
+    #[serde(default)]
+    pub grant_refs: Vec<String>,
+    #[serde(default)]
+    pub capability_refs: Vec<String>,
+    #[serde(default)]
+    pub input_refs: Vec<String>,
+    #[serde(default)]
+    pub output_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub proof_refs: Vec<String>,
+    #[serde(default)]
+    pub release_refs: Vec<String>,
+    #[serde(default)]
+    pub resource_budget: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_posture: Option<ResourcePosture>,
+    #[serde(default)]
+    pub secret_boundary: Value,
+    #[serde(default)]
+    pub release_posture: Value,
+    #[serde(default)]
+    pub rollback_posture: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rollback_ref: Option<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub requested_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accepted_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observed_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
 }
 
 pub fn validate_swarm_frame(frame: &SwarmFrame, now: u64) -> Result<()> {
@@ -5687,6 +5767,113 @@ pub fn validate_app_runner_attestation(attestation: &AppRunnerAttestation) -> Re
     Ok(())
 }
 
+pub fn validate_runner_operation(record: &RunnerOperationRecord) -> Result<()> {
+    validate_optional_kind(&record.kind, RECORD_RUNNER_OPERATION, "runner operation")?;
+    require_non_empty(&record.operation_id, "runner operation missing operationId")?;
+    require_non_empty(&record.runner_id, "runner operation missing runnerId")?;
+    validate_resolved_member_ref(&record.runner_ref, "runner operation missing runnerRef")?;
+    require_non_empty(&record.host_ref, "runner operation missing hostRef")?;
+    require_non_empty(
+        &record.requester_ref,
+        "runner operation missing requesterRef",
+    )?;
+    require_non_empty(&record.subject_ref, "runner operation missing subjectRef")?;
+    require_non_empty(&record.contract_ref, "runner operation missing contractRef")?;
+    validate_runner_operation_kind(&record.operation)?;
+    validate_runner_operation_state(&record.state)?;
+    require_non_empty_vec(&record.grant_refs, "runner operation requires grantRefs")?;
+    validate_reference_list(
+        &record.capability_refs,
+        "runner operation missing capabilityRefs",
+    )?;
+    validate_reference_list(&record.input_refs, "runner operation missing inputRefs")?;
+    validate_reference_list(&record.output_refs, "runner operation missing outputRefs")?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "runner operation missing evidenceRefs",
+    )?;
+    validate_reference_list(&record.proof_refs, "runner operation missing proofRefs")?;
+    validate_reference_list(&record.release_refs, "runner operation missing releaseRefs")?;
+    if !record.resource_budget.is_object() {
+        return Err(anyhow!("runner operation resourceBudget must be an object"));
+    }
+    validate_safe_facts(&record.resource_budget, "runner operation resourceBudget")?;
+    if let Some(resource_posture) = &record.resource_posture {
+        validate_resource_posture(resource_posture)?;
+    }
+    validate_surface_secret_boundary_value(
+        &record.secret_boundary,
+        "runner operation secretBoundary",
+    )?;
+    validate_surface_release_posture_value(
+        &record.release_posture,
+        "runner operation releasePosture",
+    )?;
+    validate_surface_release_posture_value(
+        &record.rollback_posture,
+        "runner operation rollbackPosture",
+    )?;
+    if record.operation == RUNNER_OPERATION_RELEASE
+        && record
+            .release_ref
+            .as_deref()
+            .unwrap_or_default()
+            .trim()
+            .is_empty()
+    {
+        return Err(anyhow!("runner release operation requires releaseRef"));
+    }
+    if record.operation == RUNNER_OPERATION_ROLLBACK
+        && record
+            .rollback_ref
+            .as_deref()
+            .unwrap_or_default()
+            .trim()
+            .is_empty()
+    {
+        return Err(anyhow!("runner rollback operation requires rollbackRef"));
+    }
+    validate_optional_ref(
+        record.release_ref.as_deref(),
+        "runner operation missing releaseRef",
+    )?;
+    validate_optional_ref(
+        record.rollback_ref.as_deref(),
+        "runner operation missing rollbackRef",
+    )?;
+    validate_reference_list(
+        &record.blocked_reasons,
+        "runner operation missing blockedReasons",
+    )?;
+    if matches!(
+        record.state.as_str(),
+        RUNNER_OPERATION_STATE_BLOCKED
+            | RUNNER_OPERATION_STATE_FAILED
+            | RUNNER_OPERATION_STATE_REJECTED
+    ) && record.blocked_reasons.is_empty()
+    {
+        return Err(anyhow!(
+            "runner blocked, failed, or rejected operation requires blockedReasons"
+        ));
+    }
+    validate_safe_facts(&record.safe_facts, "runner operation safeFacts")?;
+    reject_private_content_fields(&record.safe_facts, "runner operation safeFacts")?;
+    reject_private_content_fields(&serde_json::to_value(record)?, "runner operation")?;
+    reject_media_byte_fields(&serde_json::to_value(record)?, "runner operation")?;
+    validate_operation_timeline(
+        record.requested_at,
+        &[
+            record.accepted_at,
+            record.started_at,
+            record.completed_at,
+            record.observed_at,
+        ],
+        record.expires_at,
+        "runner operation",
+    )?;
+    Ok(())
+}
+
 fn validate_frame_body(frame: &SwarmFrame) -> Result<()> {
     match frame.body.encoding.as_str() {
         "caac" => {
@@ -5899,6 +6086,113 @@ fn validate_service_manager_proof_profile(profile: &str) -> Result<()> {
     } else {
         Err(anyhow!("unsupported service manager proof profile"))
     }
+}
+
+fn validate_runner_operation_kind(operation: &str) -> Result<()> {
+    if matches!(
+        operation,
+        RUNNER_OPERATION_PREPARE
+            | RUNNER_OPERATION_EXECUTE
+            | RUNNER_OPERATION_HEALTH_CHECK
+            | RUNNER_OPERATION_RELEASE
+            | RUNNER_OPERATION_ROLLBACK
+            | RUNNER_OPERATION_CANCEL
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("invalid runner operation"))
+    }
+}
+
+fn validate_runner_operation_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        RUNNER_OPERATION_STATE_REQUESTED
+            | RUNNER_OPERATION_STATE_ACCEPTED
+            | RUNNER_OPERATION_STATE_RUNNING
+            | RUNNER_OPERATION_STATE_SUCCEEDED
+            | RUNNER_OPERATION_STATE_FAILED
+            | RUNNER_OPERATION_STATE_BLOCKED
+            | RUNNER_OPERATION_STATE_REJECTED
+            | RUNNER_OPERATION_STATE_CANCELLED
+            | RUNNER_OPERATION_STATE_RELEASED
+            | RUNNER_OPERATION_STATE_SUPERSEDED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("invalid runner operation state"))
+    }
+}
+
+fn validate_surface_secret_boundary_value(value: &Value, context: &str) -> Result<()> {
+    if value.is_null() {
+        return Ok(());
+    }
+    let object = value
+        .as_object()
+        .ok_or_else(|| anyhow!("{context} must be an object"))?;
+    validate_surface_secret_boundary_state(
+        object
+            .get("state")
+            .and_then(Value::as_str)
+            .unwrap_or_default(),
+    )?;
+    reject_private_content_fields(value, context)?;
+    validate_safe_facts(value, context)?;
+    Ok(())
+}
+
+fn validate_surface_release_posture_value(value: &Value, context: &str) -> Result<()> {
+    if value.is_null() {
+        return Ok(());
+    }
+    let object = value
+        .as_object()
+        .ok_or_else(|| anyhow!("{context} must be an object"))?;
+    let state = object
+        .get("state")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    if !matches!(
+        state,
+        "static" | "buildReady" | "releaseReady" | "rollbackReady" | "blocked" | "unavailable"
+    ) {
+        return Err(anyhow!("unsupported surface release posture state"));
+    }
+    if state == "blocked"
+        && object
+            .get("blockedReasons")
+            .and_then(Value::as_array)
+            .map(Vec::is_empty)
+            .unwrap_or(true)
+    {
+        return Err(anyhow!("{context} blocked state requires blockedReasons"));
+    }
+    reject_private_content_fields(value, context)?;
+    validate_safe_facts(value, context)?;
+    Ok(())
+}
+
+fn validate_operation_timeline(
+    requested_at: u64,
+    checkpoints: &[Option<u64>],
+    expires_at: Option<u64>,
+    context: &str,
+) -> Result<()> {
+    if requested_at == 0 {
+        return Err(anyhow!("{context} missing requestedAt"));
+    }
+    for checkpoint in checkpoints.iter().flatten() {
+        if *checkpoint < requested_at {
+            return Err(anyhow!(
+                "{context} lifecycle timestamp must not be before requestedAt"
+            ));
+        }
+    }
+    if expires_at.is_some_and(|expires_at| expires_at <= requested_at) {
+        return Err(anyhow!("{context} expiresAt must be after requestedAt"));
+    }
+    Ok(())
 }
 
 fn validate_surface_fulfillment_mode(mode: &str) -> Result<()> {
@@ -7732,6 +8026,7 @@ fn frame_is_propagating(kind: &SwarmFrameKind) -> bool {
             | SwarmFrameKind::StoragePinAttestation
             | SwarmFrameKind::NodeCapability
             | SwarmFrameKind::RuntimeActivationRequest
+            | SwarmFrameKind::RunnerOperation
             | SwarmFrameKind::RoutePromise
             | SwarmFrameKind::RouteObservation
             | SwarmFrameKind::StreamRoutePlan
@@ -8189,6 +8484,81 @@ mod tests {
             expires_at: Some(1_700_000_500),
         };
         validate_app_runner_advertisement(&runner).expect("valid runner");
+
+        let runner_ref = pubkey_from_sk_hex(BROWSER_SK).expect("browser pk");
+        let runner_operation = RunnerOperationRecord {
+            kind: Some(RECORD_RUNNER_OPERATION.to_string()),
+            operation_id: "runner-operation:security-bootstrap:execute:1".to_string(),
+            runner_id: "runner:lab-gateway:security-bootstrap".to_string(),
+            runner_ref: runner_ref.clone(),
+            host_ref: "host:lab-gateway".to_string(),
+            requester_ref: "identity:aux".to_string(),
+            subject_ref: "security-processor:dev".to_string(),
+            contract_ref: "security-processor:seed@0.1.0".to_string(),
+            operation: RUNNER_OPERATION_EXECUTE.to_string(),
+            state: RUNNER_OPERATION_STATE_SUCCEEDED.to_string(),
+            grant_refs: vec!["authority-grant:runner:security-bootstrap".to_string()],
+            capability_refs: vec![CAPABILITY_APP_RUNNER_PIN.to_string()],
+            input_refs: vec!["event-fabric:security-audit".to_string()],
+            output_refs: vec!["alert-hold:security-bootstrap:1".to_string()],
+            evidence_refs: vec![
+                "evidence:runner:started".to_string(),
+                "evidence:runner:completed".to_string(),
+            ],
+            proof_refs: vec!["proof:runner:security-bootstrap".to_string()],
+            release_refs: vec!["release:runner:security-bootstrap".to_string()],
+            resource_budget: json!({
+                "profileRef": "resource-profile:operator-dev",
+                "maxMemoryMiB": 512,
+                "maxCpuPct": 40
+            }),
+            resource_posture: Some(ResourcePosture {
+                kind: Some(RECORD_RESOURCE_POSTURE.to_string()),
+                posture_id: "resource-posture:runner:security-bootstrap".to_string(),
+                profile_id: "resource-profile:operator-dev".to_string(),
+                state: "withinBudget".to_string(),
+                counts: json!({ "memoryMiB": 120, "cpuPct": 8 }),
+                budgets: json!({ "memoryMiB": 512, "cpuPct": 40 }),
+                blocked_reasons: vec![],
+                sampled_at: 1_700_000_015,
+            }),
+            secret_boundary: json!({ "state": SURFACE_SECRET_BOUNDARY_NOT_REQUIRED }),
+            release_posture: json!({
+                "state": "rollbackReady",
+                "buildRef": "build:runner:security-bootstrap",
+                "releaseRef": "release:runner:security-bootstrap",
+                "rollbackRef": "rollback:runner:security-bootstrap"
+            }),
+            rollback_posture: Value::Null,
+            release_ref: Some("release:runner:security-bootstrap".to_string()),
+            rollback_ref: Some("rollback:runner:security-bootstrap".to_string()),
+            blocked_reasons: vec![],
+            safe_facts: json!({ "role": "securityProcessor", "mode": "operatorDev" }),
+            requested_at: 1_700_000_000,
+            accepted_at: Some(1_700_000_001),
+            started_at: Some(1_700_000_002),
+            completed_at: Some(1_700_000_012),
+            observed_at: Some(1_700_000_015),
+            expires_at: Some(1_700_003_600),
+        };
+        validate_runner_operation(&runner_operation).expect("valid runner operation");
+
+        let mut missing_grant = runner_operation.clone();
+        missing_grant.grant_refs.clear();
+        assert!(validate_runner_operation(&missing_grant).is_err());
+
+        let mut missing_rollback = runner_operation.clone();
+        missing_rollback.operation = RUNNER_OPERATION_ROLLBACK.to_string();
+        missing_rollback.rollback_ref = Some(String::new());
+        assert!(validate_runner_operation(&missing_rollback).is_err());
+
+        let mut blocked_without_reason = runner_operation.clone();
+        blocked_without_reason.state = RUNNER_OPERATION_STATE_BLOCKED.to_string();
+        assert!(validate_runner_operation(&blocked_without_reason).is_err());
+
+        let mut unsafe_fact = runner_operation;
+        unsafe_fact.safe_facts = json!({ "token": "inline-secret" });
+        assert!(validate_runner_operation(&unsafe_fact).is_err());
     }
 
     #[test]

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -114,6 +114,7 @@ pub const RECORD_SERVICE_MANAGER_LAB_PROOF: &str = "service.manager.labProof";
 pub const RECORD_SURFACE_APP_MANIFEST: &str = "surface.app.manifest";
 pub const RECORD_SURFACE_APP_BOOTSTRAP_CONTRACT: &str = "surface.app.bootstrap.contract";
 pub const RECORD_RUNNER_OPERATION: &str = "runner.operation";
+pub const RECORD_APP_RUNNER_FULFILLMENT_REPORT: &str = "app.runner.fulfillment.report";
 
 pub const SURFACE_APP_CONTRACT_STATE_DRAFT: &str = "draft";
 pub const SURFACE_APP_CONTRACT_STATE_READY: &str = "ready";
@@ -167,6 +168,16 @@ pub const RUNNER_OPERATION_STATE_REJECTED: &str = "rejected";
 pub const RUNNER_OPERATION_STATE_CANCELLED: &str = "cancelled";
 pub const RUNNER_OPERATION_STATE_RELEASED: &str = "released";
 pub const RUNNER_OPERATION_STATE_SUPERSEDED: &str = "superseded";
+pub const RUNNER_FULFILLMENT_STATE_REQUESTED: &str = "requested";
+pub const RUNNER_FULFILLMENT_STATE_ACCEPTED: &str = "accepted";
+pub const RUNNER_FULFILLMENT_STATE_RUNNING: &str = "running";
+pub const RUNNER_FULFILLMENT_STATE_SUCCEEDED: &str = "succeeded";
+pub const RUNNER_FULFILLMENT_STATE_RELEASED: &str = "released";
+pub const RUNNER_FULFILLMENT_STATE_ROLLED_BACK: &str = "rolledBack";
+pub const RUNNER_FULFILLMENT_STATE_BLOCKED: &str = "blocked";
+pub const RUNNER_FULFILLMENT_STATE_FAILED: &str = "failed";
+pub const RUNNER_FULFILLMENT_STATE_REJECTED: &str = "rejected";
+pub const RUNNER_FULFILLMENT_STATE_CANCELLED: &str = "cancelled";
 
 pub const SURFACE_FULFILLMENT_MODE_BUNDLED: &str = "bundled";
 pub const SURFACE_FULFILLMENT_MODE_SWARM_PACKAGE: &str = "swarmPackage";
@@ -2613,6 +2624,73 @@ pub struct RunnerOperationRecord {
     pub completed_at: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub observed_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AppRunnerFulfillmentReport {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub report_id: String,
+    pub runner_id: String,
+    pub runner_ref: String,
+    pub host_ref: String,
+    pub runner_operation_id: String,
+    pub operation: String,
+    pub state: String,
+    pub requester_ref: String,
+    pub subject_ref: String,
+    pub contract_ref: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_contract_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_ref: Option<String>,
+    pub source_mode: String,
+    #[serde(default)]
+    pub source_refs: Vec<String>,
+    #[serde(default)]
+    pub grant_refs: Vec<String>,
+    #[serde(default)]
+    pub capability_refs: Vec<String>,
+    #[serde(default)]
+    pub input_refs: Vec<String>,
+    #[serde(default)]
+    pub output_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub proof_refs: Vec<String>,
+    #[serde(default)]
+    pub release_refs: Vec<String>,
+    #[serde(default)]
+    pub resource_budget: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_posture: Option<ResourcePosture>,
+    #[serde(default)]
+    pub secret_boundary: Value,
+    #[serde(default)]
+    pub release_posture: Value,
+    #[serde(default)]
+    pub rollback_posture: Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rollback_ref: Option<String>,
+    #[serde(default)]
+    pub operation_posture: Value,
+    #[serde(default)]
+    pub fulfillment_posture: Value,
+    #[serde(default)]
+    pub safe_facts: Value,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    pub observed_at: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<u64>,
 }
@@ -6244,6 +6322,219 @@ pub fn validate_runner_operation(record: &RunnerOperationRecord) -> Result<()> {
     Ok(())
 }
 
+pub fn validate_app_runner_fulfillment_report(record: &AppRunnerFulfillmentReport) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_APP_RUNNER_FULFILLMENT_REPORT,
+        "app runner fulfillment report",
+    )?;
+    require_non_empty(
+        &record.report_id,
+        "app runner fulfillment report missing reportId",
+    )?;
+    require_non_empty(
+        &record.runner_id,
+        "app runner fulfillment report missing runnerId",
+    )?;
+    validate_resolved_member_ref(
+        &record.runner_ref,
+        "app runner fulfillment report missing runnerRef",
+    )?;
+    require_non_empty(
+        &record.host_ref,
+        "app runner fulfillment report missing hostRef",
+    )?;
+    require_non_empty(
+        &record.runner_operation_id,
+        "app runner fulfillment report missing runnerOperationId",
+    )?;
+    validate_runner_operation_kind(&record.operation)?;
+    validate_runner_fulfillment_state(&record.state)?;
+    require_non_empty(
+        &record.requester_ref,
+        "app runner fulfillment report missing requesterRef",
+    )?;
+    require_non_empty(
+        &record.subject_ref,
+        "app runner fulfillment report missing subjectRef",
+    )?;
+    require_non_empty(
+        &record.contract_ref,
+        "app runner fulfillment report missing contractRef",
+    )?;
+    validate_optional_ref(
+        record.app_contract_ref.as_deref(),
+        "app runner fulfillment report missing appContractRef",
+    )?;
+    validate_optional_ref(
+        record.app_id.as_deref(),
+        "app runner fulfillment report missing appId",
+    )?;
+    validate_optional_ref(
+        record.version.as_deref(),
+        "app runner fulfillment report missing version",
+    )?;
+    validate_optional_ref(
+        record.manifest_ref.as_deref(),
+        "app runner fulfillment report missing manifestRef",
+    )?;
+    validate_surface_fulfillment_mode(&record.source_mode)?;
+    validate_reference_list(
+        &record.source_refs,
+        "app runner fulfillment report missing sourceRefs",
+    )?;
+    require_non_empty_vec(
+        &record.grant_refs,
+        "app runner fulfillment report requires grantRefs",
+    )?;
+    validate_reference_list(
+        &record.capability_refs,
+        "app runner fulfillment report missing capabilityRefs",
+    )?;
+    validate_reference_list(
+        &record.input_refs,
+        "app runner fulfillment report missing inputRefs",
+    )?;
+    validate_reference_list(
+        &record.output_refs,
+        "app runner fulfillment report missing outputRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "app runner fulfillment report missing evidenceRefs",
+    )?;
+    validate_reference_list(
+        &record.proof_refs,
+        "app runner fulfillment report missing proofRefs",
+    )?;
+    validate_reference_list(
+        &record.release_refs,
+        "app runner fulfillment report missing releaseRefs",
+    )?;
+    validate_reference_list(
+        &record.blocked_reasons,
+        "app runner fulfillment report missing blockedReasons",
+    )?;
+    if !record.resource_budget.is_object() {
+        return Err(anyhow!(
+            "app runner fulfillment report resourceBudget must be an object"
+        ));
+    }
+    validate_safe_facts(
+        &record.resource_budget,
+        "app runner fulfillment report resourceBudget",
+    )?;
+    if let Some(resource_posture) = &record.resource_posture {
+        validate_resource_posture(resource_posture)?;
+    }
+    validate_surface_secret_boundary_value(
+        &record.secret_boundary,
+        "app runner fulfillment report secretBoundary",
+    )?;
+    validate_surface_release_posture_value(
+        &record.release_posture,
+        "app runner fulfillment report releasePosture",
+    )?;
+    validate_surface_release_posture_value(
+        &record.rollback_posture,
+        "app runner fulfillment report rollbackPosture",
+    )?;
+    validate_optional_ref(
+        record.release_ref.as_deref(),
+        "app runner fulfillment report missing releaseRef",
+    )?;
+    validate_optional_ref(
+        record.rollback_ref.as_deref(),
+        "app runner fulfillment report missing rollbackRef",
+    )?;
+    validate_runner_posture_object(
+        &record.operation_posture,
+        &record.state,
+        "app runner fulfillment report operationPosture",
+    )?;
+    validate_runner_posture_object(
+        &record.fulfillment_posture,
+        &record.state,
+        "app runner fulfillment report fulfillmentPosture",
+    )?;
+    if matches!(
+        record.state.as_str(),
+        RUNNER_FULFILLMENT_STATE_BLOCKED
+            | RUNNER_FULFILLMENT_STATE_FAILED
+            | RUNNER_FULFILLMENT_STATE_REJECTED
+            | RUNNER_FULFILLMENT_STATE_CANCELLED
+    ) && record.blocked_reasons.is_empty()
+    {
+        return Err(anyhow!(
+            "blocked app runner fulfillment requires blockedReasons"
+        ));
+    }
+    if record.state == RUNNER_FULFILLMENT_STATE_SUCCEEDED
+        && record.output_refs.is_empty()
+        && record.proof_refs.is_empty()
+    {
+        return Err(anyhow!(
+            "succeeded app runner fulfillment requires outputRefs or proofRefs"
+        ));
+    }
+    if record.state == RUNNER_FULFILLMENT_STATE_SUCCEEDED && record.source_refs.is_empty() {
+        return Err(anyhow!(
+            "succeeded app runner fulfillment requires sourceRefs"
+        ));
+    }
+    if record.state == RUNNER_FULFILLMENT_STATE_RELEASED
+        && record.release_refs.is_empty()
+        && record
+            .release_ref
+            .as_deref()
+            .unwrap_or_default()
+            .trim()
+            .is_empty()
+    {
+        return Err(anyhow!(
+            "released app runner fulfillment requires releaseRefs or releaseRef"
+        ));
+    }
+    if record.state == RUNNER_FULFILLMENT_STATE_ROLLED_BACK
+        && record
+            .rollback_ref
+            .as_deref()
+            .unwrap_or_default()
+            .trim()
+            .is_empty()
+    {
+        return Err(anyhow!(
+            "rolledBack app runner fulfillment requires rollbackRef"
+        ));
+    }
+    validate_safe_facts(
+        &record.safe_facts,
+        "app runner fulfillment report safeFacts",
+    )?;
+    reject_private_content_fields(
+        &serde_json::to_value(record)?,
+        "app runner fulfillment report",
+    )?;
+    reject_media_byte_fields(
+        &serde_json::to_value(record)?,
+        "app runner fulfillment report",
+    )?;
+    if record.observed_at == 0 {
+        return Err(anyhow!(
+            "app runner fulfillment report missing observedAt"
+        ));
+    }
+    if record
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= record.observed_at)
+    {
+        return Err(anyhow!(
+            "app runner fulfillment report expiresAt must be after observedAt"
+        ));
+    }
+    Ok(())
+}
+
 fn validate_frame_body(frame: &SwarmFrame) -> Result<()> {
     match frame.body.encoding.as_str() {
         "caac" => {
@@ -6524,6 +6815,43 @@ fn validate_runner_operation_state(state: &str) -> Result<()> {
     } else {
         Err(anyhow!("invalid runner operation state"))
     }
+}
+
+fn validate_runner_fulfillment_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        RUNNER_FULFILLMENT_STATE_REQUESTED
+            | RUNNER_FULFILLMENT_STATE_ACCEPTED
+            | RUNNER_FULFILLMENT_STATE_RUNNING
+            | RUNNER_FULFILLMENT_STATE_SUCCEEDED
+            | RUNNER_FULFILLMENT_STATE_RELEASED
+            | RUNNER_FULFILLMENT_STATE_ROLLED_BACK
+            | RUNNER_FULFILLMENT_STATE_BLOCKED
+            | RUNNER_FULFILLMENT_STATE_FAILED
+            | RUNNER_FULFILLMENT_STATE_REJECTED
+            | RUNNER_FULFILLMENT_STATE_CANCELLED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("invalid runner fulfillment state"))
+    }
+}
+
+fn validate_runner_posture_object(value: &Value, state: &str, context: &str) -> Result<()> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| anyhow!("{context} must be an object"))?;
+    if object.is_empty() {
+        return Err(anyhow!("{context} must be an object"));
+    }
+    if let Some(posture_state) = object.get("state").and_then(Value::as_str) {
+        if posture_state != state {
+            return Err(anyhow!("{context} state must match state"));
+        }
+    }
+    validate_safe_facts(value, context)?;
+    reject_private_content_fields(value, context)?;
+    Ok(())
 }
 
 fn validate_surface_secret_boundary_value(value: &Value, context: &str) -> Result<()> {
@@ -8944,6 +9272,117 @@ mod tests {
             expires_at: Some(1_700_003_600),
         };
         validate_runner_operation(&runner_operation).expect("valid runner operation");
+
+        let fulfillment_report = AppRunnerFulfillmentReport {
+            kind: Some(RECORD_APP_RUNNER_FULFILLMENT_REPORT.to_string()),
+            report_id: "app-runner:runner:app-proof:runner-operation:app-proof:execute:1"
+                .to_string(),
+            runner_id: "runner:lab-gateway:app-proof".to_string(),
+            runner_ref: runner_ref.clone(),
+            host_ref: "host:lab-gateway".to_string(),
+            runner_operation_id: "runner-operation:app-proof:execute:1".to_string(),
+            operation: RUNNER_OPERATION_EXECUTE.to_string(),
+            state: RUNNER_FULFILLMENT_STATE_SUCCEEDED.to_string(),
+            requester_ref: "identity:aux".to_string(),
+            subject_ref: "app:runner-proof".to_string(),
+            contract_ref: "app:runner-proof".to_string(),
+            app_contract_ref: Some("app:runner-proof".to_string()),
+            app_id: Some("constitute-runner-proof".to_string()),
+            version: Some("0.1.0".to_string()),
+            manifest_ref: Some("manifest:runner-proof".to_string()),
+            source_mode: SURFACE_FULFILLMENT_MODE_BUNDLED.to_string(),
+            source_refs: vec!["bundle:runner-proof@0.1.0".to_string()],
+            grant_refs: vec!["grant:app:runner-proof:run".to_string()],
+            capability_refs: vec![CAPABILITY_APP_RUNNER_PIN.to_string()],
+            input_refs: vec![
+                "manifest:runner-proof".to_string(),
+                "app:runner-proof".to_string(),
+            ],
+            output_refs: vec!["artifact:runner-proof:dist".to_string()],
+            evidence_refs: vec![
+                "evidence:runner:accepted".to_string(),
+                "evidence:runner:completed".to_string(),
+            ],
+            proof_refs: vec!["proof:runner-proof:surface".to_string()],
+            release_refs: vec!["release:runner-proof".to_string()],
+            resource_budget: json!({
+                "profileRef": "resource-profile:operator-dev",
+                "maxMemoryMiB": 256,
+                "maxCpuPct": 25
+            }),
+            resource_posture: Some(ResourcePosture {
+                kind: Some(RECORD_RESOURCE_POSTURE.to_string()),
+                posture_id: "resource-posture:runner:app-proof".to_string(),
+                profile_id: "resource-profile:operator-dev".to_string(),
+                state: "withinBudget".to_string(),
+                counts: json!({ "memoryMiB": 96, "cpuPct": 4 }),
+                budgets: json!({ "memoryMiB": 256, "cpuPct": 25 }),
+                blocked_reasons: vec![],
+                sampled_at: 1_700_000_020,
+            }),
+            secret_boundary: json!({ "state": SURFACE_SECRET_BOUNDARY_NOT_REQUIRED }),
+            release_posture: json!({
+                "state": "rollbackReady",
+                "buildRef": "build:runner-proof",
+                "releaseRef": "release:runner-proof",
+                "rollbackRef": "rollback:runner-proof"
+            }),
+            rollback_posture: Value::Null,
+            release_ref: Some("release:runner-proof".to_string()),
+            rollback_ref: Some("rollback:runner-proof".to_string()),
+            operation_posture: json!({
+                "state": RUNNER_FULFILLMENT_STATE_SUCCEEDED,
+                "accepted": true,
+                "requestedAt": 1_700_000_000u64,
+                "acceptedAt": 1_700_000_001u64,
+                "startedAt": 1_700_000_002u64,
+                "completedAt": 1_700_000_019u64,
+                "observedAt": 1_700_000_020u64
+            }),
+            fulfillment_posture: json!({
+                "state": RUNNER_FULFILLMENT_STATE_SUCCEEDED,
+                "outputRefs": ["artifact:runner-proof:dist"],
+                "releaseRefs": ["release:runner-proof"],
+                "proofRefs": ["proof:runner-proof:surface"],
+                "evidenceRefs": ["evidence:runner:completed"]
+            }),
+            safe_facts: json!({
+                "appId": "constitute-runner-proof",
+                "version": "0.1.0",
+                "sourceMode": SURFACE_FULFILLMENT_MODE_BUNDLED,
+                "outputRefCount": 1,
+                "releaseRefCount": 1,
+                "proofRefCount": 1
+            }),
+            blocked_reasons: vec![],
+            observed_at: 1_700_000_020,
+            expires_at: Some(1_700_003_600),
+        };
+        validate_app_runner_fulfillment_report(&fulfillment_report)
+            .expect("valid app runner fulfillment report");
+
+        let mut missing_output_or_proof = fulfillment_report.clone();
+        missing_output_or_proof.report_id = "app-runner:bad:missing-proof".to_string();
+        missing_output_or_proof.output_refs.clear();
+        missing_output_or_proof.proof_refs.clear();
+        assert!(validate_app_runner_fulfillment_report(&missing_output_or_proof).is_err());
+
+        let mut missing_source_refs = fulfillment_report.clone();
+        missing_source_refs.report_id = "app-runner:bad:missing-source".to_string();
+        missing_source_refs.source_refs.clear();
+        assert!(validate_app_runner_fulfillment_report(&missing_source_refs).is_err());
+
+        let mut blocked_without_reason_report = fulfillment_report.clone();
+        blocked_without_reason_report.report_id = "app-runner:bad:blocked".to_string();
+        blocked_without_reason_report.state = RUNNER_FULFILLMENT_STATE_BLOCKED.to_string();
+        blocked_without_reason_report.operation_posture = json!({ "state": RUNNER_FULFILLMENT_STATE_BLOCKED });
+        blocked_without_reason_report.fulfillment_posture =
+            json!({ "state": RUNNER_FULFILLMENT_STATE_BLOCKED });
+        assert!(validate_app_runner_fulfillment_report(&blocked_without_reason_report).is_err());
+
+        let mut unsafe_report = fulfillment_report;
+        unsafe_report.safe_facts = json!({ "token": "inline-secret" });
+        assert!(validate_app_runner_fulfillment_report(&unsafe_report).is_err());
 
         let mut missing_grant = runner_operation.clone();
         missing_grant.grant_refs.clear();

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -774,16 +774,40 @@ test("surface app manifests pin versioned app contracts and block unproven remot
         version: "0.1.0",
         state: SURFACE_APP.MANIFEST_VERSION_STATE.CURRENT,
         sourceMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+        requiredModuleRoles: [SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT],
+        compatibilityWindow: {
+          minVersion: "0.1.0",
+          maxVersion: "0.1.x",
+          protocolRef: "protocol:surface-app:v1",
+          schemaRefs: ["schema:surface-app-contract:v1"],
+        },
+        bundledSourceRefs: ["bundle:constitute-nvr-ui@0.1.0"],
+        grantRefs: ["grant:app:nvr-ui:run"],
+        runnerRequirementRefs: ["runner:req:nvr-ui"],
+        serviceManagerRequirementRefs: ["service-manager:req:nvr-ui"],
         moduleRefs: ["constitute-ui/runtime-surface-client@0.1.0"],
         compatibilityRefs: ["protocol:surface-app:v1"],
       },
     ],
     appContractRefs: ["surface-app:nvr-ui@0.1.0"],
+    requiredModuleRoles: [SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT],
+    compatibilityWindow: {
+      minVersion: "0.1.0",
+      maxVersion: "0.1.x",
+      protocolRef: "protocol:surface-app:v1",
+      schemaRefs: ["schema:surface-app-contract:v1"],
+    },
+    bundledSourceRefs: ["bundle:constitute-nvr-ui@0.1.0"],
+    grantRefs: ["grant:app:nvr-ui:run"],
+    runnerRequirementRefs: ["runner:req:nvr-ui"],
+    serviceManagerRequirementRefs: ["service-manager:req:nvr-ui"],
     compatibilityRefs: ["protocol:surface-app:v1"],
     issuedAt,
     expiresAt: issuedAt + 3600,
   });
   assert.equal(manifest.currentAppContractRef, "surface-app:nvr-ui@0.1.0");
+  assert.deepEqual(manifest.requiredModuleRoles, [SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT]);
+  assert.equal(manifest.compatibilityWindow.protocolRef, "protocol:surface-app:v1");
 
   assert.throws(() => assertSurfaceAppManifest({
     ...manifest,
@@ -798,6 +822,7 @@ test("surface app manifests pin versioned app contracts and block unproven remot
         version: "0.2.0",
         state: SURFACE_APP.MANIFEST_VERSION_STATE.CURRENT,
         sourceMode: SURFACE_APP.FULFILLMENT_MODE.SWARM_PACKAGE,
+        remoteSourceRefs: ["swarm-package:nvr-ui@0.2.0"],
       },
     ],
     currentAppContractRef: "surface-app:nvr-ui@0.2.0",

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -91,9 +91,16 @@ import {
   assertServiceManagerOperationPosture,
   assertServiceManagerProofDigest,
   assertSurfaceAppManifest,
+  assertSurfaceAppManifestSelection,
+  assertSurfaceAppManifestRunnerPlan,
+  assertSurfaceAppRuntimeSelectionPosture,
+  assertSurfaceAppInstancePosture,
+  assertSurfaceAppRunnerPlan,
   assertSurfaceAppDistributionPosture,
   assertSurfaceAppBootstrapContract,
   assertSurfaceAppBootstrapPosture,
+  assertSurfaceModuleRolePosture,
+  assertSurfaceAppModuleBindingPosture,
   assertSurfaceAppContract,
   assertSurfaceModuleClaim,
   assertAccessEpoch,
@@ -890,6 +897,178 @@ test("surface app manifests pin versioned app contracts and block unproven remot
       state: SURFACE_APP.SCHEMA_POSTURE.MIGRATION_REQUIRED,
     },
   }), /migrationRequired state requires migrationRefs or blockedReasons/);
+});
+
+test("surface app instance grammar validates clean selection and runner posture records", () => {
+  const issuedAt = 1700000000;
+  const moduleClaim = {
+    moduleRef: "constitute-ui/runtime-surface-client@0.1.0",
+    role: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+    participantSide: SURFACE_APP.PARTICIPANT_SIDE.WINDOW,
+    fulfillmentMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+    version: "0.1.0",
+    primitiveRefs: ["runtime.attach"],
+    requiredCapabilities: ["runtime.snapshot.subscribe"],
+    inputs: ["runtime.snapshot"],
+    outputs: ["runtime.intent"],
+    issuedAt,
+  };
+  const modulePosture = assertSurfaceModuleRolePosture({
+    kind: SWARM.RECORD_KIND.SURFACE_MODULE_ROLE_POSTURE,
+    state: "ready",
+    blockedReason: "",
+    role: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+    moduleRef: "",
+    primitiveRef: "",
+    moduleCount: 1,
+    modules: [moduleClaim],
+  });
+  const bootstrapContract = assertSurfaceAppBootstrapContract({
+    kind: SWARM.RECORD_KIND.SURFACE_APP_BOOTSTRAP_CONTRACT,
+    bootstrapContractId: "bootstrap:logging-ui@0.1.0",
+    appContractRef: "surface-app:logging-ui@0.1.0",
+    appId: "constitute-logging-ui",
+    state: SURFACE_APP.SERVICE_MANAGER_CONTRACT_STATE.READY,
+    sourceMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+    moduleRefs: [moduleClaim.moduleRef],
+    secretBoundary: { state: SURFACE_APP.SECRET_BOUNDARY.NOT_REQUIRED },
+    issuedAt,
+  });
+  const runnerPlan = assertSurfaceAppRunnerPlan({
+    kind: SWARM.RECORD_KIND.SURFACE_APP_RUNNER_PLAN,
+    planId: "surface-runner:logging-ui",
+    contractId: "surface-app:logging-ui@0.1.0",
+    appId: "constitute-logging-ui",
+    state: "ready",
+    sourceMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+    attachContext: {
+      kind: "surface.app.attachContext",
+      contractId: "surface-app:logging-ui@0.1.0",
+      appId: "constitute-logging-ui",
+    },
+    modulePostures: [modulePosture],
+    secretBoundary: { state: SURFACE_APP.SECRET_BOUNDARY.NOT_REQUIRED },
+    bootstrapContract,
+    blockedReasons: [],
+    issuedAt,
+  });
+  const manifestSelection = assertSurfaceAppManifestSelection({
+    kind: SWARM.RECORD_KIND.SURFACE_APP_MANIFEST_SELECTION,
+    manifestId: "surface-app-manifest:logging-ui",
+    appId: "constitute-logging-ui",
+    state: "ready",
+    appContractRef: "surface-app:logging-ui@0.1.0",
+    version: "0.1.0",
+    sourceMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+    claimState: SURFACE_APP.MANIFEST_VERSION_STATE.CURRENT,
+    requiredModuleRoles: [SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT],
+    bundledSourceRefs: ["bundle:logging-ui@0.1.0"],
+    runnerRequirementRefs: ["runner:req:logging-ui"],
+    compatibilityRefs: ["protocol:surface-app:v1"],
+    bundledContractAvailable: true,
+    claim: {
+      appContractRef: "surface-app:logging-ui@0.1.0",
+      version: "0.1.0",
+      state: SURFACE_APP.MANIFEST_VERSION_STATE.CURRENT,
+      sourceMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      bundledSourceRefs: ["bundle:logging-ui@0.1.0"],
+    },
+    issuedAt,
+  });
+  const manifestRunnerPlan = assertSurfaceAppManifestRunnerPlan({
+    kind: SWARM.RECORD_KIND.SURFACE_APP_MANIFEST_RUNNER_PLAN,
+    planId: "surface-runner:logging-ui",
+    state: "ready",
+    manifestSelection,
+    runnerPlan,
+    blockedReasons: [],
+    issuedAt,
+  });
+  const runtimeSelection = assertSurfaceAppRuntimeSelectionPosture({
+    kind: SWARM.RECORD_KIND.SURFACE_APP_RUNTIME_SELECTION_POSTURE,
+    selectionId: "runtime-selection:logging-ui",
+    state: "ready",
+    requestedAppRef: "surface-app:logging-ui@0.1.0",
+    requestedVersion: "0.1.0",
+    manifestId: "surface-app-manifest:logging-ui",
+    appId: "constitute-logging-ui",
+    pinnedAppContractRef: "surface-app:logging-ui@0.1.0",
+    pinnedVersion: "0.1.0",
+    sourceMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+    requiredModuleRoles: [SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT],
+    compatibilityResult: {
+      kind: "surface.app.runtime.compatibility.result",
+      state: "ready",
+      blockedReasons: [],
+    },
+    sourceTrustResult: {
+      kind: "surface.app.runtime.source.trust.result",
+      state: "ready",
+      blockedReasons: [],
+    },
+    modulePostures: [modulePosture],
+    runnerReadiness: {
+      kind: "surface.app.runtime.runner.readiness",
+      state: "ready",
+      blockedReasons: [],
+    },
+    serviceManagerReadiness: {
+      kind: "surface.app.runtime.service-manager.readiness",
+      state: "unknown",
+      blockedReasons: [],
+    },
+    manifestSelection,
+    manifestRunnerPlan,
+    runnerPlan,
+    blockedReasons: [],
+    issuedAt,
+  });
+  const moduleBindingPosture = assertSurfaceAppModuleBindingPosture({
+    kind: SWARM.RECORD_KIND.SURFACE_APP_MODULE_BINDING_POSTURE,
+    state: "ready",
+    roles: [SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT],
+    keys: [SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT],
+    moduleRefs: [moduleClaim.moduleRef],
+    implementationRefs: [moduleClaim.moduleRef],
+    blockedReasons: [],
+  });
+  const instance = assertSurfaceAppInstancePosture({
+    kind: SWARM.RECORD_KIND.SURFACE_APP_INSTANCE_POSTURE,
+    instanceId: "surface-instance:logging-ui",
+    state: "ready",
+    contractId: "surface-app:logging-ui@0.1.0",
+    appId: "constitute-logging-ui",
+    appRef: "surface-app:logging-ui@0.1.0",
+    surfaceRef: "surface:logging-ui",
+    displayName: "Logging",
+    version: "0.1.0",
+    manifestId: "surface-app-manifest:logging-ui",
+    pinnedAppContractRef: "surface-app:logging-ui@0.1.0",
+    pinnedVersion: "0.1.0",
+    sourceMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+    requiredModuleRoles: [SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT],
+    moduleRefs: [moduleClaim.moduleRef],
+    modulePostures: [modulePosture],
+    moduleBindingPosture,
+    materializationBudgetRefs: ["logging-ui.event-table"],
+    runtimeSelectionPosture: runtimeSelection,
+    runnerReadiness: runtimeSelection.runnerReadiness,
+    serviceManagerReadiness: runtimeSelection.serviceManagerReadiness,
+    runnerPlanRef: runnerPlan.planId,
+    bootstrapContractRef: bootstrapContract.bootstrapContractId,
+    blockedReasons: [],
+    issuedAt,
+  });
+  assert.equal(instance.state, "ready");
+
+  const leakySelection = {
+    ...manifestSelection,
+    surfaceApp: { contractId: "local-object" },
+  };
+  assert.throws(
+    () => assertSurfaceAppManifestSelection(leakySelection),
+    /must not expose enumerable surfaceApp/,
+  );
 });
 
 test("service manager operations and proof digests validate release train evidence", () => {

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -96,6 +96,7 @@ import {
   assertSurfaceAppManifestRunnerPlan,
   assertSurfaceAppRuntimeSelectionPosture,
   assertSurfaceAppInstancePosture,
+  assertSurfaceAppFulfillmentIdentityPosture,
   assertSurfaceAppRunnerPlan,
   assertSurfaceAppDistributionPosture,
   assertSurfaceAppBootstrapContract,
@@ -659,6 +660,59 @@ test("surface app contracts validate module roles and fulfillment boundaries", (
     ...runtimeClient,
     role: "runtimePolicy",
   }), /invalid surface module role/);
+});
+
+test("surface app fulfillment identity posture separates contract, service, host, route, and runner identity", () => {
+  const issuedAt = 1700000000;
+  const posture = assertSurfaceAppFulfillmentIdentityPosture({
+    kind: SWARM.RECORD_KIND.SURFACE_APP_FULFILLMENT_IDENTITY_POSTURE,
+    identityId: "identity:surface-app:nvr-ui",
+    state: "ready",
+    appContractRef: "app:nvr-ui",
+    appId: "constitute-nvr-ui",
+    version: "0.2.0",
+    surfaceRef: "surface:nvr-ui",
+    serviceRequired: true,
+    serviceContractRef: "service:nvr",
+    serviceRef: "service:nvr",
+    serviceRouteRefs: ["service:nvr", "route:service:nvr"],
+    routeRefs: ["route:service:nvr"],
+    hostRefs: ["host:lab-gateway"],
+    managerRefs: ["manager:nvr-ui"],
+    runnerRefs: [BROWSER_PK],
+    memberRefs: [BROWSER_PK],
+    capabilityRefs: ["service.manage"],
+    grantRefs: ["grant:app:nvr-ui:run"],
+    authorityRefs: ["authority:nvr-ui:local"],
+    evidenceRefs: ["build:nvr-ui:local"],
+    identityPosture: {
+      app: "ready",
+      service: "ready",
+      route: "ready",
+      host: "ready",
+    },
+    safeFacts: {
+      serviceRequired: true,
+      serviceRouteRefCount: 2,
+      runnerRefCount: 1,
+    },
+    issuedAt,
+    expiresAt: issuedAt + 3600,
+  });
+  assert.equal(posture.serviceContractRef, "service:nvr");
+  assert.deepEqual(posture.runnerRefs, [BROWSER_PK]);
+
+  assert.throws(() => assertSurfaceAppFulfillmentIdentityPosture({
+    ...posture,
+    identityId: "identity:surface-app:nvr-ui:bad-service",
+    serviceRef: "service:nvr-route-only",
+  }), /serviceRef must not differ from serviceContractRef/);
+
+  assert.throws(() => assertSurfaceAppFulfillmentIdentityPosture({
+    ...posture,
+    identityId: "identity:surface-app:nvr-ui:bad-runner",
+    runnerRefs: ["member:unresolved"],
+  }), /must be a resolved public key/);
 });
 
 test("surface bootstrap contracts gate service manager release and secret posture", () => {

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -91,6 +91,7 @@ import {
   assertServiceManagerOperationPosture,
   assertServiceManagerProofDigest,
   assertSurfaceAppManifest,
+  assertSurfaceAppDistributionPosture,
   assertSurfaceAppBootstrapContract,
   assertSurfaceAppBootstrapPosture,
   assertSurfaceAppContract,
@@ -809,6 +810,54 @@ test("surface app manifests pin versioned app contracts and block unproven remot
   assert.deepEqual(manifest.requiredModuleRoles, [SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT]);
   assert.equal(manifest.compatibilityWindow.protocolRef, "protocol:surface-app:v1");
 
+  const distributionPosture = assertSurfaceAppDistributionPosture({
+    state: SURFACE_APP.DISTRIBUTION_POSTURE.RETAINED,
+    sourceMode: SURFACE_APP.FULFILLMENT_MODE.STORAGE_OBJECT,
+    sourceRefs: ["surface-app-source:nvr-ui@0.2.0"],
+    storageRefs: ["storage:object:surface-app:nvr-ui@0.2.0"],
+    pinIntentRefs: ["storage.pin.intent:surface-app:nvr-ui@0.2.0"],
+    pinProjectionRefs: ["storage.pin.projection:surface-app:nvr-ui@0.2.0"],
+    releaseContractRefs: ["service.manager.release:nvr-ui@0.2.0"],
+    retentionRefs: ["retention:surface-app:nvr-ui@0.2.0"],
+    retentionClass: "app-release",
+    schemaPosture: {
+      state: SURFACE_APP.SCHEMA_POSTURE.COMPATIBLE,
+      schemaRefs: ["schema:surface-app-contract:v1"],
+    },
+    releasePosture: {
+      state: SURFACE_APP.RELEASE_POSTURE.RELEASE_READY,
+      buildRef: "build:nvr-ui@0.2.0",
+      releaseRef: "release:nvr-ui@0.2.0",
+    },
+    safeFacts: {
+      retained: true,
+      version: "0.2.0",
+    },
+  });
+  assert.equal(distributionPosture.retentionClass, "app-release");
+
+  const retainedManifest = assertSurfaceAppManifest({
+    ...manifest,
+    currentAppContractRef: "surface-app:nvr-ui@0.2.0",
+    currentVersion: "0.2.0",
+    defaultSourceMode: SURFACE_APP.FULFILLMENT_MODE.STORAGE_OBJECT,
+    distributionPosture,
+    versions: [
+      {
+        appContractRef: "surface-app:nvr-ui@0.2.0",
+        version: "0.2.0",
+        state: SURFACE_APP.MANIFEST_VERSION_STATE.CURRENT,
+        sourceMode: SURFACE_APP.FULFILLMENT_MODE.STORAGE_OBJECT,
+        remoteSourceRefs: ["surface-app-source:nvr-ui@0.2.0"],
+        releaseContractRef: "service.manager.release:nvr-ui@0.2.0",
+        distributionPosture,
+      },
+    ],
+    remoteSourceRefs: ["surface-app-source:nvr-ui@0.2.0"],
+    releaseContractRefs: ["service.manager.release:nvr-ui@0.2.0"],
+  });
+  assert.equal(retainedManifest.distributionPosture.state, SURFACE_APP.DISTRIBUTION_POSTURE.RETAINED);
+
   assert.throws(() => assertSurfaceAppManifest({
     ...manifest,
     currentVersion: "0.2.0",
@@ -828,6 +877,19 @@ test("surface app manifests pin versioned app contracts and block unproven remot
     currentAppContractRef: "surface-app:nvr-ui@0.2.0",
     currentVersion: "0.2.0",
   }), /non-bundled source requires releaseContractRef/);
+
+  assert.throws(() => assertSurfaceAppDistributionPosture({
+    ...distributionPosture,
+    pinIntentRefs: [],
+    pinProjectionRefs: [],
+  }), /retained state requires pinIntentRefs or pinProjectionRefs/);
+
+  assert.throws(() => assertSurfaceAppDistributionPosture({
+    state: SURFACE_APP.DISTRIBUTION_POSTURE.DEGRADED,
+    schemaPosture: {
+      state: SURFACE_APP.SCHEMA_POSTURE.MIGRATION_REQUIRED,
+    },
+  }), /migrationRequired state requires migrationRefs or blockedReasons/);
 });
 
 test("service manager operations and proof digests validate release train evidence", () => {

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -97,6 +97,7 @@ import {
   assertSurfaceAppRuntimeSelectionPosture,
   assertSurfaceAppInstancePosture,
   assertSurfaceAppFulfillmentIdentityPosture,
+  assertSurfaceAppAuthorityAccessPosture,
   assertSurfaceAppRunnerPlan,
   assertSurfaceAppDistributionPosture,
   assertSurfaceAppBootstrapContract,
@@ -713,6 +714,55 @@ test("surface app fulfillment identity posture separates contract, service, host
     identityId: "identity:surface-app:nvr-ui:bad-runner",
     runnerRefs: ["member:unresolved"],
   }), /must be a resolved public key/);
+});
+
+test("surface app authority access posture separates action grants from content access", () => {
+  const issuedAt = 1700000000;
+  const posture = assertSurfaceAppAuthorityAccessPosture({
+    kind: SWARM.RECORD_KIND.SURFACE_APP_AUTHORITY_ACCESS_POSTURE,
+    postureId: "authority-access:surface-app:nvr-ui",
+    state: "ready",
+    appContractRef: "app:nvr-ui",
+    appId: "constitute-nvr-ui",
+    actionRequired: true,
+    accessRequired: true,
+    rootRefs: ["root:aux"],
+    deviceRefs: ["device:aux-browser"],
+    grantRefs: ["grant:app:nvr-ui:run"],
+    authorityRefs: ["authority:aux-browser"],
+    accessGroupRefs: ["access-group:nvr-ui:media-preview"],
+    requiredContentClasses: [AGREEMENT.CONTENT_CLASS.UI_PROJECTION, AGREEMENT.CONTENT_CLASS.MEDIA_REFERENCE],
+    exerciseRefs: ["exercise:app:nvr-ui:run"],
+    evidenceRefs: ["proof:nvr-ui:authority"],
+    actionPosture: { state: "ready", grantRefCount: 1 },
+    accessPosture: { state: "ready", accessGroupRefCount: 1 },
+    revocationPosture: { state: "clear" },
+    expiryPosture: { state: "fresh" },
+    safeFacts: { actionRequired: true, accessRequired: true },
+    issuedAt,
+    expiresAt: issuedAt + 3600,
+  });
+  assert.equal(posture.state, "ready");
+  assert.deepEqual(posture.accessGroupRefs, ["access-group:nvr-ui:media-preview"]);
+
+  assert.throws(() => assertSurfaceAppAuthorityAccessPosture({
+    ...posture,
+    postureId: "authority-access:surface-app:nvr-ui:missing-grant",
+    grantRefs: [],
+  }), /action requires grantRefs/);
+
+  assert.throws(() => assertSurfaceAppAuthorityAccessPosture({
+    ...posture,
+    postureId: "authority-access:surface-app:nvr-ui:missing-access",
+    accessGroupRefs: [],
+  }), /access requires accessGroupRefs/);
+
+  assert.throws(() => assertSurfaceAppAuthorityAccessPosture({
+    ...posture,
+    postureId: "authority-access:surface-app:nvr-ui:revoked",
+    state: "ready",
+    revocationState: "revoked",
+  }), /revoked state must be blocked/);
 });
 
 test("surface bootstrap contracts gate service manager release and secret posture", () => {

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -819,7 +819,30 @@ test("service manager operations and proof digests validate release train eviden
     serviceRefs: ["service:gateway"],
     capabilityRefs: ["service.manage"],
     authorityRefs: ["identity:operator"],
+    grantRefs: ["authority-grant:service-manager:gateway"],
+    runnerOperationRef: "runner-operation:gateway:promote:2026-05-17",
+    runnerRef: BROWSER_PK,
+    hostRef: "host:lab-gateway",
     releaseRef: "release:gateway:2026-05-17",
+    releasePosture: {
+      state: SURFACE_APP.RELEASE_POSTURE.ROLLBACK_READY,
+      buildRef: "build:gateway:2026-05-17",
+      releaseRef: "release:gateway:2026-05-17",
+      rollbackRef: "rollback:gateway:previous",
+    },
+    resourceBudget: {
+      profileRef: "resource-profile:service-manager",
+      maxMemoryMiB: 512,
+    },
+    resourcePosture: {
+      kind: SWARM.RECORD_KIND.RESOURCE_POSTURE,
+      postureId: "resource-posture:service-manager:gateway",
+      profileId: "resource-profile:service-manager",
+      state: SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET,
+      counts: { memoryMiB: 120 },
+      budgets: { memoryMiB: 512 },
+      sampledAt: requestedAt + 30,
+    },
     evidenceRefs: ["ci:gateway:linux", "ci:gateway:windows"],
     proofRefs: ["proof:gateway:smoke"],
     safeFacts: {
@@ -893,6 +916,11 @@ test("service manager operations and proof digests validate release train eviden
     state: SURFACE_APP.SERVICE_MANAGER_OPERATION_STATE.BLOCKED,
     requestedAt,
   }), /blocked or failed operation requires blockedReasons/);
+  assert.throws(() => assertServiceManagerOperationPosture({
+    ...operation,
+    operationId: "operation:unresolved-runner",
+    runnerRef: "member:gateway-manager",
+  }), /resolved public key/);
   assert.throws(() => assertServiceManagerProofDigest({
     kind: SWARM.RECORD_KIND.SERVICE_MANAGER_PROOF_DIGEST,
     digestId: "proof-digest:empty",

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -18,6 +18,7 @@ import {
   applyProjectionDelta,
   assertAppRecipe,
   assertAppRunnerAdvertisement,
+  assertAppRunnerFulfillmentReport,
   assertRunnerOperation,
   assertCapabilityAdvertisement,
   assertCapabilityDefinition,
@@ -211,6 +212,7 @@ test("event plane classifier separates primitive posture from local diagnostics"
   assert.equal(eventPlaneForRecordKind("projection.repair.request"), SWARM.EVENT_PLANE.PROJECTION_REPAIR);
   assert.equal(eventPlaneForRecordKind("projection.applied"), SWARM.EVENT_PLANE.PROJECTION);
   assert.equal(eventPlaneForRecordKind("stream.session.answer"), SWARM.EVENT_PLANE.ACTIVATION);
+  assert.equal(eventPlaneForRecordKind("app.runner.fulfillment.report"), SWARM.EVENT_PLANE.ACTIVATION);
   assert.equal(eventPlaneForRecordKind("route.observation"), SWARM.EVENT_PLANE.ROUTE);
   assert.equal(eventPlaneForRecordKind("contribution.lifecycle.applied"), SWARM.EVENT_PLANE.CONTRIBUTION);
   assert.equal(eventPlaneForRecordKind("runtime.retention.release.blocked"), SWARM.EVENT_PLANE.RETENTION);
@@ -1293,6 +1295,117 @@ test("runner operations bind host fulfillment to grants, resources, secrets, rel
   assert.throws(() => assertRunnerOperation({
     ...operation,
     operationId: "runner-operation:bad:secret",
+    safeFacts: { token: "inline-secret" },
+  }), /unsafe safe fact key|forbidden protocol field/);
+});
+
+test("app runner fulfillment reports reduce operation lifecycle, release, resources, and proof", () => {
+  const observedAt = 1700000020;
+  const report = assertAppRunnerFulfillmentReport({
+    kind: SWARM.RECORD_KIND.APP_RUNNER_FULFILLMENT_REPORT,
+    reportId: "app-runner:runner:app-proof:runner-operation:app-proof:execute:1",
+    runnerId: "runner:lab-gateway:app-proof",
+    runnerRef: BROWSER_PK,
+    hostRef: "host:lab-gateway",
+    runnerOperationId: "runner-operation:app-proof:execute:1",
+    operation: RUNNER.OPERATION.EXECUTE,
+    state: RUNNER.FULFILLMENT_STATE.SUCCEEDED,
+    requesterRef: "identity:aux",
+    subjectRef: "app:runner-proof",
+    contractRef: "app:runner-proof",
+    appContractRef: "app:runner-proof",
+    appId: "constitute-runner-proof",
+    version: "0.1.0",
+    manifestRef: "manifest:runner-proof",
+    sourceMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+    sourceRefs: ["bundle:runner-proof@0.1.0"],
+    grantRefs: ["grant:app:runner-proof:run"],
+    capabilityRefs: ["app.runner.pin"],
+    inputRefs: ["manifest:runner-proof", "app:runner-proof"],
+    outputRefs: ["artifact:runner-proof:dist"],
+    evidenceRefs: ["evidence:runner:accepted", "evidence:runner:completed"],
+    proofRefs: ["proof:runner-proof:surface"],
+    releaseRefs: ["release:runner-proof"],
+    resourceBudget: {
+      profileRef: "resource-profile:operator-dev",
+      maxMemoryMiB: 256,
+      maxCpuPct: 25,
+    },
+    resourcePosture: {
+      kind: SWARM.RECORD_KIND.RESOURCE_POSTURE,
+      postureId: "resource-posture:runner:app-proof",
+      profileId: "resource-profile:operator-dev",
+      state: SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET,
+      counts: { memoryMiB: 96, cpuPct: 4 },
+      budgets: { memoryMiB: 256, cpuPct: 25 },
+      sampledAt: observedAt,
+    },
+    secretBoundary: { state: SURFACE_APP.SECRET_BOUNDARY.NOT_REQUIRED },
+    releasePosture: {
+      state: SURFACE_APP.RELEASE_POSTURE.ROLLBACK_READY,
+      buildRef: "build:runner-proof",
+      releaseRef: "release:runner-proof",
+      rollbackRef: "rollback:runner-proof",
+    },
+    rollbackPosture: null,
+    releaseRef: "release:runner-proof",
+    rollbackRef: "rollback:runner-proof",
+    operationPosture: {
+      state: RUNNER.FULFILLMENT_STATE.SUCCEEDED,
+      accepted: true,
+      requestedAt: observedAt - 20,
+      acceptedAt: observedAt - 18,
+      startedAt: observedAt - 15,
+      completedAt: observedAt - 1,
+      observedAt,
+    },
+    fulfillmentPosture: {
+      state: RUNNER.FULFILLMENT_STATE.SUCCEEDED,
+      outputRefs: ["artifact:runner-proof:dist"],
+      releaseRefs: ["release:runner-proof"],
+      proofRefs: ["proof:runner-proof:surface"],
+      evidenceRefs: ["evidence:runner:completed"],
+    },
+    safeFacts: {
+      appId: "constitute-runner-proof",
+      version: "0.1.0",
+      sourceMode: SURFACE_APP.FULFILLMENT_MODE.BUNDLED,
+      outputRefCount: 1,
+      releaseRefCount: 1,
+      proofRefCount: 1,
+    },
+    blockedReasons: [],
+    observedAt,
+    expiresAt: observedAt + 3600,
+  });
+  assert.equal(report.state, RUNNER.FULFILLMENT_STATE.SUCCEEDED);
+  assert.equal(report.resourcePosture.state, SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET);
+
+  assert.throws(() => assertAppRunnerFulfillmentReport({
+    ...report,
+    reportId: "app-runner:bad:missing-proof",
+    outputRefs: [],
+    proofRefs: [],
+  }), /succeeded app runner fulfillment requires outputRefs or proofRefs/);
+
+  assert.throws(() => assertAppRunnerFulfillmentReport({
+    ...report,
+    reportId: "app-runner:bad:missing-source",
+    sourceRefs: [],
+  }), /succeeded app runner fulfillment requires sourceRefs/);
+
+  assert.throws(() => assertAppRunnerFulfillmentReport({
+    ...report,
+    reportId: "app-runner:bad:blocked",
+    state: RUNNER.FULFILLMENT_STATE.BLOCKED,
+    operationPosture: { ...report.operationPosture, state: RUNNER.FULFILLMENT_STATE.BLOCKED },
+    fulfillmentPosture: { ...report.fulfillmentPosture, state: RUNNER.FULFILLMENT_STATE.BLOCKED },
+    blockedReasons: [],
+  }), /blocked app runner fulfillment requires blockedReasons/);
+
+  assert.throws(() => assertAppRunnerFulfillmentReport({
+    ...report,
+    reportId: "app-runner:bad:secret",
     safeFacts: { token: "inline-secret" },
   }), /unsafe safe fact key|forbidden protocol field/);
 });

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -7,6 +7,7 @@ import {
   AGREEMENT,
   LOGGING,
   PROJECTION,
+  RUNNER,
   ReplayCache,
   SERVICE_SURFACE,
   SERVICE_REGISTRY,
@@ -17,6 +18,7 @@ import {
   applyProjectionDelta,
   assertAppRecipe,
   assertAppRunnerAdvertisement,
+  assertRunnerOperation,
   assertCapabilityAdvertisement,
   assertCapabilityDefinition,
   assertCapabilityName,
@@ -912,6 +914,92 @@ test("service manager operations and proof digests validate release train eviden
       token: "inline-secret",
     },
     observedAt: requestedAt + 80,
+  }), /unsafe safe fact key|forbidden protocol field/);
+});
+
+test("runner operations bind host fulfillment to grants, resources, secrets, release, and evidence", () => {
+  const requestedAt = 1700000000;
+  const operation = assertRunnerOperation({
+    kind: SWARM.RECORD_KIND.RUNNER_OPERATION,
+    operationId: "runner-operation:security-bootstrap:execute:1",
+    runnerId: "runner:lab-gateway:security-bootstrap",
+    runnerRef: BROWSER_PK,
+    hostRef: "host:lab-gateway",
+    requesterRef: "identity:aux",
+    subjectRef: "security-processor:dev",
+    contractRef: "security-processor:seed@0.1.0",
+    operation: RUNNER.OPERATION.EXECUTE,
+    state: RUNNER.OPERATION_STATE.SUCCEEDED,
+    grantRefs: ["authority-grant:runner:security-bootstrap"],
+    capabilityRefs: ["app.runner.pin"],
+    inputRefs: ["event-fabric:security-audit"],
+    outputRefs: ["alert-hold:security-bootstrap:1"],
+    evidenceRefs: ["evidence:runner:started", "evidence:runner:completed"],
+    proofRefs: ["proof:runner:security-bootstrap"],
+    releaseRefs: ["release:runner:security-bootstrap"],
+    resourceBudget: {
+      profileRef: "resource-profile:operator-dev",
+      maxMemoryMiB: 512,
+      maxCpuPct: 40,
+    },
+    resourcePosture: {
+      kind: SWARM.RECORD_KIND.RESOURCE_POSTURE,
+      postureId: "resource-posture:runner:security-bootstrap",
+      profileId: "resource-profile:operator-dev",
+      state: SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET,
+      counts: { memoryMiB: 120, cpuPct: 8 },
+      budgets: { memoryMiB: 512, cpuPct: 40 },
+      sampledAt: requestedAt + 15,
+    },
+    secretBoundary: {
+      state: SURFACE_APP.SECRET_BOUNDARY.NOT_REQUIRED,
+    },
+    releasePosture: {
+      state: SURFACE_APP.RELEASE_POSTURE.ROLLBACK_READY,
+      buildRef: "build:runner:security-bootstrap",
+      releaseRef: "release:runner:security-bootstrap",
+      rollbackRef: "rollback:runner:security-bootstrap",
+    },
+    releaseRef: "release:runner:security-bootstrap",
+    rollbackRef: "rollback:runner:security-bootstrap",
+    safeFacts: {
+      role: "securityProcessor",
+      mode: "operatorDev",
+    },
+    requestedAt,
+    acceptedAt: requestedAt + 1,
+    startedAt: requestedAt + 2,
+    completedAt: requestedAt + 12,
+    observedAt: requestedAt + 15,
+    expiresAt: requestedAt + 3600,
+  });
+  assert.equal(operation.operation, RUNNER.OPERATION.EXECUTE);
+  assert.equal(operation.resourcePosture.state, SWARM.RESOURCE_POSTURE_STATE.WITHIN_BUDGET);
+
+  assert.throws(() => assertRunnerOperation({
+    ...operation,
+    operationId: "runner-operation:bad:grantless",
+    grantRefs: [],
+  }), /runner operation grantRefs must not be empty/);
+
+  assert.throws(() => assertRunnerOperation({
+    ...operation,
+    operationId: "runner-operation:bad:rollback",
+    operation: RUNNER.OPERATION.ROLLBACK,
+    rollbackRef: "",
+  }), /runner rollback operation requires rollbackRef/);
+
+  assert.throws(() => assertRunnerOperation({
+    ...operation,
+    operationId: "runner-operation:bad:blocked",
+    state: RUNNER.OPERATION_STATE.BLOCKED,
+    blockedReasons: [],
+  }), /blocked, failed, or rejected operation requires blockedReasons/);
+
+  assert.throws(() => assertRunnerOperation({
+    ...operation,
+    operationId: "runner-operation:bad:secret",
+    safeFacts: { token: "inline-secret" },
   }), /unsafe safe fact key|forbidden protocol field/);
 });
 


### PR DESCRIPTION
Adds shared protocol grammar for contract-backed surface apps, runner fulfillment, service-manager bootstrap posture, materialization budgets, and authority/access posture.\n\nThe train also extends JS and Rust validators so surfaces, runners, and future Security work can share the same app contract and access posture records instead of local dialects.