### PR TITLE
Add swarm contract spine primitives

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,9 @@ pub const RECORD_APP_MODULE_ROLE: &str = "app.module.role";
 pub const RECORD_APP_ACTIVITY: &str = "app.activity";
 pub const RECORD_APP_RELEASE: &str = "app.release";
 pub const RECORD_APP_RELEASE_RESOLUTION: &str = "app.release.resolution";
+pub const RECORD_APP_ACTIVITY_DEPENDENCY: &str = "app.activity.dependency";
+pub const RECORD_MESSAGING_CONTRACT: &str = "messaging.contract";
+pub const RECORD_COMMUNICATIONS_MODERATION_CONTRACT: &str = "communications.moderation.contract";
 
 pub const APP_CONTRACT_STATE_DRAFT: &str = "draft";
 pub const APP_CONTRACT_STATE_READY: &str = "ready";
@@ -44,6 +47,25 @@ pub const APP_RESOLUTION_STATE_RESOLVED: &str = "resolved";
 pub const APP_RESOLUTION_STATE_BLOCKED: &str = "blocked";
 pub const APP_RESOLUTION_STATE_DEGRADED: &str = "degraded";
 pub const APP_RESOLUTION_STATE_SUPERSEDED: &str = "superseded";
+
+pub const APP_ACTIVITY_DEPENDENCY_MESSAGING: &str = "messaging";
+pub const APP_ACTIVITY_DEPENDENCY_COMMUNICATIONS_MODERATION: &str = "communicationsModeration";
+
+pub const APP_DEPENDENCY_STATE_READY: &str = "ready";
+pub const APP_DEPENDENCY_STATE_PENDING: &str = "pending";
+pub const APP_DEPENDENCY_STATE_DEGRADED: &str = "degraded";
+pub const APP_DEPENDENCY_STATE_BLOCKED: &str = "blocked";
+pub const APP_DEPENDENCY_STATE_EXPIRED: &str = "expired";
+
+pub const MESSAGING_CONTRACT_STATE_READY: &str = "ready";
+pub const MESSAGING_CONTRACT_STATE_DEGRADED: &str = "degraded";
+pub const MESSAGING_CONTRACT_STATE_BLOCKED: &str = "blocked";
+pub const MESSAGING_CONTRACT_STATE_EXPIRED: &str = "expired";
+
+pub const COMMUNICATIONS_MODERATION_STATE_READY: &str = "ready";
+pub const COMMUNICATIONS_MODERATION_STATE_DEGRADED: &str = "degraded";
+pub const COMMUNICATIONS_MODERATION_STATE_BLOCKED: &str = "blocked";
+pub const COMMUNICATIONS_MODERATION_STATE_EXPIRED: &str = "expired";
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
@@ -200,6 +222,100 @@ pub struct AppReleaseResolution {
     #[serde(default)]
     pub safe_facts: Value,
     pub resolved_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AppActivityDependency {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub dependency_ref: String,
+    pub app_contract_ref: String,
+    pub activity_ref: String,
+    pub dependency_type: String,
+    pub required: bool,
+    pub state: String,
+    #[serde(default)]
+    pub contract_refs: Vec<String>,
+    #[serde(default)]
+    pub primitive_refs: Vec<String>,
+    #[serde(default)]
+    pub permission_refs: Vec<String>,
+    #[serde(default)]
+    pub access_group_refs: Vec<String>,
+    #[serde(default)]
+    pub materialization_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct MessagingContract {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub messaging_contract_ref: String,
+    pub scope_ref: String,
+    pub author_ref: String,
+    pub state: String,
+    #[serde(default)]
+    pub conversation_refs: Vec<String>,
+    #[serde(default)]
+    pub participant_role_refs: Vec<String>,
+    #[serde(default)]
+    pub activity_refs: Vec<String>,
+    #[serde(default)]
+    pub content_class_refs: Vec<String>,
+    #[serde(default)]
+    pub access_group_refs: Vec<String>,
+    #[serde(default)]
+    pub witness_floor_refs: Vec<String>,
+    #[serde(default)]
+    pub retention_refs: Vec<String>,
+    #[serde(default)]
+    pub moderation_contract_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CommunicationsModerationContract {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub moderation_contract_ref: String,
+    pub scope_ref: String,
+    pub authority_realm_ref: String,
+    pub state: String,
+    #[serde(default)]
+    pub action_refs: Vec<String>,
+    #[serde(default)]
+    pub target_refs: Vec<String>,
+    #[serde(default)]
+    pub messaging_contract_refs: Vec<String>,
+    #[serde(default)]
+    pub event_fabric_refs: Vec<String>,
+    #[serde(default)]
+    pub permission_refs: Vec<String>,
+    #[serde(default)]
+    pub access_group_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    pub issued_at: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<u64>,
 }
@@ -441,6 +557,218 @@ pub fn validate_app_release_resolution(record: &AppReleaseResolution) -> Result<
     Ok(())
 }
 
+pub fn validate_app_activity_dependency(record: &AppActivityDependency) -> Result<()> {
+    validate_optional_kind(
+        record.kind.as_deref(),
+        RECORD_APP_ACTIVITY_DEPENDENCY,
+        "app activity dependency",
+    )?;
+    reject_private_fields(&serde_json::to_value(record)?, "app activity dependency")?;
+    validate_contract_ref(
+        &record.dependency_ref,
+        "app activity dependency dependencyRef",
+    )?;
+    validate_contract_ref(
+        &record.app_contract_ref,
+        "app activity dependency appContractRef",
+    )?;
+    validate_contract_ref(&record.activity_ref, "app activity dependency activityRef")?;
+    validate_app_activity_dependency_type(&record.dependency_type)?;
+    validate_app_dependency_state(&record.state)?;
+    validate_ref_list(
+        &record.contract_refs,
+        "app activity dependency contractRefs",
+    )?;
+    validate_ref_list(
+        &record.primitive_refs,
+        "app activity dependency primitiveRefs",
+    )?;
+    validate_ref_list(
+        &record.permission_refs,
+        "app activity dependency permissionRefs",
+    )?;
+    validate_ref_list(
+        &record.access_group_refs,
+        "app activity dependency accessGroupRefs",
+    )?;
+    validate_ref_list(
+        &record.materialization_refs,
+        "app activity dependency materializationRefs",
+    )?;
+    validate_ref_list(
+        &record.evidence_refs,
+        "app activity dependency evidenceRefs",
+    )?;
+    validate_reason_list(
+        &record.blocked_reasons,
+        "app activity dependency blockedReasons",
+    )?;
+    if record.required
+        && record.state == APP_DEPENDENCY_STATE_READY
+        && (record.contract_refs.is_empty() || record.primitive_refs.is_empty())
+    {
+        return Err(anyhow!(
+            "ready required app activity dependency requires contractRefs and primitiveRefs"
+        ));
+    }
+    if record.state == APP_DEPENDENCY_STATE_BLOCKED && record.blocked_reasons.is_empty() {
+        return Err(anyhow!(
+            "blocked app activity dependency requires blockedReasons"
+        ));
+    }
+    validate_time_bounds(
+        record.issued_at,
+        record.expires_at,
+        "app activity dependency",
+    )?;
+    Ok(())
+}
+
+pub fn validate_messaging_contract(record: &MessagingContract) -> Result<()> {
+    validate_optional_kind(
+        record.kind.as_deref(),
+        RECORD_MESSAGING_CONTRACT,
+        "messaging contract",
+    )?;
+    reject_private_fields(&serde_json::to_value(record)?, "messaging contract")?;
+    validate_contract_ref(
+        &record.messaging_contract_ref,
+        "messaging contract messagingContractRef",
+    )?;
+    validate_contract_ref(&record.scope_ref, "messaging contract scopeRef")?;
+    validate_contract_ref(&record.author_ref, "messaging contract authorRef")?;
+    validate_messaging_contract_state(&record.state)?;
+    validate_ref_list(
+        &record.conversation_refs,
+        "messaging contract conversationRefs",
+    )?;
+    validate_ref_list(
+        &record.participant_role_refs,
+        "messaging contract participantRoleRefs",
+    )?;
+    validate_ref_list(&record.activity_refs, "messaging contract activityRefs")?;
+    validate_ref_list(
+        &record.content_class_refs,
+        "messaging contract contentClassRefs",
+    )?;
+    validate_ref_list(
+        &record.access_group_refs,
+        "messaging contract accessGroupRefs",
+    )?;
+    validate_ref_list(
+        &record.witness_floor_refs,
+        "messaging contract witnessFloorRefs",
+    )?;
+    validate_ref_list(&record.retention_refs, "messaging contract retentionRefs")?;
+    validate_ref_list(
+        &record.moderation_contract_refs,
+        "messaging contract moderationContractRefs",
+    )?;
+    validate_ref_list(&record.evidence_refs, "messaging contract evidenceRefs")?;
+    validate_reason_list(&record.blocked_reasons, "messaging contract blockedReasons")?;
+    if record.state == MESSAGING_CONTRACT_STATE_READY
+        && (record.participant_role_refs.is_empty()
+            || record.activity_refs.is_empty()
+            || record.content_class_refs.is_empty()
+            || record.access_group_refs.is_empty()
+            || record.witness_floor_refs.is_empty()
+            || record.retention_refs.is_empty())
+    {
+        return Err(anyhow!(
+            "ready messaging contract requires participant roles, activities, content classes, access groups, witness floors, and retention refs"
+        ));
+    }
+    if record.state == MESSAGING_CONTRACT_STATE_BLOCKED && record.blocked_reasons.is_empty() {
+        return Err(anyhow!(
+            "blocked messaging contract requires blockedReasons"
+        ));
+    }
+    validate_time_bounds(record.issued_at, record.expires_at, "messaging contract")?;
+    Ok(())
+}
+
+pub fn validate_communications_moderation_contract(
+    record: &CommunicationsModerationContract,
+) -> Result<()> {
+    validate_optional_kind(
+        record.kind.as_deref(),
+        RECORD_COMMUNICATIONS_MODERATION_CONTRACT,
+        "communications moderation contract",
+    )?;
+    reject_private_fields(
+        &serde_json::to_value(record)?,
+        "communications moderation contract",
+    )?;
+    validate_contract_ref(
+        &record.moderation_contract_ref,
+        "communications moderation contract moderationContractRef",
+    )?;
+    validate_contract_ref(
+        &record.scope_ref,
+        "communications moderation contract scopeRef",
+    )?;
+    validate_contract_ref(
+        &record.authority_realm_ref,
+        "communications moderation contract authorityRealmRef",
+    )?;
+    validate_communications_moderation_state(&record.state)?;
+    validate_ref_list(
+        &record.action_refs,
+        "communications moderation contract actionRefs",
+    )?;
+    validate_ref_list(
+        &record.target_refs,
+        "communications moderation contract targetRefs",
+    )?;
+    validate_ref_list(
+        &record.messaging_contract_refs,
+        "communications moderation contract messagingContractRefs",
+    )?;
+    validate_ref_list(
+        &record.event_fabric_refs,
+        "communications moderation contract eventFabricRefs",
+    )?;
+    validate_ref_list(
+        &record.permission_refs,
+        "communications moderation contract permissionRefs",
+    )?;
+    validate_ref_list(
+        &record.access_group_refs,
+        "communications moderation contract accessGroupRefs",
+    )?;
+    validate_ref_list(
+        &record.evidence_refs,
+        "communications moderation contract evidenceRefs",
+    )?;
+    validate_reason_list(
+        &record.blocked_reasons,
+        "communications moderation contract blockedReasons",
+    )?;
+    if record.state == COMMUNICATIONS_MODERATION_STATE_READY
+        && (record.action_refs.is_empty()
+            || record.target_refs.is_empty()
+            || record.messaging_contract_refs.is_empty()
+            || record.permission_refs.is_empty()
+            || record.access_group_refs.is_empty())
+    {
+        return Err(anyhow!(
+            "ready communications moderation contract requires actions, targets, messaging contracts, permissions, and access groups"
+        ));
+    }
+    if record.state == COMMUNICATIONS_MODERATION_STATE_BLOCKED && record.blocked_reasons.is_empty()
+    {
+        return Err(anyhow!(
+            "blocked communications moderation contract requires blockedReasons"
+        ));
+    }
+    validate_time_bounds(
+        record.issued_at,
+        record.expires_at,
+        "communications moderation contract",
+    )?;
+    Ok(())
+}
+
 pub fn app_ref(kind: &str, id: &str) -> String {
     format!("app:{kind}:{id}")
 }
@@ -538,6 +866,60 @@ fn validate_app_resolution_state(value: &str) -> Result<()> {
         Ok(())
     } else {
         Err(anyhow!("unsupported app release resolution state"))
+    }
+}
+
+fn validate_app_activity_dependency_type(value: &str) -> Result<()> {
+    if matches!(
+        value,
+        APP_ACTIVITY_DEPENDENCY_MESSAGING | APP_ACTIVITY_DEPENDENCY_COMMUNICATIONS_MODERATION
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported app activity dependency type"))
+    }
+}
+
+fn validate_app_dependency_state(value: &str) -> Result<()> {
+    if matches!(
+        value,
+        APP_DEPENDENCY_STATE_READY
+            | APP_DEPENDENCY_STATE_PENDING
+            | APP_DEPENDENCY_STATE_DEGRADED
+            | APP_DEPENDENCY_STATE_BLOCKED
+            | APP_DEPENDENCY_STATE_EXPIRED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported app dependency state"))
+    }
+}
+
+fn validate_messaging_contract_state(value: &str) -> Result<()> {
+    if matches!(
+        value,
+        MESSAGING_CONTRACT_STATE_READY
+            | MESSAGING_CONTRACT_STATE_DEGRADED
+            | MESSAGING_CONTRACT_STATE_BLOCKED
+            | MESSAGING_CONTRACT_STATE_EXPIRED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported messaging contract state"))
+    }
+}
+
+fn validate_communications_moderation_state(value: &str) -> Result<()> {
+    if matches!(
+        value,
+        COMMUNICATIONS_MODERATION_STATE_READY
+            | COMMUNICATIONS_MODERATION_STATE_DEGRADED
+            | COMMUNICATIONS_MODERATION_STATE_BLOCKED
+            | COMMUNICATIONS_MODERATION_STATE_EXPIRED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported communications moderation state"))
     }
 }
 
@@ -817,5 +1199,143 @@ mod tests {
             expires_at: Some(10),
         };
         assert!(validate_app_release_resolution(&resolution).is_err());
+    }
+
+    #[test]
+    fn validates_messaging_and_moderation_activity_dependencies() {
+        let messaging = MessagingContract {
+            kind: Some(RECORD_MESSAGING_CONTRACT.to_string()),
+            messaging_contract_ref: "messaging:contract:truecost.web-team".to_string(),
+            scope_ref: "activity:scope:truecost.web-team.hosting".to_string(),
+            author_ref: "identity:root:truecost".to_string(),
+            state: MESSAGING_CONTRACT_STATE_READY.to_string(),
+            conversation_refs: vec!["messaging:thread:truecost.web-team.hosting".to_string()],
+            participant_role_refs: vec![
+                "role:community.member".to_string(),
+                "role:webadmin".to_string(),
+            ],
+            activity_refs: vec!["app:activity:messaging.thread".to_string()],
+            content_class_refs: vec![
+                "content:message.body".to_string(),
+                "content:message.safe-index".to_string(),
+            ],
+            access_group_refs: vec!["access:group:truecost.web-team".to_string()],
+            witness_floor_refs: vec!["witness:floor:messaging.thread".to_string()],
+            retention_refs: vec!["retention:message.thread.default".to_string()],
+            moderation_contract_refs: vec!["moderation:contract:truecost.web-team".to_string()],
+            evidence_refs: vec!["evidence:messaging.contract".to_string()],
+            blocked_reasons: vec![],
+            issued_at: 1,
+            expires_at: Some(10),
+        };
+        validate_messaging_contract(&messaging).expect("valid messaging contract");
+
+        let moderation = CommunicationsModerationContract {
+            kind: Some(RECORD_COMMUNICATIONS_MODERATION_CONTRACT.to_string()),
+            moderation_contract_ref: "moderation:contract:truecost.web-team".to_string(),
+            scope_ref: messaging.scope_ref.clone(),
+            authority_realm_ref: "authority:realm:truecost.community".to_string(),
+            state: COMMUNICATIONS_MODERATION_STATE_READY.to_string(),
+            action_refs: vec![
+                "moderation:action:report".to_string(),
+                "moderation:action:hide".to_string(),
+                "moderation:action:appeal".to_string(),
+            ],
+            target_refs: messaging.conversation_refs.clone(),
+            messaging_contract_refs: vec![messaging.messaging_contract_ref.clone()],
+            event_fabric_refs: vec!["event-fabric:logging.default".to_string()],
+            permission_refs: vec!["permission:moderation:web-team".to_string()],
+            access_group_refs: vec!["access:group:truecost.moderators".to_string()],
+            evidence_refs: vec!["evidence:moderation.contract".to_string()],
+            blocked_reasons: vec![],
+            issued_at: 2,
+            expires_at: Some(10),
+        };
+        validate_communications_moderation_contract(&moderation)
+            .expect("valid communications moderation contract");
+
+        let messaging_dependency = AppActivityDependency {
+            kind: Some(RECORD_APP_ACTIVITY_DEPENDENCY.to_string()),
+            dependency_ref: "app:dependency:community.channel.messaging".to_string(),
+            app_contract_ref: "app:contract:communities@0.1.0".to_string(),
+            activity_ref: "app:activity:community.role-channel".to_string(),
+            dependency_type: APP_ACTIVITY_DEPENDENCY_MESSAGING.to_string(),
+            required: true,
+            state: APP_DEPENDENCY_STATE_READY.to_string(),
+            contract_refs: vec![messaging.messaging_contract_ref],
+            primitive_refs: vec!["primitive:messaging.thread".to_string()],
+            permission_refs: vec!["permission:message.write".to_string()],
+            access_group_refs: vec!["access:group:truecost.web-team".to_string()],
+            materialization_refs: vec!["materialization:thread.messages".to_string()],
+            evidence_refs: vec!["evidence:dependency.messaging".to_string()],
+            blocked_reasons: vec![],
+            issued_at: 3,
+            expires_at: Some(10),
+        };
+        validate_app_activity_dependency(&messaging_dependency)
+            .expect("valid messaging activity dependency");
+
+        let moderation_dependency = AppActivityDependency {
+            kind: Some(RECORD_APP_ACTIVITY_DEPENDENCY.to_string()),
+            dependency_ref: "app:dependency:community.channel.moderation".to_string(),
+            app_contract_ref: "app:contract:communities@0.1.0".to_string(),
+            activity_ref: "app:activity:community.role-channel".to_string(),
+            dependency_type: APP_ACTIVITY_DEPENDENCY_COMMUNICATIONS_MODERATION.to_string(),
+            required: false,
+            state: APP_DEPENDENCY_STATE_READY.to_string(),
+            contract_refs: vec![moderation.moderation_contract_ref],
+            primitive_refs: vec!["primitive:communications.moderation".to_string()],
+            permission_refs: vec!["permission:moderation.web-team".to_string()],
+            access_group_refs: vec!["access:group:truecost.moderators".to_string()],
+            materialization_refs: vec!["materialization:moderation.posture".to_string()],
+            evidence_refs: vec!["evidence:dependency.moderation".to_string()],
+            blocked_reasons: vec![],
+            issued_at: 4,
+            expires_at: Some(10),
+        };
+        validate_app_activity_dependency(&moderation_dependency)
+            .expect("valid moderation activity dependency");
+    }
+
+    #[test]
+    fn rejects_messaging_moderation_conflation_and_private_payloads() {
+        let mut messaging = MessagingContract {
+            kind: Some(RECORD_MESSAGING_CONTRACT.to_string()),
+            messaging_contract_ref: "messaging:contract:blocked".to_string(),
+            scope_ref: "activity:scope:blocked".to_string(),
+            author_ref: "identity:root:truecost".to_string(),
+            state: MESSAGING_CONTRACT_STATE_READY.to_string(),
+            conversation_refs: vec![],
+            participant_role_refs: vec![],
+            activity_refs: vec![],
+            content_class_refs: vec![],
+            access_group_refs: vec![],
+            witness_floor_refs: vec![],
+            retention_refs: vec![],
+            moderation_contract_refs: vec![],
+            evidence_refs: vec![],
+            blocked_reasons: vec![],
+            issued_at: 1,
+            expires_at: Some(10),
+        };
+        assert!(validate_messaging_contract(&messaging).is_err());
+
+        messaging.state = MESSAGING_CONTRACT_STATE_BLOCKED.to_string();
+        assert!(validate_messaging_contract(&messaging).is_err());
+
+        let leaky_dependency = serde_json::json!({
+            "kind": RECORD_APP_ACTIVITY_DEPENDENCY,
+            "dependencyRef": "app:dependency:leaky",
+            "appContractRef": "app:contract:communities@0.1.0",
+            "activityRef": "app:activity:community.role-channel",
+            "dependencyType": APP_ACTIVITY_DEPENDENCY_MESSAGING,
+            "required": true,
+            "state": APP_DEPENDENCY_STATE_READY,
+            "contractRefs": ["messaging:contract:leaky"],
+            "primitiveRefs": ["primitive:messaging.thread"],
+            "payload": "message body must not be here",
+            "issuedAt": 1
+        });
+        assert!(serde_json::from_value::<AppActivityDependency>(leaky_dependency).is_err());
     }
 }

--- a/src/build.rs
+++ b/src/build.rs
@@ -30,6 +30,8 @@ pub const BUILD_PROOF_STATE_PROVED: &str = "proved";
 pub const BUILD_PROOF_STATE_FAILED: &str = "failed";
 pub const BUILD_PROOF_STATE_BLOCKED: &str = "blocked";
 
+pub const CAPABILITY_BUILD_RUN_EXECUTE: &str = "build.run.execute";
+
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct BuildContract {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1968,6 +1968,63 @@ export type AppReleaseResolutionRecord = {
   expiresAt?: number;
 };
 
+export type AppActivityDependencyRecord = {
+  kind?: "app.activity.dependency";
+  dependencyRef: string;
+  appContractRef: string;
+  activityRef: string;
+  dependencyType: "messaging" | "communicationsModeration" | string;
+  required: boolean;
+  state: "ready" | "pending" | "degraded" | "blocked" | "expired" | string;
+  contractRefs?: string[];
+  primitiveRefs?: string[];
+  permissionRefs?: string[];
+  accessGroupRefs?: string[];
+  materializationRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type MessagingContractRecord = {
+  kind?: "messaging.contract";
+  messagingContractRef: string;
+  scopeRef: string;
+  authorRef: string;
+  state: "ready" | "degraded" | "blocked" | "expired" | string;
+  conversationRefs?: string[];
+  participantRoleRefs?: string[];
+  activityRefs?: string[];
+  contentClassRefs?: string[];
+  accessGroupRefs?: string[];
+  witnessFloorRefs?: string[];
+  retentionRefs?: string[];
+  moderationContractRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type CommunicationsModerationContractRecord = {
+  kind?: "communications.moderation.contract";
+  moderationContractRef: string;
+  scopeRef: string;
+  authorityRealmRef: string;
+  state: "ready" | "degraded" | "blocked" | "expired" | string;
+  actionRefs?: string[];
+  targetRefs?: string[];
+  messagingContractRefs?: string[];
+  eventFabricRefs?: string[];
+  permissionRefs?: string[];
+  accessGroupRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
 export type SurfaceModuleClaim = {
   moduleRef: string;
   role: SurfaceModuleRole;
@@ -3052,6 +3109,9 @@ export function assertAppModuleRole(record: unknown): AppModuleRoleRecord;
 export function assertAppActivity(record: unknown): AppActivityRecord;
 export function assertAppRelease(record: unknown): AppReleaseRecord;
 export function assertAppReleaseResolution(record: unknown): AppReleaseResolutionRecord;
+export function assertAppActivityDependency(record: unknown): AppActivityDependencyRecord;
+export function assertMessagingContract(record: unknown): MessagingContractRecord;
+export function assertCommunicationsModerationContract(record: unknown): CommunicationsModerationContractRecord;
 export function assertSurfaceModuleClaim(record: unknown): SurfaceModuleClaim;
 export function assertSurfaceAppContract(record: unknown): SurfaceAppContract;
 export function assertSurfaceAppManifest(record: unknown): SurfaceAppManifest;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,7 +6,9 @@ export const DEFAULT_REQUEST_TTL_SECONDS: number;
 export const BROKER: Readonly<Record<string, string>>;
 export const SERVICE_SURFACE: Readonly<Record<string, unknown>>;
 export const SURFACE_APP: Readonly<Record<string, unknown>>;
+export const APP: Readonly<Record<string, unknown>>;
 export const RUNNER: Readonly<Record<string, unknown>>;
+export const BUILD: Readonly<Record<string, unknown>>;
 export const AGREEMENT: Readonly<Record<string, unknown>>;
 export const SERVICE_REGISTRY: Readonly<Record<string, unknown>>;
 export const STORAGE: Readonly<Record<string, string>>;
@@ -1869,6 +1871,103 @@ export type RunnerHostFulfillmentState =
   | "rejected"
   | "cancelled";
 
+export type AppContractRecord = {
+  kind?: "app.contract";
+  appContractRef: string;
+  appId: string;
+  version: string;
+  authorRef: string;
+  state: "draft" | "ready" | "blocked" | "superseded" | string;
+  primitiveRefs?: string[];
+  activityRefs?: string[];
+  moduleRoleRefs?: string[];
+  releaseRefs?: string[];
+  permissionRefs?: string[];
+  accessGroupRefs?: string[];
+  compatibilityRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type AppModuleRoleRecord = {
+  kind?: "app.module.role";
+  moduleRoleRef: string;
+  appContractRef: string;
+  roleName: SurfaceModuleRole;
+  required: boolean;
+  primitiveRefs?: string[];
+  platformRefs?: string[];
+  artifactRefs?: string[];
+  compatibilityRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+};
+
+export type AppActivityRecord = {
+  kind?: "app.activity";
+  activityRef: string;
+  appContractRef: string;
+  activityId: string;
+  state: "ready" | "blocked" | "deprecated" | string;
+  launchMode: "surface" | "embedded" | "native" | "service" | string;
+  embedPolicy: "allowed" | "restricted" | "denied" | string;
+  primitiveRefs?: string[];
+  moduleRoleRefs?: string[];
+  permissionRefs?: string[];
+  accessGroupRefs?: string[];
+  materializationRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type AppReleaseRecord = {
+  kind?: "app.release";
+  releaseRef: string;
+  appContractRef: string;
+  version: string;
+  sourceSnapshotRef: string;
+  buildRunRef: string;
+  state: "published" | "blocked" | "superseded" | "revoked" | string;
+  artifactRefs?: string[];
+  proofRefs?: string[];
+  moduleRoleRefs?: string[];
+  storageRefs?: string[];
+  compatibilityRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type AppReleaseResolutionRecord = {
+  kind?: "app.release.resolution";
+  resolutionRef: string;
+  appIntentRef: string;
+  appContractRef: string;
+  requestedVersion: string;
+  state: "resolved" | "blocked" | "degraded" | "superseded" | string;
+  selectedReleaseRef?: string;
+  selectedActivityRef?: string;
+  selectedArtifactRefs?: string[];
+  selectedModuleRoleRefs?: string[];
+  selectedStorageRefs?: string[];
+  sourceDigestRefs?: string[];
+  sourceSnapshotRef?: string;
+  buildProofRefs?: string[];
+  compatibilityRefs?: string[];
+  permissionRefs?: string[];
+  accessGroupRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+  resolvedAt: number;
+  expiresAt?: number;
+};
+
 export type SurfaceModuleClaim = {
   moduleRef: string;
   role: SurfaceModuleRole;
@@ -2948,6 +3047,11 @@ export function assertStreamSessionClose(record: unknown): StreamSessionClose;
 export function assertMediaFulfillmentEvidence(record: unknown): MediaFulfillmentEvidence;
 export function assertMediaTransportPath(record: unknown): MediaTransportPath;
 export function assertMediaTransportObservation(record: unknown): MediaTransportObservation;
+export function assertAppContract(record: unknown): AppContractRecord;
+export function assertAppModuleRole(record: unknown): AppModuleRoleRecord;
+export function assertAppActivity(record: unknown): AppActivityRecord;
+export function assertAppRelease(record: unknown): AppReleaseRecord;
+export function assertAppReleaseResolution(record: unknown): AppReleaseResolutionRecord;
 export function assertSurfaceModuleClaim(record: unknown): SurfaceModuleClaim;
 export function assertSurfaceAppContract(record: unknown): SurfaceAppContract;
 export function assertSurfaceAppManifest(record: unknown): SurfaceAppManifest;

--- a/src/index.js
+++ b/src/index.js
@@ -224,6 +224,12 @@ export const RUNNER = Object.freeze({
   }),
 });
 
+export const BUILD = Object.freeze({
+  CAPABILITY: Object.freeze({
+    RUN_EXECUTE: "build.run.execute",
+  }),
+});
+
 export const AGREEMENT = Object.freeze({
   PLANE: Object.freeze({
     ACTION_AUTHORITY: "actionAuthority",

--- a/src/index.js
+++ b/src/index.js
@@ -177,6 +177,50 @@ export const SURFACE_APP = Object.freeze({
   }),
 });
 
+export const APP = Object.freeze({
+  RECORD_KIND: Object.freeze({
+    CONTRACT: "app.contract",
+    MODULE_ROLE: "app.module.role",
+    ACTIVITY: "app.activity",
+    RELEASE: "app.release",
+    RELEASE_RESOLUTION: "app.release.resolution",
+  }),
+  CONTRACT_STATE: Object.freeze({
+    DRAFT: "draft",
+    READY: "ready",
+    BLOCKED: "blocked",
+    SUPERSEDED: "superseded",
+  }),
+  ACTIVITY_STATE: Object.freeze({
+    READY: "ready",
+    BLOCKED: "blocked",
+    DEPRECATED: "deprecated",
+  }),
+  ACTIVITY_LAUNCH: Object.freeze({
+    SURFACE: "surface",
+    EMBEDDED: "embedded",
+    NATIVE: "native",
+    SERVICE: "service",
+  }),
+  EMBED_POLICY: Object.freeze({
+    ALLOWED: "allowed",
+    RESTRICTED: "restricted",
+    DENIED: "denied",
+  }),
+  RELEASE_STATE: Object.freeze({
+    PUBLISHED: "published",
+    BLOCKED: "blocked",
+    SUPERSEDED: "superseded",
+    REVOKED: "revoked",
+  }),
+  RESOLUTION_STATE: Object.freeze({
+    RESOLVED: "resolved",
+    BLOCKED: "blocked",
+    DEGRADED: "degraded",
+    SUPERSEDED: "superseded",
+  }),
+});
+
 export const RUNNER = Object.freeze({
   OPERATION: Object.freeze({
     PREPARE: "prepare",
@@ -1385,6 +1429,11 @@ export const SWARM = Object.freeze({
     RUNNER_HOST_FULFILLMENT_POSTURE: "runner.host.fulfillment.posture",
     APP_RUNNER_FULFILLMENT_REPORT: "app.runner.fulfillment.report",
     APP_RUNNER_FULFILLMENT_LIFECYCLE: "app.runner.fulfillment.lifecycle",
+    APP_CONTRACT: "app.contract",
+    APP_MODULE_ROLE: "app.module.role",
+    APP_ACTIVITY: "app.activity",
+    APP_RELEASE: "app.release",
+    APP_RELEASE_RESOLUTION: "app.release.resolution",
   }),
   RECORD_KIND: Object.freeze({
     NODE_CAPABILITY: "node.capability",
@@ -1465,6 +1514,11 @@ export const SWARM = Object.freeze({
     RUNNER_HOST_FULFILLMENT_POSTURE: "runner.host.fulfillment.posture",
     APP_RUNNER_FULFILLMENT_REPORT: "app.runner.fulfillment.report",
     APP_RUNNER_FULFILLMENT_LIFECYCLE: "app.runner.fulfillment.lifecycle",
+    APP_CONTRACT: "app.contract",
+    APP_MODULE_ROLE: "app.module.role",
+    APP_ACTIVITY: "app.activity",
+    APP_RELEASE: "app.release",
+    APP_RELEASE_RESOLUTION: "app.release.resolution",
   }),
   AUTHORITY_DOMAIN: Object.freeze({
     IDENTITY: "identity",
@@ -4622,6 +4676,174 @@ export function assertCaacEnvelopeForMode(envelope, {
   }
   if (!verifyEnvelopeSignature(envelope)) throw new Error("invalid caac envelope signature");
   return envelope;
+}
+
+export function assertAppContract(record) {
+  if (!isObject(record)) throw new Error("app contract must be an object");
+  assertRecordKind(record, APP.RECORD_KIND.CONTRACT, "app contract");
+  requireString(record.appContractRef, "app contract appContractRef");
+  requireString(record.appId, "app contract appId");
+  requireString(record.version, "app contract version");
+  requireString(record.authorRef, "app contract authorRef");
+  const state = requireString(record.state, "app contract state");
+  if (!Object.values(APP.CONTRACT_STATE).includes(state)) throw new Error("invalid app contract state");
+  const primitiveRefs = assertOptionalReferenceList(record.primitiveRefs, "app contract primitiveRefs");
+  const activityRefs = assertOptionalReferenceList(record.activityRefs, "app contract activityRefs");
+  const moduleRoleRefs = assertOptionalReferenceList(record.moduleRoleRefs, "app contract moduleRoleRefs");
+  const releaseRefs = assertOptionalReferenceList(record.releaseRefs, "app contract releaseRefs");
+  assertOptionalReferenceList(record.permissionRefs, "app contract permissionRefs");
+  assertOptionalReferenceList(record.accessGroupRefs, "app contract accessGroupRefs");
+  assertOptionalReferenceList(record.compatibilityRefs, "app contract compatibilityRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "app contract evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "app contract blockedReasons");
+  if (state === APP.CONTRACT_STATE.READY && (
+    primitiveRefs.length === 0 || activityRefs.length === 0 || moduleRoleRefs.length === 0 || releaseRefs.length === 0
+  )) {
+    throw new Error("ready app contract requires primitiveRefs, activityRefs, moduleRoleRefs, and releaseRefs");
+  }
+  if (state === APP.CONTRACT_STATE.BLOCKED && blockedReasons.length === 0) {
+    throw new Error("blocked app contract requires blockedReasons");
+  }
+  rejectRouteControlByteFields(record, "app contract");
+  if (!Number(record.issuedAt || 0)) throw new Error("app contract missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt) <= Number(record.issuedAt)) {
+    throw new Error("app contract expires before issuedAt");
+  }
+  return record;
+}
+
+export function assertAppModuleRole(record) {
+  if (!isObject(record)) throw new Error("app module role must be an object");
+  assertRecordKind(record, APP.RECORD_KIND.MODULE_ROLE, "app module role");
+  requireString(record.moduleRoleRef, "app module role moduleRoleRef");
+  requireString(record.appContractRef, "app module role appContractRef");
+  const roleName = requireString(record.roleName, "app module role roleName");
+  if (!Object.values(SURFACE_APP.MODULE_ROLE).includes(roleName)) throw new Error("invalid app module role roleName");
+  if (typeof record.required !== "boolean") throw new Error("app module role required must be boolean");
+  const primitiveRefs = assertOptionalReferenceList(record.primitiveRefs, "app module role primitiveRefs");
+  assertOptionalReferenceList(record.platformRefs, "app module role platformRefs");
+  assertOptionalReferenceList(record.artifactRefs, "app module role artifactRefs");
+  assertOptionalReferenceList(record.compatibilityRefs, "app module role compatibilityRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "app module role evidenceRefs");
+  assertOptionalReferenceList(record.blockedReasons, "app module role blockedReasons");
+  if (record.required && primitiveRefs.length === 0) {
+    throw new Error("required app module role requires primitiveRefs");
+  }
+  rejectRouteControlByteFields(record, "app module role");
+  return record;
+}
+
+export function assertAppActivity(record) {
+  if (!isObject(record)) throw new Error("app activity must be an object");
+  assertRecordKind(record, APP.RECORD_KIND.ACTIVITY, "app activity");
+  requireString(record.activityRef, "app activity activityRef");
+  requireString(record.appContractRef, "app activity appContractRef");
+  requireString(record.activityId, "app activity activityId");
+  const state = requireString(record.state, "app activity state");
+  if (!Object.values(APP.ACTIVITY_STATE).includes(state)) throw new Error("invalid app activity state");
+  const launchMode = requireString(record.launchMode, "app activity launchMode");
+  if (!Object.values(APP.ACTIVITY_LAUNCH).includes(launchMode)) throw new Error("invalid app activity launchMode");
+  const embedPolicy = requireString(record.embedPolicy, "app activity embedPolicy");
+  if (!Object.values(APP.EMBED_POLICY).includes(embedPolicy)) throw new Error("invalid app activity embedPolicy");
+  const primitiveRefs = assertOptionalReferenceList(record.primitiveRefs, "app activity primitiveRefs");
+  const moduleRoleRefs = assertOptionalReferenceList(record.moduleRoleRefs, "app activity moduleRoleRefs");
+  assertOptionalReferenceList(record.permissionRefs, "app activity permissionRefs");
+  assertOptionalReferenceList(record.accessGroupRefs, "app activity accessGroupRefs");
+  assertOptionalReferenceList(record.materializationRefs, "app activity materializationRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "app activity evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "app activity blockedReasons");
+  if (state === APP.ACTIVITY_STATE.READY && (primitiveRefs.length === 0 || moduleRoleRefs.length === 0)) {
+    throw new Error("ready app activity requires primitiveRefs and moduleRoleRefs");
+  }
+  if (state === APP.ACTIVITY_STATE.BLOCKED && blockedReasons.length === 0) {
+    throw new Error("blocked app activity requires blockedReasons");
+  }
+  rejectRouteControlByteFields(record, "app activity");
+  if (!Number(record.issuedAt || 0)) throw new Error("app activity missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt) <= Number(record.issuedAt)) {
+    throw new Error("app activity expires before issuedAt");
+  }
+  return record;
+}
+
+export function assertAppRelease(record) {
+  if (!isObject(record)) throw new Error("app release must be an object");
+  assertRecordKind(record, APP.RECORD_KIND.RELEASE, "app release");
+  requireString(record.releaseRef, "app release releaseRef");
+  requireString(record.appContractRef, "app release appContractRef");
+  requireString(record.version, "app release version");
+  requireString(record.sourceSnapshotRef, "app release sourceSnapshotRef");
+  requireString(record.buildRunRef, "app release buildRunRef");
+  const state = requireString(record.state, "app release state");
+  if (!Object.values(APP.RELEASE_STATE).includes(state)) throw new Error("invalid app release state");
+  const artifactRefs = assertOptionalReferenceList(record.artifactRefs, "app release artifactRefs");
+  const proofRefs = assertOptionalReferenceList(record.proofRefs, "app release proofRefs");
+  assertOptionalReferenceList(record.moduleRoleRefs, "app release moduleRoleRefs");
+  const storageRefs = assertOptionalReferenceList(record.storageRefs, "app release storageRefs");
+  const compatibilityRefs = assertOptionalReferenceList(record.compatibilityRefs, "app release compatibilityRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "app release evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "app release blockedReasons");
+  if (state === APP.RELEASE_STATE.PUBLISHED && (
+    artifactRefs.length === 0 || proofRefs.length === 0 || storageRefs.length === 0 || compatibilityRefs.length === 0
+  )) {
+    throw new Error("published app release requires artifactRefs, proofRefs, storageRefs, and compatibilityRefs");
+  }
+  if ([APP.RELEASE_STATE.BLOCKED, APP.RELEASE_STATE.REVOKED].includes(state) && blockedReasons.length === 0) {
+    throw new Error("blocked or revoked app release requires blockedReasons");
+  }
+  rejectRouteControlByteFields(record, "app release");
+  if (!Number(record.issuedAt || 0)) throw new Error("app release missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt) <= Number(record.issuedAt)) {
+    throw new Error("app release expires before issuedAt");
+  }
+  return record;
+}
+
+export function assertAppReleaseResolution(record) {
+  if (!isObject(record)) throw new Error("app release resolution must be an object");
+  assertRecordKind(record, APP.RECORD_KIND.RELEASE_RESOLUTION, "app release resolution");
+  requireString(record.resolutionRef, "app release resolution resolutionRef");
+  requireString(record.appIntentRef, "app release resolution appIntentRef");
+  requireString(record.appContractRef, "app release resolution appContractRef");
+  requireString(record.requestedVersion, "app release resolution requestedVersion");
+  const state = requireString(record.state, "app release resolution state");
+  if (!Object.values(APP.RESOLUTION_STATE).includes(state)) throw new Error("invalid app release resolution state");
+  if (record.selectedReleaseRef !== undefined) requireString(record.selectedReleaseRef, "app release resolution selectedReleaseRef");
+  if (record.selectedActivityRef !== undefined) requireString(record.selectedActivityRef, "app release resolution selectedActivityRef");
+  const selectedArtifactRefs = assertOptionalReferenceList(record.selectedArtifactRefs, "app release resolution selectedArtifactRefs");
+  const selectedModuleRoleRefs = assertOptionalReferenceList(record.selectedModuleRoleRefs, "app release resolution selectedModuleRoleRefs");
+  const selectedStorageRefs = assertOptionalReferenceList(record.selectedStorageRefs, "app release resolution selectedStorageRefs");
+  const sourceDigestRefs = assertOptionalReferenceList(record.sourceDigestRefs, "app release resolution sourceDigestRefs");
+  if (record.sourceSnapshotRef !== undefined) requireString(record.sourceSnapshotRef, "app release resolution sourceSnapshotRef");
+  const buildProofRefs = assertOptionalReferenceList(record.buildProofRefs, "app release resolution buildProofRefs");
+  const compatibilityRefs = assertOptionalReferenceList(record.compatibilityRefs, "app release resolution compatibilityRefs");
+  assertOptionalReferenceList(record.permissionRefs, "app release resolution permissionRefs");
+  assertOptionalReferenceList(record.accessGroupRefs, "app release resolution accessGroupRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "app release resolution evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "app release resolution blockedReasons");
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "app release resolution safeFacts");
+  if (state === APP.RESOLUTION_STATE.RESOLVED && (
+    !String(record.selectedReleaseRef || "").trim()
+      || !String(record.selectedActivityRef || "").trim()
+      || selectedArtifactRefs.length === 0
+      || selectedModuleRoleRefs.length === 0
+      || selectedStorageRefs.length === 0
+      || sourceDigestRefs.length === 0
+      || !String(record.sourceSnapshotRef || "").trim()
+      || buildProofRefs.length === 0
+      || compatibilityRefs.length === 0
+  )) {
+    throw new Error("resolved app release requires selected release, activity, artifacts, module roles, storage, source digest, source snapshot, build proof, and compatibility refs");
+  }
+  if ([APP.RESOLUTION_STATE.BLOCKED, APP.RESOLUTION_STATE.DEGRADED].includes(state) && blockedReasons.length === 0) {
+    throw new Error("blocked or degraded app release resolution requires blockedReasons");
+  }
+  rejectRouteControlByteFields(record, "app release resolution");
+  if (!Number(record.resolvedAt || 0)) throw new Error("app release resolution missing resolvedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt) <= Number(record.resolvedAt)) {
+    throw new Error("app release resolution expires before resolvedAt");
+  }
+  return record;
 }
 
 export function assertAppRecipe(record) {

--- a/src/index.js
+++ b/src/index.js
@@ -184,6 +184,9 @@ export const APP = Object.freeze({
     ACTIVITY: "app.activity",
     RELEASE: "app.release",
     RELEASE_RESOLUTION: "app.release.resolution",
+    ACTIVITY_DEPENDENCY: "app.activity.dependency",
+    MESSAGING_CONTRACT: "messaging.contract",
+    COMMUNICATIONS_MODERATION_CONTRACT: "communications.moderation.contract",
   }),
   CONTRACT_STATE: Object.freeze({
     DRAFT: "draft",
@@ -218,6 +221,29 @@ export const APP = Object.freeze({
     BLOCKED: "blocked",
     DEGRADED: "degraded",
     SUPERSEDED: "superseded",
+  }),
+  DEPENDENCY_TYPE: Object.freeze({
+    MESSAGING: "messaging",
+    COMMUNICATIONS_MODERATION: "communicationsModeration",
+  }),
+  DEPENDENCY_STATE: Object.freeze({
+    READY: "ready",
+    PENDING: "pending",
+    DEGRADED: "degraded",
+    BLOCKED: "blocked",
+    EXPIRED: "expired",
+  }),
+  MESSAGING_STATE: Object.freeze({
+    READY: "ready",
+    DEGRADED: "degraded",
+    BLOCKED: "blocked",
+    EXPIRED: "expired",
+  }),
+  COMMUNICATIONS_MODERATION_STATE: Object.freeze({
+    READY: "ready",
+    DEGRADED: "degraded",
+    BLOCKED: "blocked",
+    EXPIRED: "expired",
   }),
 });
 
@@ -1434,6 +1460,9 @@ export const SWARM = Object.freeze({
     APP_ACTIVITY: "app.activity",
     APP_RELEASE: "app.release",
     APP_RELEASE_RESOLUTION: "app.release.resolution",
+    APP_ACTIVITY_DEPENDENCY: "app.activity.dependency",
+    MESSAGING_CONTRACT: "messaging.contract",
+    COMMUNICATIONS_MODERATION_CONTRACT: "communications.moderation.contract",
   }),
   RECORD_KIND: Object.freeze({
     NODE_CAPABILITY: "node.capability",
@@ -1519,6 +1548,9 @@ export const SWARM = Object.freeze({
     APP_ACTIVITY: "app.activity",
     APP_RELEASE: "app.release",
     APP_RELEASE_RESOLUTION: "app.release.resolution",
+    APP_ACTIVITY_DEPENDENCY: "app.activity.dependency",
+    MESSAGING_CONTRACT: "messaging.contract",
+    COMMUNICATIONS_MODERATION_CONTRACT: "communications.moderation.contract",
   }),
   AUTHORITY_DOMAIN: Object.freeze({
     IDENTITY: "identity",
@@ -4842,6 +4874,113 @@ export function assertAppReleaseResolution(record) {
   if (!Number(record.resolvedAt || 0)) throw new Error("app release resolution missing resolvedAt");
   if (record.expiresAt !== undefined && Number(record.expiresAt) <= Number(record.resolvedAt)) {
     throw new Error("app release resolution expires before resolvedAt");
+  }
+  return record;
+}
+
+export function assertAppActivityDependency(record) {
+  if (!isObject(record)) throw new Error("app activity dependency must be an object");
+  assertRecordKind(record, APP.RECORD_KIND.ACTIVITY_DEPENDENCY, "app activity dependency");
+  requireString(record.dependencyRef, "app activity dependency dependencyRef");
+  requireString(record.appContractRef, "app activity dependency appContractRef");
+  requireString(record.activityRef, "app activity dependency activityRef");
+  const dependencyType = requireString(record.dependencyType, "app activity dependency dependencyType");
+  if (!Object.values(APP.DEPENDENCY_TYPE).includes(dependencyType)) throw new Error("invalid app activity dependency type");
+  if (typeof record.required !== "boolean") throw new Error("app activity dependency required must be boolean");
+  const state = requireString(record.state, "app activity dependency state");
+  if (!Object.values(APP.DEPENDENCY_STATE).includes(state)) throw new Error("invalid app activity dependency state");
+  const contractRefs = assertOptionalReferenceList(record.contractRefs, "app activity dependency contractRefs");
+  const primitiveRefs = assertOptionalReferenceList(record.primitiveRefs, "app activity dependency primitiveRefs");
+  assertOptionalReferenceList(record.permissionRefs, "app activity dependency permissionRefs");
+  assertOptionalReferenceList(record.accessGroupRefs, "app activity dependency accessGroupRefs");
+  assertOptionalReferenceList(record.materializationRefs, "app activity dependency materializationRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "app activity dependency evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "app activity dependency blockedReasons");
+  if (record.required && state === APP.DEPENDENCY_STATE.READY && (contractRefs.length === 0 || primitiveRefs.length === 0)) {
+    throw new Error("ready required app activity dependency requires contractRefs and primitiveRefs");
+  }
+  if (state === APP.DEPENDENCY_STATE.BLOCKED && blockedReasons.length === 0) {
+    throw new Error("blocked app activity dependency requires blockedReasons");
+  }
+  assertNoPrivateContentFields(record, "app activity dependency");
+  if (!Number(record.issuedAt || 0)) throw new Error("app activity dependency missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt) <= Number(record.issuedAt)) {
+    throw new Error("app activity dependency expires before issuedAt");
+  }
+  return record;
+}
+
+export function assertMessagingContract(record) {
+  if (!isObject(record)) throw new Error("messaging contract must be an object");
+  assertRecordKind(record, APP.RECORD_KIND.MESSAGING_CONTRACT, "messaging contract");
+  requireString(record.messagingContractRef, "messaging contract messagingContractRef");
+  requireString(record.scopeRef, "messaging contract scopeRef");
+  requireString(record.authorRef, "messaging contract authorRef");
+  const state = requireString(record.state, "messaging contract state");
+  if (!Object.values(APP.MESSAGING_STATE).includes(state)) throw new Error("invalid messaging contract state");
+  assertOptionalReferenceList(record.conversationRefs, "messaging contract conversationRefs");
+  const participantRoleRefs = assertOptionalReferenceList(record.participantRoleRefs, "messaging contract participantRoleRefs");
+  const activityRefs = assertOptionalReferenceList(record.activityRefs, "messaging contract activityRefs");
+  const contentClassRefs = assertOptionalReferenceList(record.contentClassRefs, "messaging contract contentClassRefs");
+  const accessGroupRefs = assertOptionalReferenceList(record.accessGroupRefs, "messaging contract accessGroupRefs");
+  const witnessFloorRefs = assertOptionalReferenceList(record.witnessFloorRefs, "messaging contract witnessFloorRefs");
+  const retentionRefs = assertOptionalReferenceList(record.retentionRefs, "messaging contract retentionRefs");
+  assertOptionalReferenceList(record.moderationContractRefs, "messaging contract moderationContractRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "messaging contract evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "messaging contract blockedReasons");
+  if (state === APP.MESSAGING_STATE.READY && (
+    participantRoleRefs.length === 0
+      || activityRefs.length === 0
+      || contentClassRefs.length === 0
+      || accessGroupRefs.length === 0
+      || witnessFloorRefs.length === 0
+      || retentionRefs.length === 0
+  )) {
+    throw new Error("ready messaging contract requires participant roles, activities, content classes, access groups, witness floors, and retention refs");
+  }
+  if (state === APP.MESSAGING_STATE.BLOCKED && blockedReasons.length === 0) {
+    throw new Error("blocked messaging contract requires blockedReasons");
+  }
+  assertNoPrivateContentFields(record, "messaging contract");
+  if (!Number(record.issuedAt || 0)) throw new Error("messaging contract missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt) <= Number(record.issuedAt)) {
+    throw new Error("messaging contract expires before issuedAt");
+  }
+  return record;
+}
+
+export function assertCommunicationsModerationContract(record) {
+  if (!isObject(record)) throw new Error("communications moderation contract must be an object");
+  assertRecordKind(record, APP.RECORD_KIND.COMMUNICATIONS_MODERATION_CONTRACT, "communications moderation contract");
+  requireString(record.moderationContractRef, "communications moderation contract moderationContractRef");
+  requireString(record.scopeRef, "communications moderation contract scopeRef");
+  requireString(record.authorityRealmRef, "communications moderation contract authorityRealmRef");
+  const state = requireString(record.state, "communications moderation contract state");
+  if (!Object.values(APP.COMMUNICATIONS_MODERATION_STATE).includes(state)) throw new Error("invalid communications moderation contract state");
+  const actionRefs = assertOptionalReferenceList(record.actionRefs, "communications moderation contract actionRefs");
+  const targetRefs = assertOptionalReferenceList(record.targetRefs, "communications moderation contract targetRefs");
+  const messagingContractRefs = assertOptionalReferenceList(record.messagingContractRefs, "communications moderation contract messagingContractRefs");
+  assertOptionalReferenceList(record.eventFabricRefs, "communications moderation contract eventFabricRefs");
+  const permissionRefs = assertOptionalReferenceList(record.permissionRefs, "communications moderation contract permissionRefs");
+  const accessGroupRefs = assertOptionalReferenceList(record.accessGroupRefs, "communications moderation contract accessGroupRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "communications moderation contract evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "communications moderation contract blockedReasons");
+  if (state === APP.COMMUNICATIONS_MODERATION_STATE.READY && (
+    actionRefs.length === 0
+      || targetRefs.length === 0
+      || messagingContractRefs.length === 0
+      || permissionRefs.length === 0
+      || accessGroupRefs.length === 0
+  )) {
+    throw new Error("ready communications moderation contract requires actions, targets, messaging contracts, permissions, and access groups");
+  }
+  if (state === APP.COMMUNICATIONS_MODERATION_STATE.BLOCKED && blockedReasons.length === 0) {
+    throw new Error("blocked communications moderation contract requires blockedReasons");
+  }
+  assertNoPrivateContentFields(record, "communications moderation contract");
+  if (!Number(record.issuedAt || 0)) throw new Error("communications moderation contract missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt) <= Number(record.issuedAt)) {
+    throw new Error("communications moderation contract expires before issuedAt");
   }
   return record;
 }

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -5431,6 +5431,7 @@ pub fn validate_service_manager_operation_posture(
         "service manager operation posture missing rollbackRef",
     )?;
     if record.operation == SERVICE_MANAGER_OPERATION_ROLLBACK
+        && record.state != SERVICE_MANAGER_OPERATION_STATE_BLOCKED
         && record
             .rollback_ref
             .as_deref()
@@ -5443,6 +5444,7 @@ pub fn validate_service_manager_operation_posture(
         ));
     }
     if record.operation == SERVICE_MANAGER_OPERATION_RELEASE
+        && record.state != SERVICE_MANAGER_OPERATION_STATE_BLOCKED
         && record
             .release_ref
             .as_deref()

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -92,6 +92,9 @@ import {
   assertAppModuleRole,
   assertAppRelease,
   assertAppReleaseResolution,
+  assertAppActivityDependency,
+  assertMessagingContract,
+  assertCommunicationsModerationContract,
   assertServiceManagerPosture,
   assertServiceManagerSecretBoundary,
   assertServiceManagerReleaseContract,
@@ -791,6 +794,98 @@ test("app contracts validate activity release and resolution records", () => {
     ...resolution,
     selectedStorageRefs: [],
   }), /resolved app release requires selected release/);
+});
+
+test("messaging and communications moderation remain app activity dependencies", () => {
+  const issuedAt = 1_779_267_000;
+  const messaging = assertMessagingContract({
+    kind: APP.RECORD_KIND.MESSAGING_CONTRACT,
+    messagingContractRef: "messaging:contract:truecost.web-team",
+    scopeRef: "activity:scope:truecost.web-team.hosting",
+    authorRef: "identity:truecost.root",
+    state: APP.MESSAGING_STATE.READY,
+    conversationRefs: ["messaging:thread:truecost.web-team.hosting"],
+    participantRoleRefs: ["role:community.member", "role:webadmin"],
+    activityRefs: ["app:activity:messaging.thread"],
+    contentClassRefs: ["content:message.body", "content:message.safe-index"],
+    accessGroupRefs: ["access-group:truecost.web-team"],
+    witnessFloorRefs: ["witness:floor:messaging.thread"],
+    retentionRefs: ["retention:message.thread.default"],
+    moderationContractRefs: ["moderation:contract:truecost.web-team"],
+    evidenceRefs: ["evidence:messaging.contract"],
+    issuedAt,
+    expiresAt: issuedAt + 3_600,
+  });
+  const moderation = assertCommunicationsModerationContract({
+    kind: APP.RECORD_KIND.COMMUNICATIONS_MODERATION_CONTRACT,
+    moderationContractRef: "moderation:contract:truecost.web-team",
+    scopeRef: messaging.scopeRef,
+    authorityRealmRef: "authority:realm:truecost.community",
+    state: APP.COMMUNICATIONS_MODERATION_STATE.READY,
+    actionRefs: ["moderation:action:report", "moderation:action:hide", "moderation:action:appeal"],
+    targetRefs: messaging.conversationRefs,
+    messagingContractRefs: [messaging.messagingContractRef],
+    eventFabricRefs: ["event-fabric:logging.default"],
+    permissionRefs: ["permission:moderation.web-team"],
+    accessGroupRefs: ["access-group:truecost.moderators"],
+    evidenceRefs: ["evidence:moderation.contract"],
+    issuedAt,
+    expiresAt: issuedAt + 3_600,
+  });
+  const messagingDependency = assertAppActivityDependency({
+    kind: APP.RECORD_KIND.ACTIVITY_DEPENDENCY,
+    dependencyRef: "app:dependency:community.channel.messaging",
+    appContractRef: "app:contract:communities@0.1.0",
+    activityRef: "app:activity:community.role-channel",
+    dependencyType: APP.DEPENDENCY_TYPE.MESSAGING,
+    required: true,
+    state: APP.DEPENDENCY_STATE.READY,
+    contractRefs: [messaging.messagingContractRef],
+    primitiveRefs: ["primitive:messaging.thread"],
+    permissionRefs: ["permission:message.write"],
+    accessGroupRefs: messaging.accessGroupRefs,
+    materializationRefs: ["materialization:thread.messages"],
+    evidenceRefs: ["evidence:dependency.messaging"],
+    issuedAt,
+    expiresAt: issuedAt + 3_600,
+  });
+  const moderationDependency = assertAppActivityDependency({
+    kind: APP.RECORD_KIND.ACTIVITY_DEPENDENCY,
+    dependencyRef: "app:dependency:community.channel.moderation",
+    appContractRef: "app:contract:communities@0.1.0",
+    activityRef: "app:activity:community.role-channel",
+    dependencyType: APP.DEPENDENCY_TYPE.COMMUNICATIONS_MODERATION,
+    required: false,
+    state: APP.DEPENDENCY_STATE.READY,
+    contractRefs: [moderation.moderationContractRef],
+    primitiveRefs: ["primitive:communications.moderation"],
+    permissionRefs: moderation.permissionRefs,
+    accessGroupRefs: moderation.accessGroupRefs,
+    materializationRefs: ["materialization:moderation.posture"],
+    evidenceRefs: ["evidence:dependency.moderation"],
+    issuedAt,
+    expiresAt: issuedAt + 3_600,
+  });
+
+  assert.equal(messagingDependency.dependencyType, "messaging");
+  assert.equal(moderationDependency.dependencyType, "communicationsModeration");
+  assert.throws(() => assertMessagingContract({
+    ...messaging,
+    contentClassRefs: [],
+  }), /ready messaging contract requires participant roles/);
+  assert.throws(() => assertAppActivityDependency({
+    ...messagingDependency,
+    state: APP.DEPENDENCY_STATE.BLOCKED,
+    blockedReasons: [],
+  }), /blocked app activity dependency requires blockedReasons/);
+  assert.throws(() => assertCommunicationsModerationContract({
+    ...moderation,
+    actionRefs: [],
+  }), /ready communications moderation contract requires actions/);
+  assert.throws(() => assertAppActivityDependency({
+    ...messagingDependency,
+    payload: "message bodies stay behind CAAC access refs",
+  }), /forbidden protocol field: payload/);
 });
 
 test("service edge adapter posture validates service-owned admission and backpressure evidence", () => {

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -5,6 +5,7 @@ import {
   BROKER,
   DIAGNOSTICS,
   AGREEMENT,
+  APP,
   LOGGING,
   PROJECTION,
   RUNNER,
@@ -86,6 +87,11 @@ import {
   assertMediaFulfillmentEvidence,
   assertMediaTransportPath,
   assertMediaTransportObservation,
+  assertAppActivity,
+  assertAppContract,
+  assertAppModuleRole,
+  assertAppRelease,
+  assertAppReleaseResolution,
   assertServiceManagerPosture,
   assertServiceManagerSecretBoundary,
   assertServiceManagerReleaseContract,
@@ -681,6 +687,110 @@ test("surface app contracts validate module roles and fulfillment boundaries", (
     ...runtimeClient,
     role: "runtimePolicy",
   }), /invalid surface module role/);
+});
+
+test("app contracts validate activity release and resolution records", () => {
+  const contract = assertAppContract({
+    kind: APP.RECORD_KIND.CONTRACT,
+    appContractRef: "app:contract:community-launcher@0.1.0",
+    appId: "community-launcher",
+    version: "0.1.0",
+    authorRef: "identity:community-root",
+    state: APP.CONTRACT_STATE.READY,
+    primitiveRefs: ["app.activity", "runtime.selection"],
+    activityRefs: ["app:activity:community-launcher.channel"],
+    moduleRoleRefs: [
+      "app:module-role:community-launcher.runtime",
+      "app:module-role:community-launcher.view",
+    ],
+    releaseRefs: ["app:release:community-launcher@0.1.0"],
+    permissionRefs: ["permission:community-launcher:run"],
+    accessGroupRefs: ["access-group:community-launcher:members"],
+    compatibilityRefs: ["compat:surface-app:0.1"],
+    evidenceRefs: ["evidence:app-contract:community-launcher"],
+    issuedAt: 1_779_266_000,
+    expiresAt: 1_779_269_600,
+  });
+  const runtimeRole = assertAppModuleRole({
+    kind: APP.RECORD_KIND.MODULE_ROLE,
+    moduleRoleRef: "app:module-role:community-launcher.runtime",
+    appContractRef: contract.appContractRef,
+    roleName: SURFACE_APP.MODULE_ROLE.RUNTIME_CLIENT,
+    required: true,
+    primitiveRefs: ["runtime.attach"],
+    artifactRefs: ["build:artifact:community-launcher-runtime"],
+    compatibilityRefs: ["compat:surface-app:0.1"],
+    evidenceRefs: ["evidence:module-role:runtime"],
+  });
+  const activity = assertAppActivity({
+    kind: APP.RECORD_KIND.ACTIVITY,
+    activityRef: "app:activity:community-launcher.channel",
+    appContractRef: contract.appContractRef,
+    activityId: "channel",
+    state: APP.ACTIVITY_STATE.READY,
+    launchMode: APP.ACTIVITY_LAUNCH.EMBEDDED,
+    embedPolicy: APP.EMBED_POLICY.RESTRICTED,
+    primitiveRefs: ["messaging.thread.observe", "community.role.write"],
+    moduleRoleRefs: [runtimeRole.moduleRoleRef, "app:module-role:community-launcher.view"],
+    permissionRefs: ["permission:community-channel:write"],
+    accessGroupRefs: ["access-group:community-launcher:members"],
+    materializationRefs: ["materialization:community-channel:messages"],
+    evidenceRefs: ["evidence:activity:community-channel"],
+    issuedAt: 1_779_266_000,
+    expiresAt: 1_779_269_600,
+  });
+  const release = assertAppRelease({
+    kind: APP.RECORD_KIND.RELEASE,
+    releaseRef: "app:release:community-launcher@0.1.0",
+    appContractRef: contract.appContractRef,
+    version: contract.version,
+    sourceSnapshotRef: "source:snapshot:community-launcher:head",
+    buildRunRef: "build:run:community-launcher@0.1.0",
+    state: APP.RELEASE_STATE.PUBLISHED,
+    artifactRefs: ["build:artifact:community-launcher-runtime", "build:artifact:community-launcher-view"],
+    proofRefs: ["build:proof:community-launcher@0.1.0"],
+    moduleRoleRefs: contract.moduleRoleRefs,
+    storageRefs: ["storage:object:community-launcher@0.1.0"],
+    compatibilityRefs: contract.compatibilityRefs,
+    evidenceRefs: ["evidence:release:community-launcher"],
+    issuedAt: 1_779_266_010,
+    expiresAt: 1_779_269_600,
+  });
+  const resolution = assertAppReleaseResolution({
+    kind: APP.RECORD_KIND.RELEASE_RESOLUTION,
+    resolutionRef: "app:resolution:community-launcher@0.1.0",
+    appIntentRef: "app:intent:community-launcher:channel",
+    appContractRef: contract.appContractRef,
+    requestedVersion: contract.version,
+    state: APP.RESOLUTION_STATE.RESOLVED,
+    selectedReleaseRef: release.releaseRef,
+    selectedActivityRef: activity.activityRef,
+    selectedArtifactRefs: release.artifactRefs,
+    selectedModuleRoleRefs: release.moduleRoleRefs,
+    selectedStorageRefs: release.storageRefs,
+    sourceDigestRefs: ["source:digest:community-launcher@0.1.0"],
+    sourceSnapshotRef: release.sourceSnapshotRef,
+    buildProofRefs: release.proofRefs,
+    compatibilityRefs: release.compatibilityRefs,
+    permissionRefs: contract.permissionRefs,
+    accessGroupRefs: contract.accessGroupRefs,
+    evidenceRefs: ["evidence:resolution:community-launcher"],
+    safeFacts: { activityId: activity.activityId, artifactCount: release.artifactRefs.length },
+    resolvedAt: 1_779_266_020,
+    expiresAt: 1_779_269_600,
+  });
+
+  assert.equal(contract.appContractRef, "app:contract:community-launcher@0.1.0");
+  assert.equal(activity.launchMode, APP.ACTIVITY_LAUNCH.EMBEDDED);
+  assert.deepEqual(resolution.selectedStorageRefs, ["storage:object:community-launcher@0.1.0"]);
+  assert.throws(() => assertAppActivity({
+    ...activity,
+    moduleRoleRefs: [],
+  }), /ready app activity requires primitiveRefs and moduleRoleRefs/);
+  assert.throws(() => assertAppReleaseResolution({
+    ...resolution,
+    selectedStorageRefs: [],
+  }), /resolved app release requires selected release/);
 });
 
 test("service edge adapter posture validates service-owned admission and backpressure evidence", () => {


### PR DESCRIPTION
## Summary
- add lifecycle preflight posture, build runner capabilities, app activity grammar, and messaging/moderation contracts
- keep shared primitives in protocol so services and surfaces consume one grammar

## Verification
- npm run check:all
- local browser smoke