### PR TITLE
Add MSA target and fabric contract primitives

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,6 +8,7 @@ export const SERVICE_SURFACE: Readonly<Record<string, unknown>>;
 export const SURFACE_APP: Readonly<Record<string, unknown>>;
 export const APP: Readonly<Record<string, unknown>>;
 export const RUNNER: Readonly<Record<string, unknown>>;
+export const FABRIC: Readonly<Record<string, unknown>>;
 export const BUILD: Readonly<Record<string, unknown>>;
 export const AGREEMENT: Readonly<Record<string, unknown>>;
 export const SERVICE_REGISTRY: Readonly<Record<string, unknown>>;
@@ -2923,6 +2924,171 @@ export type AppRunnerFulfillmentLifecycle = {
   expiresAt?: number;
 };
 
+export type FabricAssociationHandoffState = "ready" | "handedOff" | "degraded" | "blocked" | "expired";
+export type FabricMemberRole =
+  | "gatewayAssociation"
+  | "hostServiceAdapter"
+  | "executionFulfillment"
+  | "storageJournalCache"
+  | "sourceContentIndex"
+  | "buildProcessor"
+  | "runtime"
+  | "surface"
+  | "platformAdapter"
+  | "serviceSurfaceAdapter"
+  | "serviceEdgeAdapter"
+  | "loggingProcessor"
+  | "domainService";
+export type FabricMemberContributionState = "claimed" | "accepted" | "running" | "degraded" | "blocked" | "released" | "expired" | "superseded";
+export type FabricFulfillmentPlanState = "ready" | "degraded" | "blocked" | "expired";
+export type FabricLifecyclePlanState = "ready" | "running" | "degraded" | "blocked" | "released" | "expired";
+export type FabricLifecyclePhase = "source" | "build" | "release" | "load" | "run" | "observe" | "rollback" | "expiry" | "cleanup";
+export type FabricLifecyclePhaseState = "notRequired" | "pending" | "ready" | "running" | "succeeded" | "degraded" | "blocked" | "failed" | "released" | "expired";
+export type FabricContentIndexState = "ready" | "degraded" | "blocked" | "superseded" | "expired";
+export type FabricContractIntentionState = "draft" | "ready" | "degraded" | "blocked" | "superseded" | "expired";
+export type FabricUniqueEdgeClassificationState = "genericPrimitive" | "uniqueEdge" | "blocked";
+
+export type SubstrateAssociationHandoff = {
+  kind?: "substrate.association.handoff";
+  handoffId: string;
+  substrateRef: string;
+  hostRef: string;
+  ownerRef: string;
+  fabricRef: string;
+  state: FabricAssociationHandoffState;
+  initialAssociationRefs: string[];
+  gatewayAssociationRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+  issuedAt: number;
+  handedOffAt?: number;
+  expiresAt?: number;
+};
+
+export type HostFabricMemberContribution = {
+  kind?: "hostFabric.member.contribution";
+  contributionId: string;
+  fabricRef: string;
+  hostRef: string;
+  memberRef: string;
+  role: FabricMemberRole;
+  state: FabricMemberContributionState;
+  contractRef: string;
+  subjectRef: string;
+  capabilityRefs?: string[];
+  grantRefs?: string[];
+  inputRefs?: string[];
+  outputRefs?: string[];
+  evidenceRefs?: string[];
+  lifecyclePlanRefs?: string[];
+  releaseRefs?: string[];
+  resourcePosture?: ResourcePosture | null;
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+  observedAt: number;
+  expiresAt?: number;
+};
+
+export type HostFabricFulfillmentPlan = {
+  kind?: "hostFabric.fulfillment.plan";
+  planId: string;
+  fabricRef: string;
+  hostRef: string;
+  contractRef: string;
+  state: FabricFulfillmentPlanState;
+  requiredRoleRefs: string[];
+  memberContributionRefs?: string[];
+  missingRoleRefs?: string[];
+  lifecyclePlanRefs?: string[];
+  materializationBudgetRefs?: string[];
+  associationHandoffRef?: string;
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+  observedAt: number;
+  expiresAt?: number;
+};
+
+export type LifecyclePhasePosture = {
+  phase: FabricLifecyclePhase;
+  state: FabricLifecyclePhaseState;
+  evidenceRefs?: string[];
+  outputRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+};
+
+export type LifecyclePlanPosture = {
+  kind?: "lifecycle.plan.posture";
+  lifecyclePlanId: string;
+  subjectRef: string;
+  contractRef: string;
+  state: FabricLifecyclePlanState;
+  lifecycleContractRefs: string[];
+  phasePostures: LifecyclePhasePosture[];
+  memberContributionRefs?: string[];
+  evidenceRefs?: string[];
+  releaseRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+  observedAt: number;
+  expiresAt?: number;
+};
+
+export type ContentIndexRefPosture = {
+  kind?: "contentIndex.ref.posture";
+  postureId: string;
+  contentIndexRef: string;
+  state: FabricContentIndexState;
+  sourceRefs?: string[];
+  materializedProjectionRefs?: string[];
+  storageRefs?: string[];
+  writerRefs?: string[];
+  schemaRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+  observedAt: number;
+  expiresAt?: number;
+};
+
+export type ContractIntentionPosture = {
+  kind?: "contract.intention.posture";
+  postureId: string;
+  intentionRef: string;
+  state: FabricContractIntentionState;
+  canonicalHashRef?: string;
+  contentIndexRefs?: string[];
+  authoringSurfaceRefs?: string[];
+  proofGateRefs?: string[];
+  reducerRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+  observedAt: number;
+  expiresAt?: number;
+};
+
+export type UniqueEdgeClassification = {
+  kind?: "uniqueEdge.classification";
+  classificationId: string;
+  subjectRef: string;
+  state: FabricUniqueEdgeClassificationState;
+  primitiveRef?: string;
+  externalRealityRef?: string;
+  interactionRef?: string;
+  policyRefs?: string[];
+  inputRefs?: string[];
+  outputRefs?: string[];
+  grantRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+  observedAt: number;
+  expiresAt?: number;
+};
+
 export function bytesToHex(bytes: Uint8Array): string;
 export function hexToBytes(hex: string): Uint8Array;
 export function utf8ToBytes(value: string): Uint8Array;
@@ -3145,3 +3311,10 @@ export function assertRunnerOperation(record: unknown): RunnerOperationRecord;
 export function assertRunnerHostFulfillmentPosture(record: unknown): RunnerHostFulfillmentPosture;
 export function assertAppRunnerFulfillmentReport(record: unknown): AppRunnerFulfillmentReport;
 export function assertAppRunnerFulfillmentLifecycle(record: unknown): AppRunnerFulfillmentLifecycle;
+export function assertSubstrateAssociationHandoff(record: unknown): SubstrateAssociationHandoff;
+export function assertHostFabricMemberContribution(record: unknown): HostFabricMemberContribution;
+export function assertHostFabricFulfillmentPlan(record: unknown): HostFabricFulfillmentPlan;
+export function assertLifecyclePlanPosture(record: unknown): LifecyclePlanPosture;
+export function assertContentIndexRefPosture(record: unknown): ContentIndexRefPosture;
+export function assertContractIntentionPosture(record: unknown): ContractIntentionPosture;
+export function assertUniqueEdgeClassification(record: unknown): UniqueEdgeClassification;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2947,6 +2947,8 @@ export type FabricLifecyclePhaseState = "notRequired" | "pending" | "ready" | "r
 export type FabricContentIndexState = "ready" | "degraded" | "blocked" | "superseded" | "expired";
 export type FabricContractIntentionState = "draft" | "ready" | "degraded" | "blocked" | "superseded" | "expired";
 export type FabricUniqueEdgeClassificationState = "genericPrimitive" | "uniqueEdge" | "blocked";
+export type FabricContractTargetState = "selected" | "ready" | "degraded" | "blocked" | "expired";
+export type FabricContractTargetCompatibilityState = "compatible" | "degraded" | "incompatible" | "unknown";
 
 export type SubstrateAssociationHandoff = {
   kind?: "substrate.association.handoff";
@@ -3086,6 +3088,36 @@ export type UniqueEdgeClassification = {
   blockedReasons?: string[];
   safeFacts?: Record<string, unknown>;
   observedAt: number;
+  expiresAt?: number;
+};
+
+export type ContractTarget = {
+  kind?: "contract.target";
+  targetRef: string;
+  contractRef: string;
+  profileRef: string;
+  platformRef: string;
+  state: FabricContractTargetState;
+  compatibilityState: FabricContractTargetCompatibilityState;
+  hostRef?: string;
+  substrateRef?: string;
+  modifierRefs?: string[];
+  branchRefs?: string[];
+  subbranchRefs?: string[];
+  capabilitySlotRefs: string[];
+  adapterPackRef?: string;
+  adapterRefs?: string[];
+  negativeSlotRefs?: string[];
+  missingSlotRefs?: string[];
+  degradedSlotRefs?: string[];
+  proofProfileRefs?: string[];
+  proofRefs?: string[];
+  compatibilityRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  targetAudience: string;
+  safeFacts?: Record<string, unknown>;
+  issuedAt: number;
   expiresAt?: number;
 };
 
@@ -3318,3 +3350,4 @@ export function assertLifecyclePlanPosture(record: unknown): LifecyclePlanPostur
 export function assertContentIndexRefPosture(record: unknown): ContentIndexRefPosture;
 export function assertContractIntentionPosture(record: unknown): ContractIntentionPosture;
 export function assertUniqueEdgeClassification(record: unknown): UniqueEdgeClassification;
+export function assertContractTarget(record: unknown): ContractTarget;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2949,6 +2949,9 @@ export type FabricContractIntentionState = "draft" | "ready" | "degraded" | "blo
 export type FabricUniqueEdgeClassificationState = "genericPrimitive" | "uniqueEdge" | "blocked";
 export type FabricContractTargetState = "selected" | "ready" | "degraded" | "blocked" | "expired";
 export type FabricContractTargetCompatibilityState = "compatible" | "degraded" | "incompatible" | "unknown";
+export type FabricContractTargetRegistryState = "ready" | "degraded" | "blocked" | "expired";
+export type FabricContractTargetSlotState = "available" | "degraded" | "missing" | "blocked" | "notRequired";
+export type FabricContractTargetPlatformFitState = "compatible" | "degraded" | "incompatible" | "unknown";
 
 export type SubstrateAssociationHandoff = {
   kind?: "substrate.association.handoff";
@@ -3118,6 +3121,43 @@ export type ContractTarget = {
   targetAudience: string;
   safeFacts?: Record<string, unknown>;
   issuedAt: number;
+  expiresAt?: number;
+};
+
+export type ContractTargetSlotPosture = {
+  slotRef: string;
+  state: FabricContractTargetSlotState;
+  platformFitState: FabricContractTargetPlatformFitState;
+  candidateFulfillmentRefs?: string[];
+  selectedFulfillmentRef?: string;
+  sourceRefs?: string[];
+  buildRefs?: string[];
+  platformRefs?: string[];
+  adapterRefs?: string[];
+  proofRequirementRefs?: string[];
+  proofRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+};
+
+export type ContractTargetRegistryPosture = {
+  kind?: "contract.target.registry.posture";
+  registryRef: string;
+  targetRef: string;
+  contractRef: string;
+  state: FabricContractTargetRegistryState;
+  slotPostures: ContractTargetSlotPosture[];
+  candidateFulfillmentRefs?: string[];
+  sourceRefs?: string[];
+  buildRefs?: string[];
+  adapterRefs?: string[];
+  proofRequirementRefs?: string[];
+  proofRefs?: string[];
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+  observedAt: number;
   expiresAt?: number;
 };
 
@@ -3351,3 +3391,4 @@ export function assertContentIndexRefPosture(record: unknown): ContentIndexRefPo
 export function assertContractIntentionPosture(record: unknown): ContractIntentionPosture;
 export function assertUniqueEdgeClassification(record: unknown): UniqueEdgeClassification;
 export function assertContractTarget(record: unknown): ContractTarget;
+export function assertContractTargetRegistryPosture(record: unknown): ContractTargetRegistryPosture;

--- a/src/index.js
+++ b/src/index.js
@@ -384,6 +384,19 @@ export const FABRIC = Object.freeze({
     UNIQUE_EDGE: "uniqueEdge",
     BLOCKED: "blocked",
   }),
+  CONTRACT_TARGET_STATE: Object.freeze({
+    SELECTED: "selected",
+    READY: "ready",
+    DEGRADED: "degraded",
+    BLOCKED: "blocked",
+    EXPIRED: "expired",
+  }),
+  CONTRACT_TARGET_COMPATIBILITY_STATE: Object.freeze({
+    COMPATIBLE: "compatible",
+    DEGRADED: "degraded",
+    INCOMPATIBLE: "incompatible",
+    UNKNOWN: "unknown",
+  }),
 });
 
 export const BUILD = Object.freeze({
@@ -1550,6 +1563,7 @@ export const SWARM = Object.freeze({
     CONTENT_INDEX_REF_POSTURE: "contentIndex.ref.posture",
     CONTRACT_INTENTION_POSTURE: "contract.intention.posture",
     UNIQUE_EDGE_CLASSIFICATION: "uniqueEdge.classification",
+    CONTRACT_TARGET: "contract.target",
     RUNNER_OPERATION: "runner.operation",
     RUNNER_HOST_FULFILLMENT_POSTURE: "runner.host.fulfillment.posture",
     APP_RUNNER_FULFILLMENT_REPORT: "app.runner.fulfillment.report",
@@ -1645,6 +1659,7 @@ export const SWARM = Object.freeze({
     CONTENT_INDEX_REF_POSTURE: "contentIndex.ref.posture",
     CONTRACT_INTENTION_POSTURE: "contract.intention.posture",
     UNIQUE_EDGE_CLASSIFICATION: "uniqueEdge.classification",
+    CONTRACT_TARGET: "contract.target",
     RUNNER_OPERATION: "runner.operation",
     RUNNER_HOST_FULFILLMENT_POSTURE: "runner.host.fulfillment.posture",
     APP_RUNNER_FULFILLMENT_REPORT: "app.runner.fulfillment.report",
@@ -4252,6 +4267,77 @@ export function assertUniqueEdgeClassification(record) {
   assertSurfaceManagerSensitiveBoundary(record, "unique edge classification");
   assertFabricObservedWindow(record, "unique edge classification");
   return { ...record, state, blockedReasons };
+}
+
+export function assertContractTarget(record) {
+  if (!isObject(record)) throw new Error("contract target must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.CONTRACT_TARGET, "contract target");
+  requireString(record.targetRef, "contract target targetRef");
+  requireString(record.contractRef, "contract target contractRef");
+  requireString(record.profileRef, "contract target profileRef");
+  requireString(record.platformRef, "contract target platformRef");
+  const state = assertEnumValue(record.state, FABRIC.CONTRACT_TARGET_STATE, "contract target state");
+  const compatibilityState = assertEnumValue(
+    record.compatibilityState,
+    FABRIC.CONTRACT_TARGET_COMPATIBILITY_STATE,
+    "contract target compatibilityState",
+  );
+  if (record.hostRef !== undefined) requireString(record.hostRef, "contract target hostRef");
+  if (record.substrateRef !== undefined) requireString(record.substrateRef, "contract target substrateRef");
+  const modifierRefs = assertOptionalReferenceList(record.modifierRefs, "contract target modifierRefs");
+  const branchRefs = assertOptionalReferenceList(record.branchRefs, "contract target branchRefs");
+  const subbranchRefs = assertOptionalReferenceList(record.subbranchRefs, "contract target subbranchRefs");
+  const capabilitySlotRefs = assertReferenceList(record.capabilitySlotRefs, "contract target capabilitySlotRefs");
+  if (record.adapterPackRef !== undefined) requireString(record.adapterPackRef, "contract target adapterPackRef");
+  const adapterRefs = assertOptionalReferenceList(record.adapterRefs, "contract target adapterRefs");
+  const negativeSlotRefs = assertOptionalReferenceList(record.negativeSlotRefs, "contract target negativeSlotRefs");
+  const missingSlotRefs = assertOptionalReferenceList(record.missingSlotRefs, "contract target missingSlotRefs");
+  const degradedSlotRefs = assertOptionalReferenceList(record.degradedSlotRefs, "contract target degradedSlotRefs");
+  const proofProfileRefs = assertOptionalReferenceList(record.proofProfileRefs, "contract target proofProfileRefs");
+  const proofRefs = assertOptionalReferenceList(record.proofRefs, "contract target proofRefs");
+  const compatibilityRefs = assertOptionalReferenceList(record.compatibilityRefs, "contract target compatibilityRefs");
+  const evidenceRefs = assertOptionalReferenceList(record.evidenceRefs, "contract target evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "contract target blockedReasons");
+  requireString(record.targetAudience, "contract target targetAudience");
+  assertBlockedReasonsForState(
+    state,
+    [FABRIC.CONTRACT_TARGET_STATE.BLOCKED, FABRIC.CONTRACT_TARGET_STATE.EXPIRED],
+    blockedReasons,
+    "contract target",
+  );
+  if (state === FABRIC.CONTRACT_TARGET_STATE.READY && missingSlotRefs.length > 0) {
+    throw new Error("ready contract target must not carry missingSlotRefs");
+  }
+  if (state === FABRIC.CONTRACT_TARGET_STATE.READY && degradedSlotRefs.length > 0) {
+    throw new Error("ready contract target must not carry degradedSlotRefs");
+  }
+  if (compatibilityState === FABRIC.CONTRACT_TARGET_COMPATIBILITY_STATE.INCOMPATIBLE && blockedReasons.length === 0) {
+    throw new Error("incompatible contract target requires blockedReasons");
+  }
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "contract target safeFacts");
+  assertSurfaceManagerSensitiveBoundary(record, "contract target");
+  if (!Number(record.issuedAt || 0)) throw new Error("contract target missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) {
+    throw new Error("contract target expiresAt must be after issuedAt");
+  }
+  return {
+    ...record,
+    state,
+    compatibilityState,
+    modifierRefs,
+    branchRefs,
+    subbranchRefs,
+    capabilitySlotRefs,
+    adapterRefs,
+    negativeSlotRefs,
+    missingSlotRefs,
+    degradedSlotRefs,
+    proofProfileRefs,
+    proofRefs,
+    compatibilityRefs,
+    evidenceRefs,
+    blockedReasons,
+  };
 }
 
 function assertPrivateRefList(value, name = "privateRefs") {

--- a/src/index.js
+++ b/src/index.js
@@ -302,6 +302,12 @@ export const FABRIC = Object.freeze({
     BLOCKED: "blocked",
     EXPIRED: "expired",
   }),
+  ASSOCIATION_BOUNDARY_PROOF_STATE: Object.freeze({
+    READY: "ready",
+    DEGRADED: "degraded",
+    BLOCKED: "blocked",
+    EXPIRED: "expired",
+  }),
   MEMBER_ROLE: Object.freeze({
     GATEWAY_ASSOCIATION: "gatewayAssociation",
     HOST_SERVICE_ADAPTER: "hostServiceAdapter",
@@ -1576,6 +1582,7 @@ export const SWARM = Object.freeze({
     SURFACE_APP_MODULE_BINDING_POSTURE: "surface.app.module.binding.posture",
     SURFACE_ADAPTER_LIFECYCLE_POSTURE: "surface.adapter.lifecycle.posture",
     SUBSTRATE_ASSOCIATION_HANDOFF: "substrate.association.handoff",
+    ASSOCIATION_BOUNDARY_PROOF: "association.boundary.proof",
     HOST_FABRIC_MEMBER_CONTRIBUTION: "hostFabric.member.contribution",
     HOST_FABRIC_FULFILLMENT_PLAN: "hostFabric.fulfillment.plan",
     LIFECYCLE_PLAN_POSTURE: "lifecycle.plan.posture",
@@ -1673,6 +1680,7 @@ export const SWARM = Object.freeze({
     SURFACE_APP_MODULE_BINDING_POSTURE: "surface.app.module.binding.posture",
     SURFACE_ADAPTER_LIFECYCLE_POSTURE: "surface.adapter.lifecycle.posture",
     SUBSTRATE_ASSOCIATION_HANDOFF: "substrate.association.handoff",
+    ASSOCIATION_BOUNDARY_PROOF: "association.boundary.proof",
     HOST_FABRIC_MEMBER_CONTRIBUTION: "hostFabric.member.contribution",
     HOST_FABRIC_FULFILLMENT_PLAN: "hostFabric.fulfillment.plan",
     LIFECYCLE_PLAN_POSTURE: "lifecycle.plan.posture",
@@ -4103,6 +4111,57 @@ export function assertSubstrateAssociationHandoff(record) {
     throw new Error("substrate association handoff expiresAt must be after issuedAt");
   }
   return { ...record, state, gatewayAssociationRefs, blockedReasons };
+}
+
+function assertAssociationBoundaryRefs(record, fieldName, seen) {
+  const refs = assertReferenceList(record[fieldName], `association boundary proof ${fieldName}`);
+  for (const ref of refs) {
+    if (seen.has(ref)) {
+      throw new Error(`association boundary proof collapses phase ref across boundaries: ${ref}`);
+    }
+    seen.add(ref);
+  }
+  return refs;
+}
+
+export function assertAssociationBoundaryProof(record) {
+  if (!isObject(record)) throw new Error("association boundary proof must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.ASSOCIATION_BOUNDARY_PROOF, "association boundary proof");
+  requireString(record.proofId, "association boundary proof proofId");
+  requireString(record.hostRef, "association boundary proof hostRef");
+  requireString(record.ownerRef, "association boundary proof ownerRef");
+  requireString(record.fabricRef, "association boundary proof fabricRef");
+  const state = assertEnumValue(record.state, FABRIC.ASSOCIATION_BOUNDARY_PROOF_STATE, "association boundary proof state");
+  requireString(record.substrateHandoffRef, "association boundary proof substrateHandoffRef");
+  const seen = new Set();
+  const initialAssociationRefs = assertAssociationBoundaryRefs(record, "initialAssociationRefs", seen);
+  const gatewayAssociationRefs = assertAssociationBoundaryRefs(record, "gatewayAssociationRefs", seen);
+  const routeAssociationRefs = assertAssociationBoundaryRefs(record, "routeAssociationRefs", seen);
+  const servicePresenceRefs = assertAssociationBoundaryRefs(record, "servicePresenceRefs", seen);
+  const membershipRefs = assertAssociationBoundaryRefs(record, "membershipRefs", seen);
+  const fabricPlanRefs = assertReferenceList(record.fabricPlanRefs, "association boundary proof fabricPlanRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "association boundary proof evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "association boundary proof blockedReasons");
+  assertBlockedReasonsForState(
+    state,
+    [FABRIC.ASSOCIATION_BOUNDARY_PROOF_STATE.BLOCKED, FABRIC.ASSOCIATION_BOUNDARY_PROOF_STATE.EXPIRED],
+    blockedReasons,
+    "association boundary proof",
+  );
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "association boundary proof safeFacts");
+  assertSurfaceManagerSensitiveBoundary(record, "association boundary proof");
+  assertFabricObservedWindow(record, "association boundary proof");
+  return {
+    ...record,
+    state,
+    initialAssociationRefs,
+    gatewayAssociationRefs,
+    routeAssociationRefs,
+    servicePresenceRefs,
+    membershipRefs,
+    fabricPlanRefs,
+    blockedReasons,
+  };
 }
 
 export function assertHostFabricMemberContribution(record) {

--- a/src/index.js
+++ b/src/index.js
@@ -397,6 +397,25 @@ export const FABRIC = Object.freeze({
     INCOMPATIBLE: "incompatible",
     UNKNOWN: "unknown",
   }),
+  CONTRACT_TARGET_REGISTRY_STATE: Object.freeze({
+    READY: "ready",
+    DEGRADED: "degraded",
+    BLOCKED: "blocked",
+    EXPIRED: "expired",
+  }),
+  CONTRACT_TARGET_SLOT_STATE: Object.freeze({
+    AVAILABLE: "available",
+    DEGRADED: "degraded",
+    MISSING: "missing",
+    BLOCKED: "blocked",
+    NOT_REQUIRED: "notRequired",
+  }),
+  CONTRACT_TARGET_PLATFORM_FIT_STATE: Object.freeze({
+    COMPATIBLE: "compatible",
+    DEGRADED: "degraded",
+    INCOMPATIBLE: "incompatible",
+    UNKNOWN: "unknown",
+  }),
 });
 
 export const BUILD = Object.freeze({
@@ -1564,6 +1583,7 @@ export const SWARM = Object.freeze({
     CONTRACT_INTENTION_POSTURE: "contract.intention.posture",
     UNIQUE_EDGE_CLASSIFICATION: "uniqueEdge.classification",
     CONTRACT_TARGET: "contract.target",
+    CONTRACT_TARGET_REGISTRY_POSTURE: "contract.target.registry.posture",
     RUNNER_OPERATION: "runner.operation",
     RUNNER_HOST_FULFILLMENT_POSTURE: "runner.host.fulfillment.posture",
     APP_RUNNER_FULFILLMENT_REPORT: "app.runner.fulfillment.report",
@@ -1660,6 +1680,7 @@ export const SWARM = Object.freeze({
     CONTRACT_INTENTION_POSTURE: "contract.intention.posture",
     UNIQUE_EDGE_CLASSIFICATION: "uniqueEdge.classification",
     CONTRACT_TARGET: "contract.target",
+    CONTRACT_TARGET_REGISTRY_POSTURE: "contract.target.registry.posture",
     RUNNER_OPERATION: "runner.operation",
     RUNNER_HOST_FULFILLMENT_POSTURE: "runner.host.fulfillment.posture",
     APP_RUNNER_FULFILLMENT_REPORT: "app.runner.fulfillment.report",
@@ -4338,6 +4359,96 @@ export function assertContractTarget(record) {
     evidenceRefs,
     blockedReasons,
   };
+}
+
+function assertContractTargetSlotPosture(value, context) {
+  if (!isObject(value)) throw new Error(`${context} must be an object`);
+  requireString(value.slotRef, `${context} slotRef`);
+  const state = assertEnumValue(value.state, FABRIC.CONTRACT_TARGET_SLOT_STATE, `${context} state`);
+  const platformFitState = assertEnumValue(
+    value.platformFitState,
+    FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE,
+    `${context} platformFitState`,
+  );
+  const candidateFulfillmentRefs = assertOptionalReferenceList(
+    value.candidateFulfillmentRefs,
+    `${context} candidateFulfillmentRefs`,
+  );
+  if (value.selectedFulfillmentRef !== undefined) requireString(value.selectedFulfillmentRef, `${context} selectedFulfillmentRef`);
+  assertOptionalReferenceList(value.sourceRefs, `${context} sourceRefs`);
+  assertOptionalReferenceList(value.buildRefs, `${context} buildRefs`);
+  assertOptionalReferenceList(value.platformRefs, `${context} platformRefs`);
+  assertOptionalReferenceList(value.adapterRefs, `${context} adapterRefs`);
+  assertOptionalReferenceList(value.proofRequirementRefs, `${context} proofRequirementRefs`);
+  assertOptionalReferenceList(value.proofRefs, `${context} proofRefs`);
+  assertOptionalReferenceList(value.evidenceRefs, `${context} evidenceRefs`);
+  const blockedReasons = assertOptionalReferenceList(value.blockedReasons, `${context} blockedReasons`);
+  if (state === FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE && candidateFulfillmentRefs.length === 0) {
+    throw new Error(`${context} available slot requires candidateFulfillmentRefs`);
+  }
+  assertBlockedReasonsForState(
+    state,
+    [FABRIC.CONTRACT_TARGET_SLOT_STATE.MISSING, FABRIC.CONTRACT_TARGET_SLOT_STATE.BLOCKED],
+    blockedReasons,
+    context,
+  );
+  if (platformFitState === FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.INCOMPATIBLE && blockedReasons.length === 0) {
+    throw new Error(`${context} incompatible platform fit requires blockedReasons`);
+  }
+  if (value.safeFacts !== undefined) assertSafeObject(value.safeFacts, `${context} safeFacts`);
+  assertSurfaceManagerSensitiveBoundary(value, context);
+  return { ...value, state, platformFitState, candidateFulfillmentRefs, blockedReasons };
+}
+
+export function assertContractTargetRegistryPosture(record) {
+  if (!isObject(record)) throw new Error("contract target registry posture must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.CONTRACT_TARGET_REGISTRY_POSTURE, "contract target registry posture");
+  requireString(record.registryRef, "contract target registry posture registryRef");
+  requireString(record.targetRef, "contract target registry posture targetRef");
+  requireString(record.contractRef, "contract target registry posture contractRef");
+  const state = assertEnumValue(
+    record.state,
+    FABRIC.CONTRACT_TARGET_REGISTRY_STATE,
+    "contract target registry posture state",
+  );
+  const slotPostures = requireArray(
+    record.slotPostures,
+    "contract target registry posture slotPostures",
+  ).map((slot, index) => assertContractTargetSlotPosture(
+    slot,
+    `contract target registry posture slotPostures[${index}]`,
+  ));
+  if (slotPostures.length === 0) throw new Error("contract target registry posture requires slotPostures");
+  const candidateFulfillmentRefs = assertOptionalReferenceList(
+    record.candidateFulfillmentRefs,
+    "contract target registry posture candidateFulfillmentRefs",
+  );
+  assertOptionalReferenceList(record.sourceRefs, "contract target registry posture sourceRefs");
+  assertOptionalReferenceList(record.buildRefs, "contract target registry posture buildRefs");
+  assertOptionalReferenceList(record.adapterRefs, "contract target registry posture adapterRefs");
+  assertOptionalReferenceList(record.proofRequirementRefs, "contract target registry posture proofRequirementRefs");
+  assertOptionalReferenceList(record.proofRefs, "contract target registry posture proofRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "contract target registry posture evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "contract target registry posture blockedReasons");
+  assertBlockedReasonsForState(
+    state,
+    [FABRIC.CONTRACT_TARGET_REGISTRY_STATE.BLOCKED, FABRIC.CONTRACT_TARGET_REGISTRY_STATE.EXPIRED],
+    blockedReasons,
+    "contract target registry posture",
+  );
+  if (
+    state === FABRIC.CONTRACT_TARGET_REGISTRY_STATE.READY
+    && slotPostures.some((slot) => ![
+      FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE,
+      FABRIC.CONTRACT_TARGET_SLOT_STATE.NOT_REQUIRED,
+    ].includes(slot.state))
+  ) {
+    throw new Error("ready contract target registry posture must not carry missing, degraded, or blocked slotPostures");
+  }
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "contract target registry posture safeFacts");
+  assertSurfaceManagerSensitiveBoundary(record, "contract target registry posture");
+  assertFabricObservedWindow(record, "contract target registry posture");
+  return { ...record, state, slotPostures, candidateFulfillmentRefs, blockedReasons };
 }
 
 function assertPrivateRefList(value, name = "privateRefs") {

--- a/src/index.js
+++ b/src/index.js
@@ -294,6 +294,98 @@ export const RUNNER = Object.freeze({
   }),
 });
 
+export const FABRIC = Object.freeze({
+  ASSOCIATION_HANDOFF_STATE: Object.freeze({
+    READY: "ready",
+    HANDED_OFF: "handedOff",
+    DEGRADED: "degraded",
+    BLOCKED: "blocked",
+    EXPIRED: "expired",
+  }),
+  MEMBER_ROLE: Object.freeze({
+    GATEWAY_ASSOCIATION: "gatewayAssociation",
+    HOST_SERVICE_ADAPTER: "hostServiceAdapter",
+    EXECUTION_FULFILLMENT: "executionFulfillment",
+    STORAGE_JOURNAL_CACHE: "storageJournalCache",
+    SOURCE_CONTENT_INDEX: "sourceContentIndex",
+    BUILD_PROCESSOR: "buildProcessor",
+    RUNTIME: "runtime",
+    SURFACE: "surface",
+    PLATFORM_ADAPTER: "platformAdapter",
+    SERVICE_SURFACE_ADAPTER: "serviceSurfaceAdapter",
+    SERVICE_EDGE_ADAPTER: "serviceEdgeAdapter",
+    LOGGING_PROCESSOR: "loggingProcessor",
+    DOMAIN_SERVICE: "domainService",
+  }),
+  MEMBER_CONTRIBUTION_STATE: Object.freeze({
+    CLAIMED: "claimed",
+    ACCEPTED: "accepted",
+    RUNNING: "running",
+    DEGRADED: "degraded",
+    BLOCKED: "blocked",
+    RELEASED: "released",
+    EXPIRED: "expired",
+    SUPERSEDED: "superseded",
+  }),
+  FULFILLMENT_PLAN_STATE: Object.freeze({
+    READY: "ready",
+    DEGRADED: "degraded",
+    BLOCKED: "blocked",
+    EXPIRED: "expired",
+  }),
+  LIFECYCLE_PLAN_STATE: Object.freeze({
+    READY: "ready",
+    RUNNING: "running",
+    DEGRADED: "degraded",
+    BLOCKED: "blocked",
+    RELEASED: "released",
+    EXPIRED: "expired",
+  }),
+  LIFECYCLE_PHASE: Object.freeze({
+    SOURCE: "source",
+    BUILD: "build",
+    RELEASE: "release",
+    LOAD: "load",
+    RUN: "run",
+    OBSERVE: "observe",
+    ROLLBACK: "rollback",
+    EXPIRY: "expiry",
+    CLEANUP: "cleanup",
+  }),
+  LIFECYCLE_PHASE_STATE: Object.freeze({
+    NOT_REQUIRED: "notRequired",
+    PENDING: "pending",
+    READY: "ready",
+    RUNNING: "running",
+    SUCCEEDED: "succeeded",
+    DEGRADED: "degraded",
+    BLOCKED: "blocked",
+    FAILED: "failed",
+    RELEASED: "released",
+    EXPIRED: "expired",
+  }),
+  CONTENT_INDEX_STATE: Object.freeze({
+    READY: "ready",
+    DEGRADED: "degraded",
+    BLOCKED: "blocked",
+    SUPERSEDED: "superseded",
+    EXPIRED: "expired",
+  }),
+  CONTRACT_INTENTION_STATE: Object.freeze({
+    DRAFT: "draft",
+    READY: "ready",
+    DEGRADED: "degraded",
+    BLOCKED: "blocked",
+    SUPERSEDED: "superseded",
+    EXPIRED: "expired",
+  }),
+  UNIQUE_EDGE_CLASSIFICATION: Object.freeze({
+    GENERIC_PRIMITIVE: "genericPrimitive",
+    UNIQUE_EDGE: "uniqueEdge",
+    BLOCKED: "blocked",
+  }),
+});
+
 export const BUILD = Object.freeze({
   CAPABILITY: Object.freeze({
     RUN_EXECUTE: "build.run.execute",
@@ -1451,6 +1543,13 @@ export const SWARM = Object.freeze({
     SURFACE_MODULE_ROLE_POSTURE: "surface.module.role.posture",
     SURFACE_APP_MODULE_BINDING_POSTURE: "surface.app.module.binding.posture",
     SURFACE_ADAPTER_LIFECYCLE_POSTURE: "surface.adapter.lifecycle.posture",
+    SUBSTRATE_ASSOCIATION_HANDOFF: "substrate.association.handoff",
+    HOST_FABRIC_MEMBER_CONTRIBUTION: "hostFabric.member.contribution",
+    HOST_FABRIC_FULFILLMENT_PLAN: "hostFabric.fulfillment.plan",
+    LIFECYCLE_PLAN_POSTURE: "lifecycle.plan.posture",
+    CONTENT_INDEX_REF_POSTURE: "contentIndex.ref.posture",
+    CONTRACT_INTENTION_POSTURE: "contract.intention.posture",
+    UNIQUE_EDGE_CLASSIFICATION: "uniqueEdge.classification",
     RUNNER_OPERATION: "runner.operation",
     RUNNER_HOST_FULFILLMENT_POSTURE: "runner.host.fulfillment.posture",
     APP_RUNNER_FULFILLMENT_REPORT: "app.runner.fulfillment.report",
@@ -1539,6 +1638,13 @@ export const SWARM = Object.freeze({
     SURFACE_MODULE_ROLE_POSTURE: "surface.module.role.posture",
     SURFACE_APP_MODULE_BINDING_POSTURE: "surface.app.module.binding.posture",
     SURFACE_ADAPTER_LIFECYCLE_POSTURE: "surface.adapter.lifecycle.posture",
+    SUBSTRATE_ASSOCIATION_HANDOFF: "substrate.association.handoff",
+    HOST_FABRIC_MEMBER_CONTRIBUTION: "hostFabric.member.contribution",
+    HOST_FABRIC_FULFILLMENT_PLAN: "hostFabric.fulfillment.plan",
+    LIFECYCLE_PLAN_POSTURE: "lifecycle.plan.posture",
+    CONTENT_INDEX_REF_POSTURE: "contentIndex.ref.posture",
+    CONTRACT_INTENTION_POSTURE: "contract.intention.posture",
+    UNIQUE_EDGE_CLASSIFICATION: "uniqueEdge.classification",
     RUNNER_OPERATION: "runner.operation",
     RUNNER_HOST_FULFILLMENT_POSTURE: "runner.host.fulfillment.posture",
     APP_RUNNER_FULFILLMENT_REPORT: "app.runner.fulfillment.report",
@@ -3893,6 +3999,261 @@ function assertSafeObject(value, name) {
   return object;
 }
 
+function assertEnumValue(value, allowed, name) {
+  const text = requireString(value, name);
+  if (!Object.values(allowed).includes(text)) throw new Error(`unsupported ${name}`);
+  return text;
+}
+
+function assertBlockedReasonsForState(state, blockedStates, blockedReasons, context) {
+  if (blockedStates.includes(state) && blockedReasons.length === 0) {
+    throw new Error(`${context} requires blockedReasons`);
+  }
+}
+
+function assertFabricObservedWindow(record, context) {
+  const observedAt = Number(record.observedAt || 0);
+  if (!observedAt) throw new Error(`${context} missing observedAt`);
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= observedAt) {
+    throw new Error(`${context} expiresAt must be after observedAt`);
+  }
+  return observedAt;
+}
+
+function assertLifecyclePhasePosture(value, context) {
+  if (!isObject(value)) throw new Error(`${context} must be an object`);
+  const phase = assertEnumValue(value.phase, FABRIC.LIFECYCLE_PHASE, `${context} phase`);
+  const state = assertEnumValue(value.state, FABRIC.LIFECYCLE_PHASE_STATE, `${context} state`);
+  const blockedReasons = assertOptionalReferenceList(value.blockedReasons, `${context} blockedReasons`);
+  assertBlockedReasonsForState(
+    state,
+    [FABRIC.LIFECYCLE_PHASE_STATE.BLOCKED, FABRIC.LIFECYCLE_PHASE_STATE.FAILED],
+    blockedReasons,
+    context,
+  );
+  assertOptionalReferenceList(value.evidenceRefs, `${context} evidenceRefs`);
+  assertOptionalReferenceList(value.outputRefs, `${context} outputRefs`);
+  if (value.safeFacts !== undefined) assertSafeObject(value.safeFacts, `${context} safeFacts`);
+  return { ...value, phase, state, blockedReasons };
+}
+
+export function assertSubstrateAssociationHandoff(record) {
+  if (!isObject(record)) throw new Error("substrate association handoff must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.SUBSTRATE_ASSOCIATION_HANDOFF, "substrate association handoff");
+  requireString(record.handoffId, "substrate association handoff handoffId");
+  requireString(record.substrateRef, "substrate association handoff substrateRef");
+  requireString(record.hostRef, "substrate association handoff hostRef");
+  requireString(record.ownerRef, "substrate association handoff ownerRef");
+  requireString(record.fabricRef, "substrate association handoff fabricRef");
+  const state = assertEnumValue(record.state, FABRIC.ASSOCIATION_HANDOFF_STATE, "substrate association handoff state");
+  assertReferenceList(record.initialAssociationRefs, "substrate association handoff initialAssociationRefs");
+  const gatewayAssociationRefs = assertOptionalReferenceList(record.gatewayAssociationRefs, "substrate association handoff gatewayAssociationRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "substrate association handoff evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "substrate association handoff blockedReasons");
+  assertBlockedReasonsForState(
+    state,
+    [FABRIC.ASSOCIATION_HANDOFF_STATE.BLOCKED, FABRIC.ASSOCIATION_HANDOFF_STATE.EXPIRED],
+    blockedReasons,
+    "substrate association handoff",
+  );
+  if (state === FABRIC.ASSOCIATION_HANDOFF_STATE.HANDED_OFF && gatewayAssociationRefs.length === 0) {
+    throw new Error("handed off substrate association requires gatewayAssociationRefs");
+  }
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "substrate association handoff safeFacts");
+  assertSurfaceManagerSensitiveBoundary(record, "substrate association handoff");
+  if (!Number(record.issuedAt || 0)) throw new Error("substrate association handoff missing issuedAt");
+  if (record.handedOffAt !== undefined) assertOptionalTimeField(record.handedOffAt, "substrate association handoff handedOffAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) {
+    throw new Error("substrate association handoff expiresAt must be after issuedAt");
+  }
+  return { ...record, state, gatewayAssociationRefs, blockedReasons };
+}
+
+export function assertHostFabricMemberContribution(record) {
+  if (!isObject(record)) throw new Error("host-fabric member contribution must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.HOST_FABRIC_MEMBER_CONTRIBUTION, "host-fabric member contribution");
+  requireString(record.contributionId, "host-fabric member contribution contributionId");
+  requireString(record.fabricRef, "host-fabric member contribution fabricRef");
+  requireString(record.hostRef, "host-fabric member contribution hostRef");
+  assertResolvedMemberRef(record.memberRef, "host-fabric member contribution memberRef");
+  const role = assertEnumValue(record.role, FABRIC.MEMBER_ROLE, "host-fabric member contribution role");
+  const state = assertEnumValue(record.state, FABRIC.MEMBER_CONTRIBUTION_STATE, "host-fabric member contribution state");
+  requireString(record.contractRef, "host-fabric member contribution contractRef");
+  requireString(record.subjectRef, "host-fabric member contribution subjectRef");
+  assertOptionalReferenceList(record.capabilityRefs, "host-fabric member contribution capabilityRefs");
+  assertOptionalReferenceList(record.grantRefs, "host-fabric member contribution grantRefs");
+  assertOptionalReferenceList(record.inputRefs, "host-fabric member contribution inputRefs");
+  assertOptionalReferenceList(record.outputRefs, "host-fabric member contribution outputRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "host-fabric member contribution evidenceRefs");
+  assertOptionalReferenceList(record.lifecyclePlanRefs, "host-fabric member contribution lifecyclePlanRefs");
+  assertOptionalReferenceList(record.releaseRefs, "host-fabric member contribution releaseRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "host-fabric member contribution blockedReasons");
+  assertBlockedReasonsForState(
+    state,
+    [FABRIC.MEMBER_CONTRIBUTION_STATE.BLOCKED, FABRIC.MEMBER_CONTRIBUTION_STATE.EXPIRED],
+    blockedReasons,
+    "host-fabric member contribution",
+  );
+  if (record.resourcePosture !== undefined && record.resourcePosture !== null) assertResourcePosture(record.resourcePosture);
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "host-fabric member contribution safeFacts");
+  assertSurfaceManagerSensitiveBoundary(record, "host-fabric member contribution");
+  assertFabricObservedWindow(record, "host-fabric member contribution");
+  return { ...record, role, state, blockedReasons };
+}
+
+export function assertHostFabricFulfillmentPlan(record) {
+  if (!isObject(record)) throw new Error("host-fabric fulfillment plan must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.HOST_FABRIC_FULFILLMENT_PLAN, "host-fabric fulfillment plan");
+  requireString(record.planId, "host-fabric fulfillment plan planId");
+  requireString(record.fabricRef, "host-fabric fulfillment plan fabricRef");
+  requireString(record.hostRef, "host-fabric fulfillment plan hostRef");
+  requireString(record.contractRef, "host-fabric fulfillment plan contractRef");
+  const state = assertEnumValue(record.state, FABRIC.FULFILLMENT_PLAN_STATE, "host-fabric fulfillment plan state");
+  const requiredRoleRefs = assertReferenceList(record.requiredRoleRefs, "host-fabric fulfillment plan requiredRoleRefs");
+  const memberContributionRefs = assertOptionalReferenceList(record.memberContributionRefs, "host-fabric fulfillment plan memberContributionRefs");
+  assertOptionalReferenceList(record.missingRoleRefs, "host-fabric fulfillment plan missingRoleRefs");
+  assertOptionalReferenceList(record.lifecyclePlanRefs, "host-fabric fulfillment plan lifecyclePlanRefs");
+  assertOptionalReferenceList(record.materializationBudgetRefs, "host-fabric fulfillment plan materializationBudgetRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "host-fabric fulfillment plan evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "host-fabric fulfillment plan blockedReasons");
+  assertBlockedReasonsForState(
+    state,
+    [FABRIC.FULFILLMENT_PLAN_STATE.BLOCKED, FABRIC.FULFILLMENT_PLAN_STATE.EXPIRED],
+    blockedReasons,
+    "host-fabric fulfillment plan",
+  );
+  if (state === FABRIC.FULFILLMENT_PLAN_STATE.READY && memberContributionRefs.length === 0) {
+    throw new Error("ready host-fabric fulfillment plan requires memberContributionRefs");
+  }
+  if (record.associationHandoffRef !== undefined) requireString(record.associationHandoffRef, "host-fabric fulfillment plan associationHandoffRef");
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "host-fabric fulfillment plan safeFacts");
+  assertSurfaceManagerSensitiveBoundary(record, "host-fabric fulfillment plan");
+  assertFabricObservedWindow(record, "host-fabric fulfillment plan");
+  return { ...record, state, requiredRoleRefs, memberContributionRefs, blockedReasons };
+}
+
+export function assertLifecyclePlanPosture(record) {
+  if (!isObject(record)) throw new Error("lifecycle plan posture must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.LIFECYCLE_PLAN_POSTURE, "lifecycle plan posture");
+  requireString(record.lifecyclePlanId, "lifecycle plan posture lifecyclePlanId");
+  requireString(record.subjectRef, "lifecycle plan posture subjectRef");
+  requireString(record.contractRef, "lifecycle plan posture contractRef");
+  const state = assertEnumValue(record.state, FABRIC.LIFECYCLE_PLAN_STATE, "lifecycle plan posture state");
+  assertReferenceList(record.lifecycleContractRefs, "lifecycle plan posture lifecycleContractRefs");
+  const phasePostures = requireNonEmptyArray(record.phasePostures, "lifecycle plan posture phasePostures")
+    .map((entry, index) => assertLifecyclePhasePosture(entry, `lifecycle plan posture phasePostures ${index}`));
+  assertOptionalReferenceList(record.memberContributionRefs, "lifecycle plan posture memberContributionRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "lifecycle plan posture evidenceRefs");
+  assertOptionalReferenceList(record.releaseRefs, "lifecycle plan posture releaseRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "lifecycle plan posture blockedReasons");
+  assertBlockedReasonsForState(
+    state,
+    [FABRIC.LIFECYCLE_PLAN_STATE.BLOCKED, FABRIC.LIFECYCLE_PLAN_STATE.EXPIRED],
+    blockedReasons,
+    "lifecycle plan posture",
+  );
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "lifecycle plan posture safeFacts");
+  assertSurfaceManagerSensitiveBoundary(record, "lifecycle plan posture");
+  assertFabricObservedWindow(record, "lifecycle plan posture");
+  return { ...record, state, phasePostures, blockedReasons };
+}
+
+export function assertContentIndexRefPosture(record) {
+  if (!isObject(record)) throw new Error("content-index ref posture must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.CONTENT_INDEX_REF_POSTURE, "content-index ref posture");
+  requireString(record.postureId, "content-index ref posture postureId");
+  requireString(record.contentIndexRef, "content-index ref posture contentIndexRef");
+  const state = assertEnumValue(record.state, FABRIC.CONTENT_INDEX_STATE, "content-index ref posture state");
+  const sourceRefs = assertOptionalReferenceList(record.sourceRefs, "content-index ref posture sourceRefs");
+  const materializedProjectionRefs = assertOptionalReferenceList(record.materializedProjectionRefs, "content-index ref posture materializedProjectionRefs");
+  assertOptionalReferenceList(record.storageRefs, "content-index ref posture storageRefs");
+  assertOptionalReferenceList(record.writerRefs, "content-index ref posture writerRefs");
+  assertOptionalReferenceList(record.schemaRefs, "content-index ref posture schemaRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "content-index ref posture evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "content-index ref posture blockedReasons");
+  assertBlockedReasonsForState(
+    state,
+    [FABRIC.CONTENT_INDEX_STATE.BLOCKED, FABRIC.CONTENT_INDEX_STATE.EXPIRED],
+    blockedReasons,
+    "content-index ref posture",
+  );
+  if (state === FABRIC.CONTENT_INDEX_STATE.READY && sourceRefs.length === 0) {
+    throw new Error("ready content-index ref posture requires sourceRefs");
+  }
+  if (state === FABRIC.CONTENT_INDEX_STATE.READY && materializedProjectionRefs.length === 0) {
+    throw new Error("ready content-index ref posture requires materializedProjectionRefs");
+  }
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "content-index ref posture safeFacts");
+  assertSurfaceManagerSensitiveBoundary(record, "content-index ref posture");
+  assertFabricObservedWindow(record, "content-index ref posture");
+  return { ...record, state, sourceRefs, materializedProjectionRefs, blockedReasons };
+}
+
+export function assertContractIntentionPosture(record) {
+  if (!isObject(record)) throw new Error("contract intention posture must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.CONTRACT_INTENTION_POSTURE, "contract intention posture");
+  requireString(record.postureId, "contract intention posture postureId");
+  requireString(record.intentionRef, "contract intention posture intentionRef");
+  const state = assertEnumValue(record.state, FABRIC.CONTRACT_INTENTION_STATE, "contract intention posture state");
+  const contentIndexRefs = assertOptionalReferenceList(record.contentIndexRefs, "contract intention posture contentIndexRefs");
+  assertOptionalReferenceList(record.authoringSurfaceRefs, "contract intention posture authoringSurfaceRefs");
+  assertOptionalReferenceList(record.proofGateRefs, "contract intention posture proofGateRefs");
+  assertOptionalReferenceList(record.reducerRefs, "contract intention posture reducerRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "contract intention posture evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "contract intention posture blockedReasons");
+  assertBlockedReasonsForState(
+    state,
+    [FABRIC.CONTRACT_INTENTION_STATE.BLOCKED, FABRIC.CONTRACT_INTENTION_STATE.EXPIRED],
+    blockedReasons,
+    "contract intention posture",
+  );
+  if (state === FABRIC.CONTRACT_INTENTION_STATE.READY && !String(record.canonicalHashRef || "").trim()) {
+    throw new Error("ready contract intention posture requires canonicalHashRef");
+  }
+  if (state === FABRIC.CONTRACT_INTENTION_STATE.READY && contentIndexRefs.length === 0) {
+    throw new Error("ready contract intention posture requires contentIndexRefs");
+  }
+  if (record.canonicalHashRef !== undefined) requireString(record.canonicalHashRef, "contract intention posture canonicalHashRef");
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "contract intention posture safeFacts");
+  assertSurfaceManagerSensitiveBoundary(record, "contract intention posture");
+  assertFabricObservedWindow(record, "contract intention posture");
+  return { ...record, state, contentIndexRefs, blockedReasons };
+}
+
+export function assertUniqueEdgeClassification(record) {
+  if (!isObject(record)) throw new Error("unique edge classification must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.UNIQUE_EDGE_CLASSIFICATION, "unique edge classification");
+  requireString(record.classificationId, "unique edge classification classificationId");
+  requireString(record.subjectRef, "unique edge classification subjectRef");
+  const state = assertEnumValue(record.state, FABRIC.UNIQUE_EDGE_CLASSIFICATION, "unique edge classification state");
+  if (record.primitiveRef !== undefined) requireString(record.primitiveRef, "unique edge classification primitiveRef");
+  if (record.externalRealityRef !== undefined) requireString(record.externalRealityRef, "unique edge classification externalRealityRef");
+  if (record.interactionRef !== undefined) requireString(record.interactionRef, "unique edge classification interactionRef");
+  if (state === FABRIC.UNIQUE_EDGE_CLASSIFICATION.UNIQUE_EDGE) {
+    requireString(record.externalRealityRef, "unique edge classification externalRealityRef");
+    requireString(record.interactionRef, "unique edge classification interactionRef");
+  }
+  if (state === FABRIC.UNIQUE_EDGE_CLASSIFICATION.GENERIC_PRIMITIVE) {
+    requireString(record.primitiveRef, "unique edge classification primitiveRef");
+  }
+  assertOptionalReferenceList(record.policyRefs, "unique edge classification policyRefs");
+  assertOptionalReferenceList(record.inputRefs, "unique edge classification inputRefs");
+  assertOptionalReferenceList(record.outputRefs, "unique edge classification outputRefs");
+  assertOptionalReferenceList(record.grantRefs, "unique edge classification grantRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "unique edge classification evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "unique edge classification blockedReasons");
+  assertBlockedReasonsForState(
+    state,
+    [FABRIC.UNIQUE_EDGE_CLASSIFICATION.BLOCKED],
+    blockedReasons,
+    "unique edge classification",
+  );
+  if (record.safeFacts !== undefined) assertSafeObject(record.safeFacts, "unique edge classification safeFacts");
+  assertSurfaceManagerSensitiveBoundary(record, "unique edge classification");
+  assertFabricObservedWindow(record, "unique edge classification");
+  return { ...record, state, blockedReasons };
+}
+
 function assertPrivateRefList(value, name = "privateRefs") {
   if (value === undefined || value === null) return [];
   const refs = requireArray(value, name);
@@ -4643,6 +5004,10 @@ export function assertSwarmIdentityGraph(records) {
     SWARM.RECORD_KIND.CONSUMER_FLOOR,
     SWARM.RECORD_KIND.MEDIA_TRANSPORT_PATH,
     SWARM.RECORD_KIND.MEDIA_TRANSPORT_OBSERVATION,
+    SWARM.RECORD_KIND.SUBSTRATE_ASSOCIATION_HANDOFF,
+    SWARM.RECORD_KIND.HOST_FABRIC_MEMBER_CONTRIBUTION,
+    SWARM.RECORD_KIND.HOST_FABRIC_FULFILLMENT_PLAN,
+    SWARM.RECORD_KIND.LIFECYCLE_PLAN_POSTURE,
     "stream.session.offer",
     "stream.session.answer",
     "stream.session.candidate",

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -12885,6 +12885,58 @@ mod tests {
     }
 
     #[test]
+    fn validates_multi_gateway_contract_target_vector() {
+        let vector: Value = serde_json::from_str(include_str!(
+            "../vectors/contract-target-multi-gateway-v1.json"
+        ))
+        .expect("multi-gateway target vector");
+        let target: ContractTarget =
+            serde_json::from_value(vector["target"].clone()).expect("target record");
+        let registry: ContractTargetRegistryPosture =
+            serde_json::from_value(vector["registry"].clone()).expect("registry record");
+        let contributions: Vec<HostFabricMemberContribution> =
+            serde_json::from_value(vector["hostFabricContributions"].clone())
+                .expect("fabric contributions");
+        let plan: HostFabricFulfillmentPlan =
+            serde_json::from_value(vector["fulfillmentPlan"].clone())
+                .expect("fabric fulfillment plan");
+
+        validate_contract_target(&target).expect("target validates");
+        validate_contract_target_registry_posture(&registry).expect("registry validates");
+        for contribution in &contributions {
+            validate_host_fabric_member_contribution(contribution)
+                .expect("fabric contribution validates");
+        }
+        validate_host_fabric_fulfillment_plan(&plan).expect("fabric plan validates");
+        let gateway_slot = registry
+            .slot_postures
+            .iter()
+            .find(|slot| slot.slot_ref == "slot:gateway-association")
+            .expect("gateway slot");
+        assert_eq!(target.state, FABRIC_CONTRACT_TARGET_READY);
+        assert_eq!(gateway_slot.candidate_fulfillment_refs.len(), 2);
+        assert_eq!(
+            gateway_slot.selected_fulfillment_ref.as_deref(),
+            Some("fulfillment:gateway-association:local-dev")
+        );
+        assert_eq!(
+            contributions
+                .iter()
+                .filter(|entry| entry.role == FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION)
+                .count(),
+            2
+        );
+        assert!(contributions.iter().any(|entry| {
+            entry.role == FABRIC_MEMBER_ROLE_SERVICE_EDGE_ADAPTER
+                && entry.subject_ref == "service:nvr"
+        }));
+        assert!(
+            plan.member_contribution_refs
+                .contains(&"fabric-contribution:gateway-association:lab-dev".to_string())
+        );
+    }
+
+    #[test]
     fn validates_participant_self_capability_resource_and_retention_posture() {
         let participant_ref = pubkey_from_sk_hex(BROWSER_SK).expect("browser pk");
         let service_member_ref = pubkey_from_sk_hex(GATEWAY_SK).expect("gateway pk");

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -138,6 +138,7 @@ pub const RECORD_SURFACE_APP_FULFILLMENT_IDENTITY_POSTURE: &str =
 pub const RECORD_SURFACE_APP_AUTHORITY_ACCESS_POSTURE: &str =
     "surface.app.authority.access.posture";
 pub const RECORD_SUBSTRATE_ASSOCIATION_HANDOFF: &str = "substrate.association.handoff";
+pub const RECORD_ASSOCIATION_BOUNDARY_PROOF: &str = "association.boundary.proof";
 pub const RECORD_HOST_FABRIC_MEMBER_CONTRIBUTION: &str = "hostFabric.member.contribution";
 pub const RECORD_HOST_FABRIC_FULFILLMENT_PLAN: &str = "hostFabric.fulfillment.plan";
 pub const RECORD_LIFECYCLE_PLAN_POSTURE: &str = "lifecycle.plan.posture";
@@ -259,6 +260,10 @@ pub const FABRIC_ASSOCIATION_HANDOFF_HANDED_OFF: &str = "handedOff";
 pub const FABRIC_ASSOCIATION_HANDOFF_DEGRADED: &str = "degraded";
 pub const FABRIC_ASSOCIATION_HANDOFF_BLOCKED: &str = "blocked";
 pub const FABRIC_ASSOCIATION_HANDOFF_EXPIRED: &str = "expired";
+pub const FABRIC_ASSOCIATION_BOUNDARY_PROOF_READY: &str = "ready";
+pub const FABRIC_ASSOCIATION_BOUNDARY_PROOF_DEGRADED: &str = "degraded";
+pub const FABRIC_ASSOCIATION_BOUNDARY_PROOF_BLOCKED: &str = "blocked";
+pub const FABRIC_ASSOCIATION_BOUNDARY_PROOF_EXPIRED: &str = "expired";
 pub const FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION: &str = "gatewayAssociation";
 pub const FABRIC_MEMBER_ROLE_HOST_SERVICE_ADAPTER: &str = "hostServiceAdapter";
 pub const FABRIC_MEMBER_ROLE_EXECUTION_FULFILLMENT: &str = "executionFulfillment";
@@ -3133,6 +3138,40 @@ pub struct SubstrateAssociationHandoff {
     pub issued_at: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub handed_off_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct AssociationBoundaryProof {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub proof_id: String,
+    pub host_ref: String,
+    pub owner_ref: String,
+    pub fabric_ref: String,
+    pub state: String,
+    pub substrate_handoff_ref: String,
+    #[serde(default)]
+    pub initial_association_refs: Vec<String>,
+    #[serde(default)]
+    pub gateway_association_refs: Vec<String>,
+    #[serde(default)]
+    pub route_association_refs: Vec<String>,
+    #[serde(default)]
+    pub service_presence_refs: Vec<String>,
+    #[serde(default)]
+    pub membership_refs: Vec<String>,
+    #[serde(default)]
+    pub fabric_plan_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub observed_at: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<u64>,
 }
@@ -8249,6 +8288,104 @@ pub fn validate_substrate_association_handoff(record: &SubstrateAssociationHando
     Ok(())
 }
 
+pub fn validate_association_boundary_proof(record: &AssociationBoundaryProof) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_ASSOCIATION_BOUNDARY_PROOF,
+        "association boundary proof",
+    )?;
+    require_non_empty(
+        &record.proof_id,
+        "association boundary proof missing proofId",
+    )?;
+    require_non_empty(
+        &record.host_ref,
+        "association boundary proof missing hostRef",
+    )?;
+    require_non_empty(
+        &record.owner_ref,
+        "association boundary proof missing ownerRef",
+    )?;
+    require_non_empty(
+        &record.fabric_ref,
+        "association boundary proof missing fabricRef",
+    )?;
+    validate_association_boundary_proof_state(&record.state)?;
+    require_non_empty(
+        &record.substrate_handoff_ref,
+        "association boundary proof missing substrateHandoffRef",
+    )?;
+    let mut phase_refs = BTreeSet::new();
+    validate_association_boundary_phase_refs(
+        &record.initial_association_refs,
+        "initialAssociationRefs",
+        &mut phase_refs,
+    )?;
+    validate_association_boundary_phase_refs(
+        &record.gateway_association_refs,
+        "gatewayAssociationRefs",
+        &mut phase_refs,
+    )?;
+    validate_association_boundary_phase_refs(
+        &record.route_association_refs,
+        "routeAssociationRefs",
+        &mut phase_refs,
+    )?;
+    validate_association_boundary_phase_refs(
+        &record.service_presence_refs,
+        "servicePresenceRefs",
+        &mut phase_refs,
+    )?;
+    validate_association_boundary_phase_refs(
+        &record.membership_refs,
+        "membershipRefs",
+        &mut phase_refs,
+    )?;
+    require_non_empty_vec(
+        &record.fabric_plan_refs,
+        "association boundary proof requires fabricPlanRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "association boundary proof missing evidenceRefs",
+    )?;
+    validate_blocked_reasons(
+        matches!(
+            record.state.as_str(),
+            FABRIC_ASSOCIATION_BOUNDARY_PROOF_BLOCKED | FABRIC_ASSOCIATION_BOUNDARY_PROOF_EXPIRED
+        ),
+        &record.blocked_reasons,
+        "association boundary proof",
+    )?;
+    validate_safe_facts(&record.safe_facts, "association boundary proof safeFacts")?;
+    reject_private_content_fields(&serde_json::to_value(record)?, "association boundary proof")?;
+    reject_media_byte_fields(&serde_json::to_value(record)?, "association boundary proof")?;
+    validate_fabric_observed_window(
+        record.observed_at,
+        record.expires_at,
+        "association boundary proof",
+    )
+}
+
+fn validate_association_boundary_phase_refs(
+    refs: &[String],
+    field_name: &str,
+    seen: &mut BTreeSet<String>,
+) -> Result<()> {
+    require_non_empty_vec(
+        refs,
+        &format!("association boundary proof requires {field_name}"),
+    )?;
+    for reference in refs {
+        if !seen.insert(reference.clone()) {
+            return Err(anyhow!(
+                "association boundary proof collapses phase ref across boundaries: {reference}"
+            ));
+        }
+    }
+    Ok(())
+}
+
 pub fn validate_host_fabric_member_contribution(
     record: &HostFabricMemberContribution,
 ) -> Result<()> {
@@ -8733,12 +8870,18 @@ pub fn validate_contract_target(record: &ContractTarget) -> Result<()> {
     require_non_empty(&record.platform_ref, "contract target missing platformRef")?;
     validate_contract_target_state(&record.state)?;
     validate_contract_target_compatibility_state(&record.compatibility_state)?;
-    validate_optional_ref(record.host_ref.as_deref(), "contract target missing hostRef")?;
+    validate_optional_ref(
+        record.host_ref.as_deref(),
+        "contract target missing hostRef",
+    )?;
     validate_optional_ref(
         record.substrate_ref.as_deref(),
         "contract target missing substrateRef",
     )?;
-    validate_reference_list(&record.modifier_refs, "contract target missing modifierRefs")?;
+    validate_reference_list(
+        &record.modifier_refs,
+        "contract target missing modifierRefs",
+    )?;
     validate_reference_list(&record.branch_refs, "contract target missing branchRefs")?;
     validate_reference_list(
         &record.subbranch_refs,
@@ -8774,7 +8917,10 @@ pub fn validate_contract_target(record: &ContractTarget) -> Result<()> {
         &record.compatibility_refs,
         "contract target missing compatibilityRefs",
     )?;
-    validate_reference_list(&record.evidence_refs, "contract target missing evidenceRefs")?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "contract target missing evidenceRefs",
+    )?;
     validate_blocked_reasons(
         matches!(
             record.state.as_str(),
@@ -8784,7 +8930,9 @@ pub fn validate_contract_target(record: &ContractTarget) -> Result<()> {
         "contract target",
     )?;
     if record.state == FABRIC_CONTRACT_TARGET_READY && !record.missing_slot_refs.is_empty() {
-        return Err(anyhow!("ready contract target must not carry missingSlotRefs"));
+        return Err(anyhow!(
+            "ready contract target must not carry missingSlotRefs"
+        ));
     }
     if record.state == FABRIC_CONTRACT_TARGET_READY && !record.degraded_slot_refs.is_empty() {
         return Err(anyhow!(
@@ -8832,16 +8980,28 @@ fn validate_contract_target_slot_posture(
         record.selected_fulfillment_ref.as_deref(),
         &format!("{context} missing selectedFulfillmentRef"),
     )?;
-    validate_reference_list(&record.source_refs, &format!("{context} missing sourceRefs"))?;
+    validate_reference_list(
+        &record.source_refs,
+        &format!("{context} missing sourceRefs"),
+    )?;
     validate_reference_list(&record.build_refs, &format!("{context} missing buildRefs"))?;
-    validate_reference_list(&record.platform_refs, &format!("{context} missing platformRefs"))?;
-    validate_reference_list(&record.adapter_refs, &format!("{context} missing adapterRefs"))?;
+    validate_reference_list(
+        &record.platform_refs,
+        &format!("{context} missing platformRefs"),
+    )?;
+    validate_reference_list(
+        &record.adapter_refs,
+        &format!("{context} missing adapterRefs"),
+    )?;
     validate_reference_list(
         &record.proof_requirement_refs,
         &format!("{context} missing proofRequirementRefs"),
     )?;
     validate_reference_list(&record.proof_refs, &format!("{context} missing proofRefs"))?;
-    validate_reference_list(&record.evidence_refs, &format!("{context} missing evidenceRefs"))?;
+    validate_reference_list(
+        &record.evidence_refs,
+        &format!("{context} missing evidenceRefs"),
+    )?;
     validate_blocked_reasons(
         matches!(
             record.state.as_str(),
@@ -8853,12 +9013,16 @@ fn validate_contract_target_slot_posture(
     if record.state == FABRIC_CONTRACT_TARGET_SLOT_AVAILABLE
         && record.candidate_fulfillment_refs.is_empty()
     {
-        return Err(anyhow!("{context} available slot requires candidateFulfillmentRefs"));
+        return Err(anyhow!(
+            "{context} available slot requires candidateFulfillmentRefs"
+        ));
     }
     if record.platform_fit_state == FABRIC_CONTRACT_TARGET_PLATFORM_FIT_INCOMPATIBLE
         && record.blocked_reasons.is_empty()
     {
-        return Err(anyhow!("{context} incompatible platform fit requires blockedReasons"));
+        return Err(anyhow!(
+            "{context} incompatible platform fit requires blockedReasons"
+        ));
     }
     validate_safe_facts(&record.safe_facts, &format!("{context} safeFacts"))?;
     reject_private_content_fields(&serde_json::to_value(record)?, context)?;
@@ -8941,7 +9105,9 @@ pub fn validate_contract_target_registry_posture(
             )
         })
     {
-        return Err(anyhow!("ready contract target registry posture must not carry missing, degraded, or blocked slotPostures"));
+        return Err(anyhow!(
+            "ready contract target registry posture must not carry missing, degraded, or blocked slotPostures"
+        ));
     }
     validate_safe_facts(
         &record.safe_facts,
@@ -9591,6 +9757,20 @@ fn validate_fabric_association_handoff_state(state: &str) -> Result<()> {
         Ok(())
     } else {
         Err(anyhow!("unsupported fabric association handoff state"))
+    }
+}
+
+fn validate_association_boundary_proof_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        FABRIC_ASSOCIATION_BOUNDARY_PROOF_READY
+            | FABRIC_ASSOCIATION_BOUNDARY_PROOF_DEGRADED
+            | FABRIC_ASSOCIATION_BOUNDARY_PROOF_BLOCKED
+            | FABRIC_ASSOCIATION_BOUNDARY_PROOF_EXPIRED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported association boundary proof state"))
     }
 }
 
@@ -12550,6 +12730,29 @@ mod tests {
         };
         validate_host_fabric_fulfillment_plan(&plan).expect("valid fabric plan");
 
+        let association_boundary = AssociationBoundaryProof {
+            kind: Some(RECORD_ASSOCIATION_BOUNDARY_PROOF.to_string()),
+            proof_id: "association-boundary-proof:lab-gateway".to_string(),
+            host_ref: "host:lab-gateway".to_string(),
+            owner_ref: "identity:aux".to_string(),
+            fabric_ref: "fabric:lab-gateway".to_string(),
+            state: FABRIC_ASSOCIATION_BOUNDARY_PROOF_READY.to_string(),
+            substrate_handoff_ref: handoff.handoff_id.clone(),
+            initial_association_refs: handoff.initial_association_refs.clone(),
+            gateway_association_refs: handoff.gateway_association_refs.clone(),
+            route_association_refs: vec!["route-association:gateway:lab-gateway".to_string()],
+            service_presence_refs: vec!["service-presence:nvr:lab-gateway".to_string()],
+            membership_refs: vec!["member-presence:service:nvr:lab-gateway".to_string()],
+            fabric_plan_refs: vec![plan.plan_id.clone()],
+            evidence_refs: vec!["evidence:association-boundary:distinct".to_string()],
+            blocked_reasons: vec![],
+            safe_facts: json!({ "phaseSplit": "substrate-gateway-route-service-membership" }),
+            observed_at,
+            expires_at: Some(observed_at + 600),
+        };
+        validate_association_boundary_proof(&association_boundary)
+            .expect("valid association boundary proof");
+
         let content_index = ContentIndexRefPosture {
             kind: Some(RECORD_CONTENT_INDEX_REF_POSTURE.to_string()),
             posture_id: "content-index-posture:gateway-association".to_string(),
@@ -12629,6 +12832,12 @@ mod tests {
         let mut bad_handoff = handoff.clone();
         bad_handoff.gateway_association_refs.clear();
         assert!(validate_substrate_association_handoff(&bad_handoff).is_err());
+        let mut collapsed_boundary = association_boundary.clone();
+        collapsed_boundary.membership_refs = collapsed_boundary.gateway_association_refs.clone();
+        assert!(validate_association_boundary_proof(&collapsed_boundary).is_err());
+        let mut missing_route_boundary = association_boundary.clone();
+        missing_route_boundary.route_association_refs.clear();
+        assert!(validate_association_boundary_proof(&missing_route_boundary).is_err());
         let mut bad_lifecycle = lifecycle.clone();
         bad_lifecycle.state = FABRIC_LIFECYCLE_PLAN_BLOCKED.to_string();
         assert!(validate_lifecycle_plan_posture(&bad_lifecycle).is_err());
@@ -12753,7 +12962,9 @@ mod tests {
                     slot_ref: "slot:operator-focus".to_string(),
                     state: FABRIC_CONTRACT_TARGET_SLOT_DEGRADED.to_string(),
                     platform_fit_state: FABRIC_CONTRACT_TARGET_PLATFORM_FIT_COMPATIBLE.to_string(),
-                    candidate_fulfillment_refs: vec!["fulfillment:operator:aux-firefox".to_string()],
+                    candidate_fulfillment_refs: vec![
+                        "fulfillment:operator:aux-firefox".to_string(),
+                    ],
                     selected_fulfillment_ref: None,
                     source_refs: vec![],
                     build_refs: vec![],

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -144,6 +144,7 @@ pub const RECORD_LIFECYCLE_PLAN_POSTURE: &str = "lifecycle.plan.posture";
 pub const RECORD_CONTENT_INDEX_REF_POSTURE: &str = "contentIndex.ref.posture";
 pub const RECORD_CONTRACT_INTENTION_POSTURE: &str = "contract.intention.posture";
 pub const RECORD_UNIQUE_EDGE_CLASSIFICATION: &str = "uniqueEdge.classification";
+pub const RECORD_CONTRACT_TARGET: &str = "contract.target";
 pub const RECORD_RUNNER_OPERATION: &str = "runner.operation";
 pub const RECORD_APP_RUNNER_FULFILLMENT_REPORT: &str = "app.runner.fulfillment.report";
 pub const RECORD_APP_RUNNER_FULFILLMENT_LIFECYCLE: &str = "app.runner.fulfillment.lifecycle";
@@ -321,6 +322,15 @@ pub const FABRIC_CONTRACT_INTENTION_EXPIRED: &str = "expired";
 pub const FABRIC_UNIQUE_EDGE_GENERIC_PRIMITIVE: &str = "genericPrimitive";
 pub const FABRIC_UNIQUE_EDGE_UNIQUE_EDGE: &str = "uniqueEdge";
 pub const FABRIC_UNIQUE_EDGE_BLOCKED: &str = "blocked";
+pub const FABRIC_CONTRACT_TARGET_SELECTED: &str = "selected";
+pub const FABRIC_CONTRACT_TARGET_READY: &str = "ready";
+pub const FABRIC_CONTRACT_TARGET_DEGRADED: &str = "degraded";
+pub const FABRIC_CONTRACT_TARGET_BLOCKED: &str = "blocked";
+pub const FABRIC_CONTRACT_TARGET_EXPIRED: &str = "expired";
+pub const FABRIC_CONTRACT_TARGET_COMPATIBLE: &str = "compatible";
+pub const FABRIC_CONTRACT_TARGET_COMPATIBILITY_DEGRADED: &str = "degraded";
+pub const FABRIC_CONTRACT_TARGET_INCOMPATIBLE: &str = "incompatible";
+pub const FABRIC_CONTRACT_TARGET_COMPATIBILITY_UNKNOWN: &str = "unknown";
 
 pub const SURFACE_FULFILLMENT_MODE_BUNDLED: &str = "bundled";
 pub const SURFACE_FULFILLMENT_MODE_SWARM_PACKAGE: &str = "swarmPackage";
@@ -3314,6 +3324,57 @@ pub struct UniqueEdgeClassification {
     #[serde(default)]
     pub safe_facts: Value,
     pub observed_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ContractTarget {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub target_ref: String,
+    pub contract_ref: String,
+    pub profile_ref: String,
+    pub platform_ref: String,
+    pub state: String,
+    pub compatibility_state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub substrate_ref: Option<String>,
+    #[serde(default)]
+    pub modifier_refs: Vec<String>,
+    #[serde(default)]
+    pub branch_refs: Vec<String>,
+    #[serde(default)]
+    pub subbranch_refs: Vec<String>,
+    #[serde(default)]
+    pub capability_slot_refs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub adapter_pack_ref: Option<String>,
+    #[serde(default)]
+    pub adapter_refs: Vec<String>,
+    #[serde(default)]
+    pub negative_slot_refs: Vec<String>,
+    #[serde(default)]
+    pub missing_slot_refs: Vec<String>,
+    #[serde(default)]
+    pub degraded_slot_refs: Vec<String>,
+    #[serde(default)]
+    pub proof_profile_refs: Vec<String>,
+    #[serde(default)]
+    pub proof_refs: Vec<String>,
+    #[serde(default)]
+    pub compatibility_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    pub target_audience: String,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub issued_at: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<u64>,
 }
@@ -8586,6 +8647,98 @@ pub fn validate_unique_edge_classification(record: &UniqueEdgeClassification) ->
     )
 }
 
+pub fn validate_contract_target(record: &ContractTarget) -> Result<()> {
+    validate_optional_kind(&record.kind, RECORD_CONTRACT_TARGET, "contract target")?;
+    require_non_empty(&record.target_ref, "contract target missing targetRef")?;
+    require_non_empty(&record.contract_ref, "contract target missing contractRef")?;
+    require_non_empty(&record.profile_ref, "contract target missing profileRef")?;
+    require_non_empty(&record.platform_ref, "contract target missing platformRef")?;
+    validate_contract_target_state(&record.state)?;
+    validate_contract_target_compatibility_state(&record.compatibility_state)?;
+    validate_optional_ref(record.host_ref.as_deref(), "contract target missing hostRef")?;
+    validate_optional_ref(
+        record.substrate_ref.as_deref(),
+        "contract target missing substrateRef",
+    )?;
+    validate_reference_list(&record.modifier_refs, "contract target missing modifierRefs")?;
+    validate_reference_list(&record.branch_refs, "contract target missing branchRefs")?;
+    validate_reference_list(
+        &record.subbranch_refs,
+        "contract target missing subbranchRefs",
+    )?;
+    require_non_empty_vec(
+        &record.capability_slot_refs,
+        "contract target requires capabilitySlotRefs",
+    )?;
+    validate_optional_ref(
+        record.adapter_pack_ref.as_deref(),
+        "contract target missing adapterPackRef",
+    )?;
+    validate_reference_list(&record.adapter_refs, "contract target missing adapterRefs")?;
+    validate_reference_list(
+        &record.negative_slot_refs,
+        "contract target missing negativeSlotRefs",
+    )?;
+    validate_reference_list(
+        &record.missing_slot_refs,
+        "contract target missing missingSlotRefs",
+    )?;
+    validate_reference_list(
+        &record.degraded_slot_refs,
+        "contract target missing degradedSlotRefs",
+    )?;
+    validate_reference_list(
+        &record.proof_profile_refs,
+        "contract target missing proofProfileRefs",
+    )?;
+    validate_reference_list(&record.proof_refs, "contract target missing proofRefs")?;
+    validate_reference_list(
+        &record.compatibility_refs,
+        "contract target missing compatibilityRefs",
+    )?;
+    validate_reference_list(&record.evidence_refs, "contract target missing evidenceRefs")?;
+    validate_blocked_reasons(
+        matches!(
+            record.state.as_str(),
+            FABRIC_CONTRACT_TARGET_BLOCKED | FABRIC_CONTRACT_TARGET_EXPIRED
+        ),
+        &record.blocked_reasons,
+        "contract target",
+    )?;
+    if record.state == FABRIC_CONTRACT_TARGET_READY && !record.missing_slot_refs.is_empty() {
+        return Err(anyhow!("ready contract target must not carry missingSlotRefs"));
+    }
+    if record.state == FABRIC_CONTRACT_TARGET_READY && !record.degraded_slot_refs.is_empty() {
+        return Err(anyhow!(
+            "ready contract target must not carry degradedSlotRefs"
+        ));
+    }
+    if record.compatibility_state == FABRIC_CONTRACT_TARGET_INCOMPATIBLE
+        && record.blocked_reasons.is_empty()
+    {
+        return Err(anyhow!(
+            "incompatible contract target requires blockedReasons"
+        ));
+    }
+    require_non_empty(
+        &record.target_audience,
+        "contract target missing targetAudience",
+    )?;
+    validate_safe_facts(&record.safe_facts, "contract target safeFacts")?;
+    reject_private_content_fields(&serde_json::to_value(record)?, "contract target")?;
+    reject_media_byte_fields(&serde_json::to_value(record)?, "contract target")?;
+    if record.issued_at == 0 {
+        return Err(anyhow!("contract target missing issuedAt"));
+    }
+    if record
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= record.issued_at)
+    {
+        return Err(anyhow!("contract target expiresAt must be after issuedAt"));
+    }
+    Ok(())
+}
+
 pub fn validate_runner_operation(record: &RunnerOperationRecord) -> Result<()> {
     validate_optional_kind(&record.kind, RECORD_RUNNER_OPERATION, "runner operation")?;
     require_non_empty(&record.operation_id, "runner operation missing operationId")?;
@@ -9369,6 +9522,35 @@ fn validate_unique_edge_classification_state(state: &str) -> Result<()> {
         Ok(())
     } else {
         Err(anyhow!("unsupported unique edge classification state"))
+    }
+}
+
+fn validate_contract_target_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        FABRIC_CONTRACT_TARGET_SELECTED
+            | FABRIC_CONTRACT_TARGET_READY
+            | FABRIC_CONTRACT_TARGET_DEGRADED
+            | FABRIC_CONTRACT_TARGET_BLOCKED
+            | FABRIC_CONTRACT_TARGET_EXPIRED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported contract target state"))
+    }
+}
+
+fn validate_contract_target_compatibility_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        FABRIC_CONTRACT_TARGET_COMPATIBLE
+            | FABRIC_CONTRACT_TARGET_COMPATIBILITY_DEGRADED
+            | FABRIC_CONTRACT_TARGET_INCOMPATIBLE
+            | FABRIC_CONTRACT_TARGET_COMPATIBILITY_UNKNOWN
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported contract target compatibility state"))
     }
 }
 
@@ -12196,6 +12378,67 @@ mod tests {
         let mut unsafe_contribution = contribution;
         unsafe_contribution.safe_facts = json!({ "token": "inline-secret" });
         assert!(validate_host_fabric_member_contribution(&unsafe_contribution).is_err());
+    }
+
+    #[test]
+    fn validates_contract_target_refs_slots_and_proof_posture() {
+        let issued_at = 1_700_000_050;
+        let target = ContractTarget {
+            kind: Some(RECORD_CONTRACT_TARGET.to_string()),
+            target_ref: "contract-target:desktop-dev:msa-transition".to_string(),
+            contract_ref: "app:contract:nvr@0.1.0".to_string(),
+            profile_ref: "host-profile:desktop".to_string(),
+            platform_ref: "platform:windows".to_string(),
+            state: FABRIC_CONTRACT_TARGET_DEGRADED.to_string(),
+            compatibility_state: FABRIC_CONTRACT_TARGET_COMPATIBLE.to_string(),
+            host_ref: Some("host:local-workstation".to_string()),
+            substrate_ref: Some("substrate:desktop-dev".to_string()),
+            modifier_refs: vec!["modifier:dev".to_string()],
+            branch_refs: vec!["branch:0x/msa-transition".to_string()],
+            subbranch_refs: vec!["subbranch:target-contract".to_string()],
+            capability_slot_refs: vec![
+                "slot:runtime".to_string(),
+                "slot:gateway".to_string(),
+                "slot:nvr-service".to_string(),
+                "slot:nvr-surface".to_string(),
+            ],
+            adapter_pack_ref: Some("adapter-pack:desktop-dev".to_string()),
+            adapter_refs: vec![
+                "adapter:webrtc:browser".to_string(),
+                "adapter:host-service:windows".to_string(),
+            ],
+            negative_slot_refs: vec!["slot:native-client".to_string()],
+            missing_slot_refs: vec![],
+            degraded_slot_refs: vec!["slot:operator-proof-focus".to_string()],
+            proof_profile_refs: vec![
+                "proof-profile:nvr-smoke-5s".to_string(),
+                "proof-profile:long-stream-10m".to_string(),
+            ],
+            proof_refs: vec!["proof:nvr-smoke-5s:20260522".to_string()],
+            compatibility_refs: vec!["compat:runtime-2.56".to_string()],
+            evidence_refs: vec!["evidence:target:selected".to_string()],
+            blocked_reasons: vec![],
+            target_audience: "developer".to_string(),
+            safe_facts: json!({ "profile": "desktop-dev" }),
+            issued_at,
+            expires_at: Some(issued_at + 3600),
+        };
+        validate_contract_target(&target).expect("valid contract target");
+
+        let mut bad_ready = target.clone();
+        bad_ready.state = FABRIC_CONTRACT_TARGET_READY.to_string();
+        bad_ready.missing_slot_refs = vec!["slot:gateway".to_string()];
+        assert!(validate_contract_target(&bad_ready).is_err());
+
+        let mut bad_incompatible = target.clone();
+        bad_incompatible.target_ref = "contract-target:bad:incompatible".to_string();
+        bad_incompatible.compatibility_state = FABRIC_CONTRACT_TARGET_INCOMPATIBLE.to_string();
+        assert!(validate_contract_target(&bad_incompatible).is_err());
+
+        let mut unsafe_target = target;
+        unsafe_target.target_ref = "contract-target:bad:secret".to_string();
+        unsafe_target.safe_facts = json!({ "token": "inline-secret" });
+        assert!(validate_contract_target(&unsafe_target).is_err());
     }
 
     #[test]

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -137,6 +137,13 @@ pub const RECORD_SURFACE_APP_FULFILLMENT_IDENTITY_POSTURE: &str =
     "surface.app.fulfillment.identity.posture";
 pub const RECORD_SURFACE_APP_AUTHORITY_ACCESS_POSTURE: &str =
     "surface.app.authority.access.posture";
+pub const RECORD_SUBSTRATE_ASSOCIATION_HANDOFF: &str = "substrate.association.handoff";
+pub const RECORD_HOST_FABRIC_MEMBER_CONTRIBUTION: &str = "hostFabric.member.contribution";
+pub const RECORD_HOST_FABRIC_FULFILLMENT_PLAN: &str = "hostFabric.fulfillment.plan";
+pub const RECORD_LIFECYCLE_PLAN_POSTURE: &str = "lifecycle.plan.posture";
+pub const RECORD_CONTENT_INDEX_REF_POSTURE: &str = "contentIndex.ref.posture";
+pub const RECORD_CONTRACT_INTENTION_POSTURE: &str = "contract.intention.posture";
+pub const RECORD_UNIQUE_EDGE_CLASSIFICATION: &str = "uniqueEdge.classification";
 pub const RECORD_RUNNER_OPERATION: &str = "runner.operation";
 pub const RECORD_APP_RUNNER_FULFILLMENT_REPORT: &str = "app.runner.fulfillment.report";
 pub const RECORD_APP_RUNNER_FULFILLMENT_LIFECYCLE: &str = "app.runner.fulfillment.lifecycle";
@@ -244,6 +251,76 @@ pub const RUNNER_FULFILLMENT_STATE_BLOCKED: &str = "blocked";
 pub const RUNNER_FULFILLMENT_STATE_FAILED: &str = "failed";
 pub const RUNNER_FULFILLMENT_STATE_REJECTED: &str = "rejected";
 pub const RUNNER_FULFILLMENT_STATE_CANCELLED: &str = "cancelled";
+
+pub const FABRIC_ASSOCIATION_HANDOFF_READY: &str = "ready";
+pub const FABRIC_ASSOCIATION_HANDOFF_HANDED_OFF: &str = "handedOff";
+pub const FABRIC_ASSOCIATION_HANDOFF_DEGRADED: &str = "degraded";
+pub const FABRIC_ASSOCIATION_HANDOFF_BLOCKED: &str = "blocked";
+pub const FABRIC_ASSOCIATION_HANDOFF_EXPIRED: &str = "expired";
+pub const FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION: &str = "gatewayAssociation";
+pub const FABRIC_MEMBER_ROLE_HOST_SERVICE_ADAPTER: &str = "hostServiceAdapter";
+pub const FABRIC_MEMBER_ROLE_EXECUTION_FULFILLMENT: &str = "executionFulfillment";
+pub const FABRIC_MEMBER_ROLE_STORAGE_JOURNAL_CACHE: &str = "storageJournalCache";
+pub const FABRIC_MEMBER_ROLE_SOURCE_CONTENT_INDEX: &str = "sourceContentIndex";
+pub const FABRIC_MEMBER_ROLE_BUILD_PROCESSOR: &str = "buildProcessor";
+pub const FABRIC_MEMBER_ROLE_RUNTIME: &str = "runtime";
+pub const FABRIC_MEMBER_ROLE_SURFACE: &str = "surface";
+pub const FABRIC_MEMBER_ROLE_PLATFORM_ADAPTER: &str = "platformAdapter";
+pub const FABRIC_MEMBER_ROLE_SERVICE_SURFACE_ADAPTER: &str = "serviceSurfaceAdapter";
+pub const FABRIC_MEMBER_ROLE_SERVICE_EDGE_ADAPTER: &str = "serviceEdgeAdapter";
+pub const FABRIC_MEMBER_ROLE_LOGGING_PROCESSOR: &str = "loggingProcessor";
+pub const FABRIC_MEMBER_ROLE_DOMAIN_SERVICE: &str = "domainService";
+pub const FABRIC_MEMBER_CONTRIBUTION_CLAIMED: &str = "claimed";
+pub const FABRIC_MEMBER_CONTRIBUTION_ACCEPTED: &str = "accepted";
+pub const FABRIC_MEMBER_CONTRIBUTION_RUNNING: &str = "running";
+pub const FABRIC_MEMBER_CONTRIBUTION_DEGRADED: &str = "degraded";
+pub const FABRIC_MEMBER_CONTRIBUTION_BLOCKED: &str = "blocked";
+pub const FABRIC_MEMBER_CONTRIBUTION_RELEASED: &str = "released";
+pub const FABRIC_MEMBER_CONTRIBUTION_EXPIRED: &str = "expired";
+pub const FABRIC_MEMBER_CONTRIBUTION_SUPERSEDED: &str = "superseded";
+pub const FABRIC_FULFILLMENT_PLAN_READY: &str = "ready";
+pub const FABRIC_FULFILLMENT_PLAN_DEGRADED: &str = "degraded";
+pub const FABRIC_FULFILLMENT_PLAN_BLOCKED: &str = "blocked";
+pub const FABRIC_FULFILLMENT_PLAN_EXPIRED: &str = "expired";
+pub const FABRIC_LIFECYCLE_PLAN_READY: &str = "ready";
+pub const FABRIC_LIFECYCLE_PLAN_RUNNING: &str = "running";
+pub const FABRIC_LIFECYCLE_PLAN_DEGRADED: &str = "degraded";
+pub const FABRIC_LIFECYCLE_PLAN_BLOCKED: &str = "blocked";
+pub const FABRIC_LIFECYCLE_PLAN_RELEASED: &str = "released";
+pub const FABRIC_LIFECYCLE_PLAN_EXPIRED: &str = "expired";
+pub const FABRIC_LIFECYCLE_PHASE_SOURCE: &str = "source";
+pub const FABRIC_LIFECYCLE_PHASE_BUILD: &str = "build";
+pub const FABRIC_LIFECYCLE_PHASE_RELEASE: &str = "release";
+pub const FABRIC_LIFECYCLE_PHASE_LOAD: &str = "load";
+pub const FABRIC_LIFECYCLE_PHASE_RUN: &str = "run";
+pub const FABRIC_LIFECYCLE_PHASE_OBSERVE: &str = "observe";
+pub const FABRIC_LIFECYCLE_PHASE_ROLLBACK: &str = "rollback";
+pub const FABRIC_LIFECYCLE_PHASE_EXPIRY: &str = "expiry";
+pub const FABRIC_LIFECYCLE_PHASE_CLEANUP: &str = "cleanup";
+pub const FABRIC_LIFECYCLE_PHASE_NOT_REQUIRED: &str = "notRequired";
+pub const FABRIC_LIFECYCLE_PHASE_PENDING: &str = "pending";
+pub const FABRIC_LIFECYCLE_PHASE_READY: &str = "ready";
+pub const FABRIC_LIFECYCLE_PHASE_RUNNING: &str = "running";
+pub const FABRIC_LIFECYCLE_PHASE_SUCCEEDED: &str = "succeeded";
+pub const FABRIC_LIFECYCLE_PHASE_DEGRADED: &str = "degraded";
+pub const FABRIC_LIFECYCLE_PHASE_BLOCKED: &str = "blocked";
+pub const FABRIC_LIFECYCLE_PHASE_FAILED: &str = "failed";
+pub const FABRIC_LIFECYCLE_PHASE_RELEASED: &str = "released";
+pub const FABRIC_LIFECYCLE_PHASE_EXPIRED: &str = "expired";
+pub const FABRIC_CONTENT_INDEX_READY: &str = "ready";
+pub const FABRIC_CONTENT_INDEX_DEGRADED: &str = "degraded";
+pub const FABRIC_CONTENT_INDEX_BLOCKED: &str = "blocked";
+pub const FABRIC_CONTENT_INDEX_SUPERSEDED: &str = "superseded";
+pub const FABRIC_CONTENT_INDEX_EXPIRED: &str = "expired";
+pub const FABRIC_CONTRACT_INTENTION_DRAFT: &str = "draft";
+pub const FABRIC_CONTRACT_INTENTION_READY: &str = "ready";
+pub const FABRIC_CONTRACT_INTENTION_DEGRADED: &str = "degraded";
+pub const FABRIC_CONTRACT_INTENTION_BLOCKED: &str = "blocked";
+pub const FABRIC_CONTRACT_INTENTION_SUPERSEDED: &str = "superseded";
+pub const FABRIC_CONTRACT_INTENTION_EXPIRED: &str = "expired";
+pub const FABRIC_UNIQUE_EDGE_GENERIC_PRIMITIVE: &str = "genericPrimitive";
+pub const FABRIC_UNIQUE_EDGE_UNIQUE_EDGE: &str = "uniqueEdge";
+pub const FABRIC_UNIQUE_EDGE_BLOCKED: &str = "blocked";
 
 pub const SURFACE_FULFILLMENT_MODE_BUNDLED: &str = "bundled";
 pub const SURFACE_FULFILLMENT_MODE_SWARM_PACKAGE: &str = "swarmPackage";
@@ -3006,6 +3083,239 @@ pub struct AppRunnerAttestation {
     pub recipe_id: String,
     pub status: String,
     pub issued_at: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct SubstrateAssociationHandoff {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub handoff_id: String,
+    pub substrate_ref: String,
+    pub host_ref: String,
+    pub owner_ref: String,
+    pub fabric_ref: String,
+    pub state: String,
+    #[serde(default)]
+    pub initial_association_refs: Vec<String>,
+    #[serde(default)]
+    pub gateway_association_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub handed_off_at: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct HostFabricMemberContribution {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub contribution_id: String,
+    pub fabric_ref: String,
+    pub host_ref: String,
+    pub member_ref: String,
+    pub role: String,
+    pub state: String,
+    pub contract_ref: String,
+    pub subject_ref: String,
+    #[serde(default)]
+    pub capability_refs: Vec<String>,
+    #[serde(default)]
+    pub grant_refs: Vec<String>,
+    #[serde(default)]
+    pub input_refs: Vec<String>,
+    #[serde(default)]
+    pub output_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub lifecycle_plan_refs: Vec<String>,
+    #[serde(default)]
+    pub release_refs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_posture: Option<ResourcePosture>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub observed_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct HostFabricFulfillmentPlan {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub plan_id: String,
+    pub fabric_ref: String,
+    pub host_ref: String,
+    pub contract_ref: String,
+    pub state: String,
+    #[serde(default)]
+    pub required_role_refs: Vec<String>,
+    #[serde(default)]
+    pub member_contribution_refs: Vec<String>,
+    #[serde(default)]
+    pub missing_role_refs: Vec<String>,
+    #[serde(default)]
+    pub lifecycle_plan_refs: Vec<String>,
+    #[serde(default)]
+    pub materialization_budget_refs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub association_handoff_ref: Option<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub observed_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LifecyclePhasePosture {
+    pub phase: String,
+    pub state: String,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub output_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct LifecyclePlanPosture {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub lifecycle_plan_id: String,
+    pub subject_ref: String,
+    pub contract_ref: String,
+    pub state: String,
+    #[serde(default)]
+    pub lifecycle_contract_refs: Vec<String>,
+    #[serde(default)]
+    pub phase_postures: Vec<LifecyclePhasePosture>,
+    #[serde(default)]
+    pub member_contribution_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub release_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub observed_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ContentIndexRefPosture {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub posture_id: String,
+    pub content_index_ref: String,
+    pub state: String,
+    #[serde(default)]
+    pub source_refs: Vec<String>,
+    #[serde(default)]
+    pub materialized_projection_refs: Vec<String>,
+    #[serde(default)]
+    pub storage_refs: Vec<String>,
+    #[serde(default)]
+    pub writer_refs: Vec<String>,
+    #[serde(default)]
+    pub schema_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub observed_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ContractIntentionPosture {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub posture_id: String,
+    pub intention_ref: String,
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonical_hash_ref: Option<String>,
+    #[serde(default)]
+    pub content_index_refs: Vec<String>,
+    #[serde(default)]
+    pub authoring_surface_refs: Vec<String>,
+    #[serde(default)]
+    pub proof_gate_refs: Vec<String>,
+    #[serde(default)]
+    pub reducer_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub observed_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct UniqueEdgeClassification {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub classification_id: String,
+    pub subject_ref: String,
+    pub state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub primitive_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_reality_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interaction_ref: Option<String>,
+    #[serde(default)]
+    pub policy_refs: Vec<String>,
+    #[serde(default)]
+    pub input_refs: Vec<String>,
+    #[serde(default)]
+    pub output_refs: Vec<String>,
+    #[serde(default)]
+    pub grant_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub observed_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
@@ -7691,6 +8001,591 @@ pub fn validate_app_runner_attestation(attestation: &AppRunnerAttestation) -> Re
     Ok(())
 }
 
+fn validate_fabric_observed_window(
+    observed_at: u64,
+    expires_at: Option<u64>,
+    context: &str,
+) -> Result<()> {
+    if observed_at == 0 {
+        return Err(anyhow!("{context} missing observedAt"));
+    }
+    if expires_at.is_some_and(|expires_at| expires_at <= observed_at) {
+        return Err(anyhow!("{context} expiresAt must be after observedAt"));
+    }
+    Ok(())
+}
+
+fn validate_blocked_reasons(
+    blocked: bool,
+    blocked_reasons: &[String],
+    context: &str,
+) -> Result<()> {
+    validate_reference_list(
+        blocked_reasons,
+        &format!("{context} missing blockedReasons"),
+    )?;
+    if blocked && blocked_reasons.is_empty() {
+        return Err(anyhow!("{context} requires blockedReasons"));
+    }
+    Ok(())
+}
+
+pub fn validate_substrate_association_handoff(record: &SubstrateAssociationHandoff) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_SUBSTRATE_ASSOCIATION_HANDOFF,
+        "substrate association handoff",
+    )?;
+    require_non_empty(
+        &record.handoff_id,
+        "substrate association handoff missing handoffId",
+    )?;
+    require_non_empty(
+        &record.substrate_ref,
+        "substrate association handoff missing substrateRef",
+    )?;
+    require_non_empty(
+        &record.host_ref,
+        "substrate association handoff missing hostRef",
+    )?;
+    require_non_empty(
+        &record.owner_ref,
+        "substrate association handoff missing ownerRef",
+    )?;
+    require_non_empty(
+        &record.fabric_ref,
+        "substrate association handoff missing fabricRef",
+    )?;
+    validate_fabric_association_handoff_state(&record.state)?;
+    require_non_empty_vec(
+        &record.initial_association_refs,
+        "substrate association handoff requires initialAssociationRefs",
+    )?;
+    validate_reference_list(
+        &record.gateway_association_refs,
+        "substrate association handoff missing gatewayAssociationRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "substrate association handoff missing evidenceRefs",
+    )?;
+    validate_blocked_reasons(
+        matches!(
+            record.state.as_str(),
+            FABRIC_ASSOCIATION_HANDOFF_BLOCKED | FABRIC_ASSOCIATION_HANDOFF_EXPIRED
+        ),
+        &record.blocked_reasons,
+        "substrate association handoff",
+    )?;
+    if record.state == FABRIC_ASSOCIATION_HANDOFF_HANDED_OFF
+        && record.gateway_association_refs.is_empty()
+    {
+        return Err(anyhow!(
+            "handed off substrate association requires gatewayAssociationRefs"
+        ));
+    }
+    validate_safe_facts(
+        &record.safe_facts,
+        "substrate association handoff safeFacts",
+    )?;
+    reject_private_content_fields(
+        &serde_json::to_value(record)?,
+        "substrate association handoff",
+    )?;
+    reject_media_byte_fields(
+        &serde_json::to_value(record)?,
+        "substrate association handoff",
+    )?;
+    if record.issued_at == 0 {
+        return Err(anyhow!("substrate association handoff missing issuedAt"));
+    }
+    if record
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= record.issued_at)
+    {
+        return Err(anyhow!(
+            "substrate association handoff expiresAt must be after issuedAt"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_host_fabric_member_contribution(
+    record: &HostFabricMemberContribution,
+) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_HOST_FABRIC_MEMBER_CONTRIBUTION,
+        "host-fabric member contribution",
+    )?;
+    require_non_empty(
+        &record.contribution_id,
+        "host-fabric member contribution missing contributionId",
+    )?;
+    require_non_empty(
+        &record.fabric_ref,
+        "host-fabric member contribution missing fabricRef",
+    )?;
+    require_non_empty(
+        &record.host_ref,
+        "host-fabric member contribution missing hostRef",
+    )?;
+    validate_resolved_member_ref(
+        &record.member_ref,
+        "host-fabric member contribution missing memberRef",
+    )?;
+    validate_fabric_member_role(&record.role)?;
+    validate_fabric_member_contribution_state(&record.state)?;
+    require_non_empty(
+        &record.contract_ref,
+        "host-fabric member contribution missing contractRef",
+    )?;
+    require_non_empty(
+        &record.subject_ref,
+        "host-fabric member contribution missing subjectRef",
+    )?;
+    validate_reference_list(
+        &record.capability_refs,
+        "host-fabric member contribution missing capabilityRefs",
+    )?;
+    validate_reference_list(
+        &record.grant_refs,
+        "host-fabric member contribution missing grantRefs",
+    )?;
+    validate_reference_list(
+        &record.input_refs,
+        "host-fabric member contribution missing inputRefs",
+    )?;
+    validate_reference_list(
+        &record.output_refs,
+        "host-fabric member contribution missing outputRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "host-fabric member contribution missing evidenceRefs",
+    )?;
+    validate_reference_list(
+        &record.lifecycle_plan_refs,
+        "host-fabric member contribution missing lifecyclePlanRefs",
+    )?;
+    validate_reference_list(
+        &record.release_refs,
+        "host-fabric member contribution missing releaseRefs",
+    )?;
+    validate_blocked_reasons(
+        matches!(
+            record.state.as_str(),
+            FABRIC_MEMBER_CONTRIBUTION_BLOCKED | FABRIC_MEMBER_CONTRIBUTION_EXPIRED
+        ),
+        &record.blocked_reasons,
+        "host-fabric member contribution",
+    )?;
+    if let Some(resource_posture) = &record.resource_posture {
+        validate_resource_posture(resource_posture)?;
+    }
+    validate_safe_facts(
+        &record.safe_facts,
+        "host-fabric member contribution safeFacts",
+    )?;
+    reject_private_content_fields(
+        &serde_json::to_value(record)?,
+        "host-fabric member contribution",
+    )?;
+    reject_media_byte_fields(
+        &serde_json::to_value(record)?,
+        "host-fabric member contribution",
+    )?;
+    validate_fabric_observed_window(
+        record.observed_at,
+        record.expires_at,
+        "host-fabric member contribution",
+    )
+}
+
+pub fn validate_host_fabric_fulfillment_plan(record: &HostFabricFulfillmentPlan) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_HOST_FABRIC_FULFILLMENT_PLAN,
+        "host-fabric fulfillment plan",
+    )?;
+    require_non_empty(
+        &record.plan_id,
+        "host-fabric fulfillment plan missing planId",
+    )?;
+    require_non_empty(
+        &record.fabric_ref,
+        "host-fabric fulfillment plan missing fabricRef",
+    )?;
+    require_non_empty(
+        &record.host_ref,
+        "host-fabric fulfillment plan missing hostRef",
+    )?;
+    require_non_empty(
+        &record.contract_ref,
+        "host-fabric fulfillment plan missing contractRef",
+    )?;
+    validate_fabric_fulfillment_plan_state(&record.state)?;
+    require_non_empty_vec(
+        &record.required_role_refs,
+        "host-fabric fulfillment plan requires requiredRoleRefs",
+    )?;
+    validate_reference_list(
+        &record.member_contribution_refs,
+        "host-fabric fulfillment plan missing memberContributionRefs",
+    )?;
+    validate_reference_list(
+        &record.missing_role_refs,
+        "host-fabric fulfillment plan missing missingRoleRefs",
+    )?;
+    validate_reference_list(
+        &record.lifecycle_plan_refs,
+        "host-fabric fulfillment plan missing lifecyclePlanRefs",
+    )?;
+    validate_reference_list(
+        &record.materialization_budget_refs,
+        "host-fabric fulfillment plan missing materializationBudgetRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "host-fabric fulfillment plan missing evidenceRefs",
+    )?;
+    validate_optional_ref(
+        record.association_handoff_ref.as_deref(),
+        "host-fabric fulfillment plan missing associationHandoffRef",
+    )?;
+    validate_blocked_reasons(
+        matches!(
+            record.state.as_str(),
+            FABRIC_FULFILLMENT_PLAN_BLOCKED | FABRIC_FULFILLMENT_PLAN_EXPIRED
+        ),
+        &record.blocked_reasons,
+        "host-fabric fulfillment plan",
+    )?;
+    if record.state == FABRIC_FULFILLMENT_PLAN_READY && record.member_contribution_refs.is_empty() {
+        return Err(anyhow!(
+            "ready host-fabric fulfillment plan requires memberContributionRefs"
+        ));
+    }
+    validate_safe_facts(&record.safe_facts, "host-fabric fulfillment plan safeFacts")?;
+    reject_private_content_fields(
+        &serde_json::to_value(record)?,
+        "host-fabric fulfillment plan",
+    )?;
+    reject_media_byte_fields(
+        &serde_json::to_value(record)?,
+        "host-fabric fulfillment plan",
+    )?;
+    validate_fabric_observed_window(
+        record.observed_at,
+        record.expires_at,
+        "host-fabric fulfillment plan",
+    )
+}
+
+fn validate_lifecycle_phase_posture(record: &LifecyclePhasePosture, context: &str) -> Result<()> {
+    validate_fabric_lifecycle_phase(&record.phase)?;
+    validate_fabric_lifecycle_phase_state(&record.state)?;
+    validate_reference_list(
+        &record.evidence_refs,
+        &format!("{context} missing evidenceRefs"),
+    )?;
+    validate_reference_list(
+        &record.output_refs,
+        &format!("{context} missing outputRefs"),
+    )?;
+    validate_blocked_reasons(
+        matches!(
+            record.state.as_str(),
+            FABRIC_LIFECYCLE_PHASE_BLOCKED | FABRIC_LIFECYCLE_PHASE_FAILED
+        ),
+        &record.blocked_reasons,
+        context,
+    )?;
+    validate_safe_facts(&record.safe_facts, &format!("{context} safeFacts"))
+}
+
+pub fn validate_lifecycle_plan_posture(record: &LifecyclePlanPosture) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_LIFECYCLE_PLAN_POSTURE,
+        "lifecycle plan posture",
+    )?;
+    require_non_empty(
+        &record.lifecycle_plan_id,
+        "lifecycle plan posture missing lifecyclePlanId",
+    )?;
+    require_non_empty(
+        &record.subject_ref,
+        "lifecycle plan posture missing subjectRef",
+    )?;
+    require_non_empty(
+        &record.contract_ref,
+        "lifecycle plan posture missing contractRef",
+    )?;
+    validate_fabric_lifecycle_plan_state(&record.state)?;
+    require_non_empty_vec(
+        &record.lifecycle_contract_refs,
+        "lifecycle plan posture requires lifecycleContractRefs",
+    )?;
+    if record.phase_postures.is_empty() {
+        return Err(anyhow!("lifecycle plan posture requires phasePostures"));
+    }
+    for (index, phase) in record.phase_postures.iter().enumerate() {
+        validate_lifecycle_phase_posture(
+            phase,
+            &format!("lifecycle plan posture phasePostures {index}"),
+        )?;
+    }
+    validate_reference_list(
+        &record.member_contribution_refs,
+        "lifecycle plan posture missing memberContributionRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "lifecycle plan posture missing evidenceRefs",
+    )?;
+    validate_reference_list(
+        &record.release_refs,
+        "lifecycle plan posture missing releaseRefs",
+    )?;
+    validate_blocked_reasons(
+        matches!(
+            record.state.as_str(),
+            FABRIC_LIFECYCLE_PLAN_BLOCKED | FABRIC_LIFECYCLE_PLAN_EXPIRED
+        ),
+        &record.blocked_reasons,
+        "lifecycle plan posture",
+    )?;
+    validate_safe_facts(&record.safe_facts, "lifecycle plan posture safeFacts")?;
+    reject_private_content_fields(&serde_json::to_value(record)?, "lifecycle plan posture")?;
+    reject_media_byte_fields(&serde_json::to_value(record)?, "lifecycle plan posture")?;
+    validate_fabric_observed_window(
+        record.observed_at,
+        record.expires_at,
+        "lifecycle plan posture",
+    )
+}
+
+pub fn validate_content_index_ref_posture(record: &ContentIndexRefPosture) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_CONTENT_INDEX_REF_POSTURE,
+        "content-index ref posture",
+    )?;
+    require_non_empty(
+        &record.posture_id,
+        "content-index ref posture missing postureId",
+    )?;
+    require_non_empty(
+        &record.content_index_ref,
+        "content-index ref posture missing contentIndexRef",
+    )?;
+    validate_fabric_content_index_state(&record.state)?;
+    validate_reference_list(
+        &record.source_refs,
+        "content-index ref posture missing sourceRefs",
+    )?;
+    validate_reference_list(
+        &record.materialized_projection_refs,
+        "content-index ref posture missing materializedProjectionRefs",
+    )?;
+    validate_reference_list(
+        &record.storage_refs,
+        "content-index ref posture missing storageRefs",
+    )?;
+    validate_reference_list(
+        &record.writer_refs,
+        "content-index ref posture missing writerRefs",
+    )?;
+    validate_reference_list(
+        &record.schema_refs,
+        "content-index ref posture missing schemaRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "content-index ref posture missing evidenceRefs",
+    )?;
+    validate_blocked_reasons(
+        matches!(
+            record.state.as_str(),
+            FABRIC_CONTENT_INDEX_BLOCKED | FABRIC_CONTENT_INDEX_EXPIRED
+        ),
+        &record.blocked_reasons,
+        "content-index ref posture",
+    )?;
+    if record.state == FABRIC_CONTENT_INDEX_READY && record.source_refs.is_empty() {
+        return Err(anyhow!(
+            "ready content-index ref posture requires sourceRefs"
+        ));
+    }
+    if record.state == FABRIC_CONTENT_INDEX_READY && record.materialized_projection_refs.is_empty()
+    {
+        return Err(anyhow!(
+            "ready content-index ref posture requires materializedProjectionRefs"
+        ));
+    }
+    validate_safe_facts(&record.safe_facts, "content-index ref posture safeFacts")?;
+    reject_private_content_fields(&serde_json::to_value(record)?, "content-index ref posture")?;
+    reject_media_byte_fields(&serde_json::to_value(record)?, "content-index ref posture")?;
+    validate_fabric_observed_window(
+        record.observed_at,
+        record.expires_at,
+        "content-index ref posture",
+    )
+}
+
+pub fn validate_contract_intention_posture(record: &ContractIntentionPosture) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_CONTRACT_INTENTION_POSTURE,
+        "contract intention posture",
+    )?;
+    require_non_empty(
+        &record.posture_id,
+        "contract intention posture missing postureId",
+    )?;
+    require_non_empty(
+        &record.intention_ref,
+        "contract intention posture missing intentionRef",
+    )?;
+    validate_fabric_contract_intention_state(&record.state)?;
+    validate_optional_ref(
+        record.canonical_hash_ref.as_deref(),
+        "contract intention posture missing canonicalHashRef",
+    )?;
+    validate_reference_list(
+        &record.content_index_refs,
+        "contract intention posture missing contentIndexRefs",
+    )?;
+    validate_reference_list(
+        &record.authoring_surface_refs,
+        "contract intention posture missing authoringSurfaceRefs",
+    )?;
+    validate_reference_list(
+        &record.proof_gate_refs,
+        "contract intention posture missing proofGateRefs",
+    )?;
+    validate_reference_list(
+        &record.reducer_refs,
+        "contract intention posture missing reducerRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "contract intention posture missing evidenceRefs",
+    )?;
+    validate_blocked_reasons(
+        matches!(
+            record.state.as_str(),
+            FABRIC_CONTRACT_INTENTION_BLOCKED | FABRIC_CONTRACT_INTENTION_EXPIRED
+        ),
+        &record.blocked_reasons,
+        "contract intention posture",
+    )?;
+    if record.state == FABRIC_CONTRACT_INTENTION_READY
+        && record
+            .canonical_hash_ref
+            .as_deref()
+            .unwrap_or_default()
+            .trim()
+            .is_empty()
+    {
+        return Err(anyhow!(
+            "ready contract intention posture requires canonicalHashRef"
+        ));
+    }
+    if record.state == FABRIC_CONTRACT_INTENTION_READY && record.content_index_refs.is_empty() {
+        return Err(anyhow!(
+            "ready contract intention posture requires contentIndexRefs"
+        ));
+    }
+    validate_safe_facts(&record.safe_facts, "contract intention posture safeFacts")?;
+    reject_private_content_fields(&serde_json::to_value(record)?, "contract intention posture")?;
+    reject_media_byte_fields(&serde_json::to_value(record)?, "contract intention posture")?;
+    validate_fabric_observed_window(
+        record.observed_at,
+        record.expires_at,
+        "contract intention posture",
+    )
+}
+
+pub fn validate_unique_edge_classification(record: &UniqueEdgeClassification) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_UNIQUE_EDGE_CLASSIFICATION,
+        "unique edge classification",
+    )?;
+    require_non_empty(
+        &record.classification_id,
+        "unique edge classification missing classificationId",
+    )?;
+    require_non_empty(
+        &record.subject_ref,
+        "unique edge classification missing subjectRef",
+    )?;
+    validate_unique_edge_classification_state(&record.state)?;
+    validate_optional_ref(
+        record.primitive_ref.as_deref(),
+        "unique edge classification missing primitiveRef",
+    )?;
+    validate_optional_ref(
+        record.external_reality_ref.as_deref(),
+        "unique edge classification missing externalRealityRef",
+    )?;
+    validate_optional_ref(
+        record.interaction_ref.as_deref(),
+        "unique edge classification missing interactionRef",
+    )?;
+    if record.state == FABRIC_UNIQUE_EDGE_UNIQUE_EDGE {
+        require_non_empty(
+            record.external_reality_ref.as_deref().unwrap_or_default(),
+            "unique edge classification requires externalRealityRef",
+        )?;
+        require_non_empty(
+            record.interaction_ref.as_deref().unwrap_or_default(),
+            "unique edge classification requires interactionRef",
+        )?;
+    }
+    if record.state == FABRIC_UNIQUE_EDGE_GENERIC_PRIMITIVE {
+        require_non_empty(
+            record.primitive_ref.as_deref().unwrap_or_default(),
+            "unique edge classification requires primitiveRef",
+        )?;
+    }
+    validate_reference_list(
+        &record.policy_refs,
+        "unique edge classification missing policyRefs",
+    )?;
+    validate_reference_list(
+        &record.input_refs,
+        "unique edge classification missing inputRefs",
+    )?;
+    validate_reference_list(
+        &record.output_refs,
+        "unique edge classification missing outputRefs",
+    )?;
+    validate_reference_list(
+        &record.grant_refs,
+        "unique edge classification missing grantRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "unique edge classification missing evidenceRefs",
+    )?;
+    validate_blocked_reasons(
+        record.state == FABRIC_UNIQUE_EDGE_BLOCKED,
+        &record.blocked_reasons,
+        "unique edge classification",
+    )?;
+    validate_safe_facts(&record.safe_facts, "unique edge classification safeFacts")?;
+    reject_private_content_fields(&serde_json::to_value(record)?, "unique edge classification")?;
+    reject_media_byte_fields(&serde_json::to_value(record)?, "unique edge classification")?;
+    validate_fabric_observed_window(
+        record.observed_at,
+        record.expires_at,
+        "unique edge classification",
+    )
+}
+
 pub fn validate_runner_operation(record: &RunnerOperationRecord) -> Result<()> {
     validate_optional_kind(&record.kind, RECORD_RUNNER_OPERATION, "runner operation")?;
     require_non_empty(&record.operation_id, "runner operation missing operationId")?;
@@ -8305,6 +9200,175 @@ fn validate_service_manager_proof_profile(profile: &str) -> Result<()> {
         Ok(())
     } else {
         Err(anyhow!("unsupported service manager proof profile"))
+    }
+}
+
+fn validate_fabric_association_handoff_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        FABRIC_ASSOCIATION_HANDOFF_READY
+            | FABRIC_ASSOCIATION_HANDOFF_HANDED_OFF
+            | FABRIC_ASSOCIATION_HANDOFF_DEGRADED
+            | FABRIC_ASSOCIATION_HANDOFF_BLOCKED
+            | FABRIC_ASSOCIATION_HANDOFF_EXPIRED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported fabric association handoff state"))
+    }
+}
+
+fn validate_fabric_member_role(role: &str) -> Result<()> {
+    if matches!(
+        role,
+        FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION
+            | FABRIC_MEMBER_ROLE_HOST_SERVICE_ADAPTER
+            | FABRIC_MEMBER_ROLE_EXECUTION_FULFILLMENT
+            | FABRIC_MEMBER_ROLE_STORAGE_JOURNAL_CACHE
+            | FABRIC_MEMBER_ROLE_SOURCE_CONTENT_INDEX
+            | FABRIC_MEMBER_ROLE_BUILD_PROCESSOR
+            | FABRIC_MEMBER_ROLE_RUNTIME
+            | FABRIC_MEMBER_ROLE_SURFACE
+            | FABRIC_MEMBER_ROLE_PLATFORM_ADAPTER
+            | FABRIC_MEMBER_ROLE_SERVICE_SURFACE_ADAPTER
+            | FABRIC_MEMBER_ROLE_SERVICE_EDGE_ADAPTER
+            | FABRIC_MEMBER_ROLE_LOGGING_PROCESSOR
+            | FABRIC_MEMBER_ROLE_DOMAIN_SERVICE
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported host-fabric member role"))
+    }
+}
+
+fn validate_fabric_member_contribution_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        FABRIC_MEMBER_CONTRIBUTION_CLAIMED
+            | FABRIC_MEMBER_CONTRIBUTION_ACCEPTED
+            | FABRIC_MEMBER_CONTRIBUTION_RUNNING
+            | FABRIC_MEMBER_CONTRIBUTION_DEGRADED
+            | FABRIC_MEMBER_CONTRIBUTION_BLOCKED
+            | FABRIC_MEMBER_CONTRIBUTION_RELEASED
+            | FABRIC_MEMBER_CONTRIBUTION_EXPIRED
+            | FABRIC_MEMBER_CONTRIBUTION_SUPERSEDED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported host-fabric member contribution state"))
+    }
+}
+
+fn validate_fabric_fulfillment_plan_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        FABRIC_FULFILLMENT_PLAN_READY
+            | FABRIC_FULFILLMENT_PLAN_DEGRADED
+            | FABRIC_FULFILLMENT_PLAN_BLOCKED
+            | FABRIC_FULFILLMENT_PLAN_EXPIRED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported host-fabric fulfillment plan state"))
+    }
+}
+
+fn validate_fabric_lifecycle_plan_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        FABRIC_LIFECYCLE_PLAN_READY
+            | FABRIC_LIFECYCLE_PLAN_RUNNING
+            | FABRIC_LIFECYCLE_PLAN_DEGRADED
+            | FABRIC_LIFECYCLE_PLAN_BLOCKED
+            | FABRIC_LIFECYCLE_PLAN_RELEASED
+            | FABRIC_LIFECYCLE_PLAN_EXPIRED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported lifecycle plan state"))
+    }
+}
+
+fn validate_fabric_lifecycle_phase(phase: &str) -> Result<()> {
+    if matches!(
+        phase,
+        FABRIC_LIFECYCLE_PHASE_SOURCE
+            | FABRIC_LIFECYCLE_PHASE_BUILD
+            | FABRIC_LIFECYCLE_PHASE_RELEASE
+            | FABRIC_LIFECYCLE_PHASE_LOAD
+            | FABRIC_LIFECYCLE_PHASE_RUN
+            | FABRIC_LIFECYCLE_PHASE_OBSERVE
+            | FABRIC_LIFECYCLE_PHASE_ROLLBACK
+            | FABRIC_LIFECYCLE_PHASE_EXPIRY
+            | FABRIC_LIFECYCLE_PHASE_CLEANUP
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported lifecycle phase"))
+    }
+}
+
+fn validate_fabric_lifecycle_phase_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        FABRIC_LIFECYCLE_PHASE_NOT_REQUIRED
+            | FABRIC_LIFECYCLE_PHASE_PENDING
+            | FABRIC_LIFECYCLE_PHASE_READY
+            | FABRIC_LIFECYCLE_PHASE_RUNNING
+            | FABRIC_LIFECYCLE_PHASE_SUCCEEDED
+            | FABRIC_LIFECYCLE_PHASE_DEGRADED
+            | FABRIC_LIFECYCLE_PHASE_BLOCKED
+            | FABRIC_LIFECYCLE_PHASE_FAILED
+            | FABRIC_LIFECYCLE_PHASE_RELEASED
+            | FABRIC_LIFECYCLE_PHASE_EXPIRED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported lifecycle phase state"))
+    }
+}
+
+fn validate_fabric_content_index_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        FABRIC_CONTENT_INDEX_READY
+            | FABRIC_CONTENT_INDEX_DEGRADED
+            | FABRIC_CONTENT_INDEX_BLOCKED
+            | FABRIC_CONTENT_INDEX_SUPERSEDED
+            | FABRIC_CONTENT_INDEX_EXPIRED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported content-index state"))
+    }
+}
+
+fn validate_fabric_contract_intention_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        FABRIC_CONTRACT_INTENTION_DRAFT
+            | FABRIC_CONTRACT_INTENTION_READY
+            | FABRIC_CONTRACT_INTENTION_DEGRADED
+            | FABRIC_CONTRACT_INTENTION_BLOCKED
+            | FABRIC_CONTRACT_INTENTION_SUPERSEDED
+            | FABRIC_CONTRACT_INTENTION_EXPIRED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported contract intention state"))
+    }
+}
+
+fn validate_unique_edge_classification_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        FABRIC_UNIQUE_EDGE_GENERIC_PRIMITIVE
+            | FABRIC_UNIQUE_EDGE_UNIQUE_EDGE
+            | FABRIC_UNIQUE_EDGE_BLOCKED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported unique edge classification state"))
     }
 }
 
@@ -10928,6 +11992,210 @@ mod tests {
         let mut unsafe_fact = runner_operation;
         unsafe_fact.safe_facts = json!({ "token": "inline-secret" });
         assert!(validate_runner_operation(&unsafe_fact).is_err());
+    }
+
+    #[test]
+    fn validates_host_fabric_lifecycle_content_index_and_unique_edge_records() {
+        let member_ref = pubkey_from_sk_hex(BROWSER_SK).expect("browser pk");
+        let observed_at = 1_700_000_040;
+        let handoff = SubstrateAssociationHandoff {
+            kind: Some(RECORD_SUBSTRATE_ASSOCIATION_HANDOFF.to_string()),
+            handoff_id: "handoff:lab-gateway:initial-owner".to_string(),
+            substrate_ref: "substrate:first-trust:lab".to_string(),
+            host_ref: "host:lab-gateway".to_string(),
+            owner_ref: "identity:aux".to_string(),
+            fabric_ref: "fabric:lab-gateway".to_string(),
+            state: FABRIC_ASSOCIATION_HANDOFF_HANDED_OFF.to_string(),
+            initial_association_refs: vec!["association:substrate:aux:lab-gateway".to_string()],
+            gateway_association_refs: vec!["association:gateway:lab-gateway:ongoing".to_string()],
+            evidence_refs: vec!["evidence:substrate:verified".to_string()],
+            blocked_reasons: vec![],
+            safe_facts: json!({ "handoff": "substrate-to-gateway-association" }),
+            issued_at: observed_at - 10,
+            handed_off_at: Some(observed_at - 1),
+            expires_at: Some(observed_at + 600),
+        };
+        validate_substrate_association_handoff(&handoff).expect("valid substrate handoff");
+
+        let contribution = HostFabricMemberContribution {
+            kind: Some(RECORD_HOST_FABRIC_MEMBER_CONTRIBUTION.to_string()),
+            contribution_id: "fabric-contribution:gateway-association:1".to_string(),
+            fabric_ref: "fabric:lab-gateway".to_string(),
+            host_ref: "host:lab-gateway".to_string(),
+            member_ref: member_ref.clone(),
+            role: FABRIC_MEMBER_ROLE_GATEWAY_ASSOCIATION.to_string(),
+            state: FABRIC_MEMBER_CONTRIBUTION_RUNNING.to_string(),
+            contract_ref: "contract:gateway-association@0.1.0".to_string(),
+            subject_ref: "association:gateway:lab-gateway:ongoing".to_string(),
+            capability_refs: vec!["gateway.association.fulfill".to_string()],
+            grant_refs: vec!["grant:gateway-association:fulfill".to_string()],
+            input_refs: vec![],
+            output_refs: vec![],
+            evidence_refs: vec!["evidence:gateway-association:presence".to_string()],
+            lifecycle_plan_refs: vec!["lifecycle-plan:gateway-association:1".to_string()],
+            release_refs: vec![],
+            resource_posture: None,
+            blocked_reasons: vec![],
+            safe_facts: json!({ "role": "gatewayAssociation" }),
+            observed_at,
+            expires_at: Some(observed_at + 600),
+        };
+        validate_host_fabric_member_contribution(&contribution).expect("valid fabric contribution");
+
+        let lifecycle = LifecyclePlanPosture {
+            kind: Some(RECORD_LIFECYCLE_PLAN_POSTURE.to_string()),
+            lifecycle_plan_id: "lifecycle-plan:gateway-association:1".to_string(),
+            subject_ref: "association:gateway:lab-gateway:ongoing".to_string(),
+            contract_ref: "contract:lifecycle.gateway-association@0.1.0".to_string(),
+            state: FABRIC_LIFECYCLE_PLAN_READY.to_string(),
+            lifecycle_contract_refs: vec![
+                "contract:lifecycle.gateway-association@0.1.0".to_string(),
+            ],
+            phase_postures: vec![
+                LifecyclePhasePosture {
+                    phase: FABRIC_LIFECYCLE_PHASE_SOURCE.to_string(),
+                    state: FABRIC_LIFECYCLE_PHASE_READY.to_string(),
+                    evidence_refs: vec!["evidence:source:indexed".to_string()],
+                    output_refs: vec![],
+                    blocked_reasons: vec![],
+                    safe_facts: Value::Null,
+                },
+                LifecyclePhasePosture {
+                    phase: FABRIC_LIFECYCLE_PHASE_RUN.to_string(),
+                    state: FABRIC_LIFECYCLE_PHASE_RUNNING.to_string(),
+                    evidence_refs: vec!["evidence:association:running".to_string()],
+                    output_refs: vec![],
+                    blocked_reasons: vec![],
+                    safe_facts: Value::Null,
+                },
+            ],
+            member_contribution_refs: vec![contribution.contribution_id.clone()],
+            evidence_refs: vec!["evidence:lifecycle:reduced".to_string()],
+            release_refs: vec![],
+            blocked_reasons: vec![],
+            safe_facts: Value::Null,
+            observed_at,
+            expires_at: Some(observed_at + 600),
+        };
+        validate_lifecycle_plan_posture(&lifecycle).expect("valid lifecycle plan");
+
+        let plan = HostFabricFulfillmentPlan {
+            kind: Some(RECORD_HOST_FABRIC_FULFILLMENT_PLAN.to_string()),
+            plan_id: "fabric-plan:lab-gateway:association".to_string(),
+            fabric_ref: "fabric:lab-gateway".to_string(),
+            host_ref: "host:lab-gateway".to_string(),
+            contract_ref: "contract:gateway-association@0.1.0".to_string(),
+            state: FABRIC_FULFILLMENT_PLAN_READY.to_string(),
+            required_role_refs: vec!["role:gatewayAssociation".to_string()],
+            member_contribution_refs: vec![contribution.contribution_id.clone()],
+            missing_role_refs: vec![],
+            lifecycle_plan_refs: vec![lifecycle.lifecycle_plan_id.clone()],
+            materialization_budget_refs: vec![
+                "materialization-budget:gateway-association".to_string(),
+            ],
+            association_handoff_ref: Some(handoff.handoff_id.clone()),
+            evidence_refs: vec!["evidence:fabric:plan-ready".to_string()],
+            blocked_reasons: vec![],
+            safe_facts: Value::Null,
+            observed_at,
+            expires_at: Some(observed_at + 600),
+        };
+        validate_host_fabric_fulfillment_plan(&plan).expect("valid fabric plan");
+
+        let content_index = ContentIndexRefPosture {
+            kind: Some(RECORD_CONTENT_INDEX_REF_POSTURE.to_string()),
+            posture_id: "content-index-posture:gateway-association".to_string(),
+            content_index_ref: "content-index:gateway-association@0.1.0".to_string(),
+            state: FABRIC_CONTENT_INDEX_READY.to_string(),
+            source_refs: vec!["source:gateway-association:contract".to_string()],
+            materialized_projection_refs: vec!["projection:gateway-association:hot".to_string()],
+            storage_refs: vec!["storage:pin:gateway-association:contract".to_string()],
+            writer_refs: vec![],
+            schema_refs: vec!["schema:content-index:v1".to_string()],
+            evidence_refs: vec!["evidence:content-index:materialized".to_string()],
+            blocked_reasons: vec![],
+            safe_facts: Value::Null,
+            observed_at,
+            expires_at: Some(observed_at + 600),
+        };
+        validate_content_index_ref_posture(&content_index).expect("valid content-index posture");
+
+        let intention = ContractIntentionPosture {
+            kind: Some(RECORD_CONTRACT_INTENTION_POSTURE.to_string()),
+            posture_id: "contract-intention-posture:gateway-association".to_string(),
+            intention_ref: "contract-intention:gateway-association@0.1.0".to_string(),
+            state: FABRIC_CONTRACT_INTENTION_READY.to_string(),
+            canonical_hash_ref: Some("hash:contract-intention:gateway-association".to_string()),
+            content_index_refs: vec![content_index.content_index_ref.clone()],
+            authoring_surface_refs: vec!["authoring:typed-library".to_string()],
+            proof_gate_refs: vec!["proof-gate:protocol-validated".to_string()],
+            reducer_refs: vec!["reducer:gateway-association".to_string()],
+            evidence_refs: vec!["evidence:intention:signed".to_string()],
+            blocked_reasons: vec![],
+            safe_facts: Value::Null,
+            observed_at,
+            expires_at: Some(observed_at + 600),
+        };
+        validate_contract_intention_posture(&intention).expect("valid contract intention");
+
+        let unique_edge = UniqueEdgeClassification {
+            kind: Some(RECORD_UNIQUE_EDGE_CLASSIFICATION.to_string()),
+            classification_id: "unique-edge:host-service-adapter:systemd".to_string(),
+            subject_ref: "adapter:host-service:systemd".to_string(),
+            state: FABRIC_UNIQUE_EDGE_UNIQUE_EDGE.to_string(),
+            primitive_ref: None,
+            external_reality_ref: Some("external:host-os:systemd".to_string()),
+            interaction_ref: Some("interaction:service-lifecycle:systemd-unit".to_string()),
+            policy_refs: vec!["policy:host-service-adapter".to_string()],
+            input_refs: vec![],
+            output_refs: vec![],
+            grant_refs: vec!["grant:host-service-adapter".to_string()],
+            evidence_refs: vec!["evidence:systemd:unit-state".to_string()],
+            blocked_reasons: vec![],
+            safe_facts: Value::Null,
+            observed_at,
+            expires_at: Some(observed_at + 600),
+        };
+        validate_unique_edge_classification(&unique_edge).expect("valid unique edge");
+
+        let generic = UniqueEdgeClassification {
+            kind: Some(RECORD_UNIQUE_EDGE_CLASSIFICATION.to_string()),
+            classification_id: "unique-edge:runtime-client:generic".to_string(),
+            subject_ref: "module:runtime-client".to_string(),
+            state: FABRIC_UNIQUE_EDGE_GENERIC_PRIMITIVE.to_string(),
+            primitive_ref: Some("primitive:surface-runtime-client".to_string()),
+            external_reality_ref: None,
+            interaction_ref: None,
+            policy_refs: vec![],
+            input_refs: vec![],
+            output_refs: vec![],
+            grant_refs: vec![],
+            evidence_refs: vec!["evidence:runtime-client:generic".to_string()],
+            blocked_reasons: vec![],
+            safe_facts: Value::Null,
+            observed_at,
+            expires_at: Some(observed_at + 600),
+        };
+        validate_unique_edge_classification(&generic).expect("valid generic primitive edge");
+
+        let mut bad_handoff = handoff.clone();
+        bad_handoff.gateway_association_refs.clear();
+        assert!(validate_substrate_association_handoff(&bad_handoff).is_err());
+        let mut bad_lifecycle = lifecycle.clone();
+        bad_lifecycle.state = FABRIC_LIFECYCLE_PLAN_BLOCKED.to_string();
+        assert!(validate_lifecycle_plan_posture(&bad_lifecycle).is_err());
+        let mut bad_content_index = content_index.clone();
+        bad_content_index.source_refs.clear();
+        assert!(validate_content_index_ref_posture(&bad_content_index).is_err());
+        let mut bad_intention = intention.clone();
+        bad_intention.canonical_hash_ref = Some(String::new());
+        assert!(validate_contract_intention_posture(&bad_intention).is_err());
+        let mut bad_unique_edge = unique_edge.clone();
+        bad_unique_edge.external_reality_ref = Some(String::new());
+        assert!(validate_unique_edge_classification(&bad_unique_edge).is_err());
+        let mut unsafe_contribution = contribution;
+        unsafe_contribution.safe_facts = json!({ "token": "inline-secret" });
+        assert!(validate_host_fabric_member_contribution(&unsafe_contribution).is_err());
     }
 
     #[test]

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -145,6 +145,7 @@ pub const RECORD_CONTENT_INDEX_REF_POSTURE: &str = "contentIndex.ref.posture";
 pub const RECORD_CONTRACT_INTENTION_POSTURE: &str = "contract.intention.posture";
 pub const RECORD_UNIQUE_EDGE_CLASSIFICATION: &str = "uniqueEdge.classification";
 pub const RECORD_CONTRACT_TARGET: &str = "contract.target";
+pub const RECORD_CONTRACT_TARGET_REGISTRY_POSTURE: &str = "contract.target.registry.posture";
 pub const RECORD_RUNNER_OPERATION: &str = "runner.operation";
 pub const RECORD_APP_RUNNER_FULFILLMENT_REPORT: &str = "app.runner.fulfillment.report";
 pub const RECORD_APP_RUNNER_FULFILLMENT_LIFECYCLE: &str = "app.runner.fulfillment.lifecycle";
@@ -331,6 +332,19 @@ pub const FABRIC_CONTRACT_TARGET_COMPATIBLE: &str = "compatible";
 pub const FABRIC_CONTRACT_TARGET_COMPATIBILITY_DEGRADED: &str = "degraded";
 pub const FABRIC_CONTRACT_TARGET_INCOMPATIBLE: &str = "incompatible";
 pub const FABRIC_CONTRACT_TARGET_COMPATIBILITY_UNKNOWN: &str = "unknown";
+pub const FABRIC_CONTRACT_TARGET_REGISTRY_READY: &str = "ready";
+pub const FABRIC_CONTRACT_TARGET_REGISTRY_DEGRADED: &str = "degraded";
+pub const FABRIC_CONTRACT_TARGET_REGISTRY_BLOCKED: &str = "blocked";
+pub const FABRIC_CONTRACT_TARGET_REGISTRY_EXPIRED: &str = "expired";
+pub const FABRIC_CONTRACT_TARGET_SLOT_AVAILABLE: &str = "available";
+pub const FABRIC_CONTRACT_TARGET_SLOT_DEGRADED: &str = "degraded";
+pub const FABRIC_CONTRACT_TARGET_SLOT_MISSING: &str = "missing";
+pub const FABRIC_CONTRACT_TARGET_SLOT_BLOCKED: &str = "blocked";
+pub const FABRIC_CONTRACT_TARGET_SLOT_NOT_REQUIRED: &str = "notRequired";
+pub const FABRIC_CONTRACT_TARGET_PLATFORM_FIT_COMPATIBLE: &str = "compatible";
+pub const FABRIC_CONTRACT_TARGET_PLATFORM_FIT_DEGRADED: &str = "degraded";
+pub const FABRIC_CONTRACT_TARGET_PLATFORM_FIT_INCOMPATIBLE: &str = "incompatible";
+pub const FABRIC_CONTRACT_TARGET_PLATFORM_FIT_UNKNOWN: &str = "unknown";
 
 pub const SURFACE_FULFILLMENT_MODE_BUNDLED: &str = "bundled";
 pub const SURFACE_FULFILLMENT_MODE_SWARM_PACKAGE: &str = "swarmPackage";
@@ -3375,6 +3389,70 @@ pub struct ContractTarget {
     #[serde(default)]
     pub safe_facts: Value,
     pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ContractTargetSlotPosture {
+    pub slot_ref: String,
+    pub state: String,
+    pub platform_fit_state: String,
+    #[serde(default)]
+    pub candidate_fulfillment_refs: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_fulfillment_ref: Option<String>,
+    #[serde(default)]
+    pub source_refs: Vec<String>,
+    #[serde(default)]
+    pub build_refs: Vec<String>,
+    #[serde(default)]
+    pub platform_refs: Vec<String>,
+    #[serde(default)]
+    pub adapter_refs: Vec<String>,
+    #[serde(default)]
+    pub proof_requirement_refs: Vec<String>,
+    #[serde(default)]
+    pub proof_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ContractTargetRegistryPosture {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub registry_ref: String,
+    pub target_ref: String,
+    pub contract_ref: String,
+    pub state: String,
+    #[serde(default)]
+    pub slot_postures: Vec<ContractTargetSlotPosture>,
+    #[serde(default)]
+    pub candidate_fulfillment_refs: Vec<String>,
+    #[serde(default)]
+    pub source_refs: Vec<String>,
+    #[serde(default)]
+    pub build_refs: Vec<String>,
+    #[serde(default)]
+    pub adapter_refs: Vec<String>,
+    #[serde(default)]
+    pub proof_requirement_refs: Vec<String>,
+    #[serde(default)]
+    pub proof_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub observed_at: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<u64>,
 }
@@ -8739,6 +8817,151 @@ pub fn validate_contract_target(record: &ContractTarget) -> Result<()> {
     Ok(())
 }
 
+fn validate_contract_target_slot_posture(
+    record: &ContractTargetSlotPosture,
+    context: &str,
+) -> Result<()> {
+    require_non_empty(&record.slot_ref, &format!("{context} missing slotRef"))?;
+    validate_contract_target_slot_state(&record.state)?;
+    validate_contract_target_platform_fit_state(&record.platform_fit_state)?;
+    validate_reference_list(
+        &record.candidate_fulfillment_refs,
+        &format!("{context} missing candidateFulfillmentRefs"),
+    )?;
+    validate_optional_ref(
+        record.selected_fulfillment_ref.as_deref(),
+        &format!("{context} missing selectedFulfillmentRef"),
+    )?;
+    validate_reference_list(&record.source_refs, &format!("{context} missing sourceRefs"))?;
+    validate_reference_list(&record.build_refs, &format!("{context} missing buildRefs"))?;
+    validate_reference_list(&record.platform_refs, &format!("{context} missing platformRefs"))?;
+    validate_reference_list(&record.adapter_refs, &format!("{context} missing adapterRefs"))?;
+    validate_reference_list(
+        &record.proof_requirement_refs,
+        &format!("{context} missing proofRequirementRefs"),
+    )?;
+    validate_reference_list(&record.proof_refs, &format!("{context} missing proofRefs"))?;
+    validate_reference_list(&record.evidence_refs, &format!("{context} missing evidenceRefs"))?;
+    validate_blocked_reasons(
+        matches!(
+            record.state.as_str(),
+            FABRIC_CONTRACT_TARGET_SLOT_MISSING | FABRIC_CONTRACT_TARGET_SLOT_BLOCKED
+        ),
+        &record.blocked_reasons,
+        context,
+    )?;
+    if record.state == FABRIC_CONTRACT_TARGET_SLOT_AVAILABLE
+        && record.candidate_fulfillment_refs.is_empty()
+    {
+        return Err(anyhow!("{context} available slot requires candidateFulfillmentRefs"));
+    }
+    if record.platform_fit_state == FABRIC_CONTRACT_TARGET_PLATFORM_FIT_INCOMPATIBLE
+        && record.blocked_reasons.is_empty()
+    {
+        return Err(anyhow!("{context} incompatible platform fit requires blockedReasons"));
+    }
+    validate_safe_facts(&record.safe_facts, &format!("{context} safeFacts"))?;
+    reject_private_content_fields(&serde_json::to_value(record)?, context)?;
+    reject_media_byte_fields(&serde_json::to_value(record)?, context)
+}
+
+pub fn validate_contract_target_registry_posture(
+    record: &ContractTargetRegistryPosture,
+) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_CONTRACT_TARGET_REGISTRY_POSTURE,
+        "contract target registry posture",
+    )?;
+    require_non_empty(
+        &record.registry_ref,
+        "contract target registry posture missing registryRef",
+    )?;
+    require_non_empty(
+        &record.target_ref,
+        "contract target registry posture missing targetRef",
+    )?;
+    require_non_empty(
+        &record.contract_ref,
+        "contract target registry posture missing contractRef",
+    )?;
+    validate_contract_target_registry_state(&record.state)?;
+    if record.slot_postures.is_empty() {
+        return Err(anyhow!(
+            "contract target registry posture requires slotPostures"
+        ));
+    }
+    for (index, slot) in record.slot_postures.iter().enumerate() {
+        validate_contract_target_slot_posture(
+            slot,
+            &format!("contract target registry posture slotPostures[{index}]"),
+        )?;
+    }
+    validate_reference_list(
+        &record.candidate_fulfillment_refs,
+        "contract target registry posture missing candidateFulfillmentRefs",
+    )?;
+    validate_reference_list(
+        &record.source_refs,
+        "contract target registry posture missing sourceRefs",
+    )?;
+    validate_reference_list(
+        &record.build_refs,
+        "contract target registry posture missing buildRefs",
+    )?;
+    validate_reference_list(
+        &record.adapter_refs,
+        "contract target registry posture missing adapterRefs",
+    )?;
+    validate_reference_list(
+        &record.proof_requirement_refs,
+        "contract target registry posture missing proofRequirementRefs",
+    )?;
+    validate_reference_list(
+        &record.proof_refs,
+        "contract target registry posture missing proofRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "contract target registry posture missing evidenceRefs",
+    )?;
+    validate_blocked_reasons(
+        matches!(
+            record.state.as_str(),
+            FABRIC_CONTRACT_TARGET_REGISTRY_BLOCKED | FABRIC_CONTRACT_TARGET_REGISTRY_EXPIRED
+        ),
+        &record.blocked_reasons,
+        "contract target registry posture",
+    )?;
+    if record.state == FABRIC_CONTRACT_TARGET_REGISTRY_READY
+        && record.slot_postures.iter().any(|slot| {
+            !matches!(
+                slot.state.as_str(),
+                FABRIC_CONTRACT_TARGET_SLOT_AVAILABLE | FABRIC_CONTRACT_TARGET_SLOT_NOT_REQUIRED
+            )
+        })
+    {
+        return Err(anyhow!("ready contract target registry posture must not carry missing, degraded, or blocked slotPostures"));
+    }
+    validate_safe_facts(
+        &record.safe_facts,
+        "contract target registry posture safeFacts",
+    )?;
+    reject_private_content_fields(
+        &serde_json::to_value(record)?,
+        "contract target registry posture",
+    )?;
+    reject_media_byte_fields(
+        &serde_json::to_value(record)?,
+        "contract target registry posture",
+    )?;
+    validate_fabric_observed_window(
+        record.observed_at,
+        record.expires_at,
+        "contract target registry posture",
+    )
+}
+
 pub fn validate_runner_operation(record: &RunnerOperationRecord) -> Result<()> {
     validate_optional_kind(&record.kind, RECORD_RUNNER_OPERATION, "runner operation")?;
     require_non_empty(&record.operation_id, "runner operation missing operationId")?;
@@ -9551,6 +9774,49 @@ fn validate_contract_target_compatibility_state(state: &str) -> Result<()> {
         Ok(())
     } else {
         Err(anyhow!("unsupported contract target compatibility state"))
+    }
+}
+
+fn validate_contract_target_registry_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        FABRIC_CONTRACT_TARGET_REGISTRY_READY
+            | FABRIC_CONTRACT_TARGET_REGISTRY_DEGRADED
+            | FABRIC_CONTRACT_TARGET_REGISTRY_BLOCKED
+            | FABRIC_CONTRACT_TARGET_REGISTRY_EXPIRED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported contract target registry state"))
+    }
+}
+
+fn validate_contract_target_slot_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        FABRIC_CONTRACT_TARGET_SLOT_AVAILABLE
+            | FABRIC_CONTRACT_TARGET_SLOT_DEGRADED
+            | FABRIC_CONTRACT_TARGET_SLOT_MISSING
+            | FABRIC_CONTRACT_TARGET_SLOT_BLOCKED
+            | FABRIC_CONTRACT_TARGET_SLOT_NOT_REQUIRED
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported contract target slot state"))
+    }
+}
+
+fn validate_contract_target_platform_fit_state(state: &str) -> Result<()> {
+    if matches!(
+        state,
+        FABRIC_CONTRACT_TARGET_PLATFORM_FIT_COMPATIBLE
+            | FABRIC_CONTRACT_TARGET_PLATFORM_FIT_DEGRADED
+            | FABRIC_CONTRACT_TARGET_PLATFORM_FIT_INCOMPATIBLE
+            | FABRIC_CONTRACT_TARGET_PLATFORM_FIT_UNKNOWN
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("unsupported contract target platform fit state"))
     }
 }
 
@@ -12439,6 +12705,118 @@ mod tests {
         unsafe_target.target_ref = "contract-target:bad:secret".to_string();
         unsafe_target.safe_facts = json!({ "token": "inline-secret" });
         assert!(validate_contract_target(&unsafe_target).is_err());
+    }
+
+    #[test]
+    fn validates_contract_target_registry_posture_slots_candidates_and_blockers() {
+        let observed_at = 1_700_000_060;
+        let registry = ContractTargetRegistryPosture {
+            kind: Some(RECORD_CONTRACT_TARGET_REGISTRY_POSTURE.to_string()),
+            registry_ref: "contract-target-registry:desktop-dev:msa-transition".to_string(),
+            target_ref: "contract-target:desktop-dev:msa-transition".to_string(),
+            contract_ref: "app:contract:nvr@0.1.0".to_string(),
+            state: FABRIC_CONTRACT_TARGET_REGISTRY_DEGRADED.to_string(),
+            slot_postures: vec![
+                ContractTargetSlotPosture {
+                    slot_ref: "slot:runtime".to_string(),
+                    state: FABRIC_CONTRACT_TARGET_SLOT_AVAILABLE.to_string(),
+                    platform_fit_state: FABRIC_CONTRACT_TARGET_PLATFORM_FIT_COMPATIBLE.to_string(),
+                    candidate_fulfillment_refs: vec!["fulfillment:runtime:browser".to_string()],
+                    selected_fulfillment_ref: Some("fulfillment:runtime:browser".to_string()),
+                    source_refs: vec!["content-index:runtime-client".to_string()],
+                    build_refs: vec!["build:runtime-client:local".to_string()],
+                    platform_refs: vec!["platform:browser".to_string()],
+                    adapter_refs: vec!["adapter:runtime-surface-client".to_string()],
+                    proof_requirement_refs: vec!["proof-requirement:surface-load".to_string()],
+                    proof_refs: vec!["proof:nvr-smoke-5s:20260522".to_string()],
+                    evidence_refs: vec!["evidence:runtime:attached".to_string()],
+                    blocked_reasons: vec![],
+                    safe_facts: json!({ "slot": "runtime" }),
+                },
+                ContractTargetSlotPosture {
+                    slot_ref: "slot:native-client".to_string(),
+                    state: FABRIC_CONTRACT_TARGET_SLOT_NOT_REQUIRED.to_string(),
+                    platform_fit_state: FABRIC_CONTRACT_TARGET_PLATFORM_FIT_UNKNOWN.to_string(),
+                    candidate_fulfillment_refs: vec![],
+                    selected_fulfillment_ref: None,
+                    source_refs: vec![],
+                    build_refs: vec![],
+                    platform_refs: vec![],
+                    adapter_refs: vec![],
+                    proof_requirement_refs: vec![],
+                    proof_refs: vec![],
+                    evidence_refs: vec![],
+                    blocked_reasons: vec![],
+                    safe_facts: Value::Null,
+                },
+                ContractTargetSlotPosture {
+                    slot_ref: "slot:operator-focus".to_string(),
+                    state: FABRIC_CONTRACT_TARGET_SLOT_DEGRADED.to_string(),
+                    platform_fit_state: FABRIC_CONTRACT_TARGET_PLATFORM_FIT_COMPATIBLE.to_string(),
+                    candidate_fulfillment_refs: vec!["fulfillment:operator:aux-firefox".to_string()],
+                    selected_fulfillment_ref: None,
+                    source_refs: vec![],
+                    build_refs: vec![],
+                    platform_refs: vec![],
+                    adapter_refs: vec![],
+                    proof_requirement_refs: vec![],
+                    proof_refs: vec![],
+                    evidence_refs: vec!["evidence:operator:focus-repaired".to_string()],
+                    blocked_reasons: vec![],
+                    safe_facts: Value::Null,
+                },
+            ],
+            candidate_fulfillment_refs: vec![
+                "fulfillment:runtime:browser".to_string(),
+                "fulfillment:operator:aux-firefox".to_string(),
+            ],
+            source_refs: vec!["content-index:nvr-surface".to_string()],
+            build_refs: vec!["build:nvr-surface:local".to_string()],
+            adapter_refs: vec!["adapter:webrtc:browser".to_string()],
+            proof_requirement_refs: vec!["proof-requirement:long-stream-10m".to_string()],
+            proof_refs: vec!["proof:long-stream-10m:20260522".to_string()],
+            evidence_refs: vec!["evidence:registry:reduced".to_string()],
+            blocked_reasons: vec![],
+            safe_facts: json!({ "target": "desktop-dev" }),
+            observed_at,
+            expires_at: Some(observed_at + 3600),
+        };
+        validate_contract_target_registry_posture(&registry).expect("valid registry posture");
+
+        let mut bad_ready = registry.clone();
+        bad_ready.registry_ref = "contract-target-registry:bad:ready".to_string();
+        bad_ready.state = FABRIC_CONTRACT_TARGET_REGISTRY_READY.to_string();
+        assert!(validate_contract_target_registry_posture(&bad_ready).is_err());
+
+        let mut bad_available = registry.clone();
+        bad_available.registry_ref = "contract-target-registry:bad:available".to_string();
+        bad_available.slot_postures = vec![ContractTargetSlotPosture {
+            slot_ref: "slot:runtime".to_string(),
+            state: FABRIC_CONTRACT_TARGET_SLOT_AVAILABLE.to_string(),
+            platform_fit_state: FABRIC_CONTRACT_TARGET_PLATFORM_FIT_COMPATIBLE.to_string(),
+            candidate_fulfillment_refs: vec![],
+            selected_fulfillment_ref: None,
+            source_refs: vec![],
+            build_refs: vec![],
+            platform_refs: vec![],
+            adapter_refs: vec![],
+            proof_requirement_refs: vec![],
+            proof_refs: vec![],
+            evidence_refs: vec![],
+            blocked_reasons: vec![],
+            safe_facts: Value::Null,
+        }];
+        assert!(validate_contract_target_registry_posture(&bad_available).is_err());
+
+        let mut bad_blocked = registry.clone();
+        bad_blocked.registry_ref = "contract-target-registry:bad:blocked".to_string();
+        bad_blocked.state = FABRIC_CONTRACT_TARGET_REGISTRY_BLOCKED.to_string();
+        assert!(validate_contract_target_registry_posture(&bad_blocked).is_err());
+
+        let mut unsafe_registry = registry;
+        unsafe_registry.registry_ref = "contract-target-registry:bad:secret".to_string();
+        unsafe_registry.safe_facts = json!({ "secret": "nope" });
+        assert!(validate_contract_target_registry_posture(&unsafe_registry).is_err());
     }
 
     #[test]

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -12850,6 +12850,41 @@ mod tests {
     }
 
     #[test]
+    fn validates_lab_linux_contract_target_vector() {
+        let vector: Value =
+            serde_json::from_str(include_str!("../vectors/contract-target-lab-linux-v1.json"))
+                .expect("lab linux target vector");
+        let target: ContractTarget =
+            serde_json::from_value(vector["target"].clone()).expect("target record");
+        let registry: ContractTargetRegistryPosture =
+            serde_json::from_value(vector["registry"].clone()).expect("registry record");
+
+        validate_contract_target(&target).expect("target validates");
+        validate_contract_target_registry_posture(&registry).expect("registry validates");
+        assert_eq!(target.platform_ref, "platform:linux.lab");
+        assert_eq!(target.state, FABRIC_CONTRACT_TARGET_SELECTED);
+        assert_eq!(
+            target.compatibility_state,
+            FABRIC_CONTRACT_TARGET_COMPATIBILITY_DEGRADED
+        );
+        assert!(
+            target
+                .missing_slot_refs
+                .contains(&"slot:runtime-client".to_string())
+        );
+        assert_eq!(registry.state, FABRIC_CONTRACT_TARGET_REGISTRY_DEGRADED);
+        assert!(registry.slot_postures.iter().any(|slot| {
+            slot.slot_ref == "slot:lab-proof-automation"
+                && slot.state == FABRIC_CONTRACT_TARGET_SLOT_MISSING
+        }));
+        assert!(
+            registry
+                .proof_requirement_refs
+                .contains(&"proof-requirement:lab-live".to_string())
+        );
+    }
+
+    #[test]
     fn validates_participant_self_capability_resource_and_retention_posture() {
         let participant_ref = pubkey_from_sk_hex(BROWSER_SK).expect("browser pk");
         let service_member_ref = pubkey_from_sk_hex(GATEWAY_SK).expect("gateway pk");

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -12820,6 +12820,36 @@ mod tests {
     }
 
     #[test]
+    fn validates_local_workstation_contract_target_vector() {
+        let vector: Value = serde_json::from_str(include_str!(
+            "../vectors/contract-target-local-workstation-v1.json"
+        ))
+        .expect("local workstation target vector");
+        let target: ContractTarget =
+            serde_json::from_value(vector["target"].clone()).expect("target record");
+        let registry: ContractTargetRegistryPosture =
+            serde_json::from_value(vector["registry"].clone()).expect("registry record");
+
+        validate_contract_target(&target).expect("target validates");
+        validate_contract_target_registry_posture(&registry).expect("registry validates");
+        assert_eq!(target.platform_ref, "platform:windows.desktop");
+        assert_eq!(
+            target.negative_slot_refs,
+            vec!["slot:native-client".to_string()]
+        );
+        assert_eq!(registry.state, FABRIC_CONTRACT_TARGET_REGISTRY_READY);
+        assert!(registry.slot_postures.iter().any(|slot| {
+            slot.slot_ref == "slot:native-client"
+                && slot.state == FABRIC_CONTRACT_TARGET_SLOT_NOT_REQUIRED
+        }));
+        assert!(
+            registry
+                .proof_refs
+                .contains(&"proof:long-stream-10m:20260522T074937Z".to_string())
+        );
+    }
+
+    #[test]
     fn validates_participant_self_capability_resource_and_retention_posture() {
         let participant_ref = pubkey_from_sk_hex(BROWSER_SK).expect("browser pk");
         let service_member_ref = pubkey_from_sk_hex(GATEWAY_SK).expect("gateway pk");

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -26,6 +26,7 @@ import {
   assertContractTargetRegistryPosture,
   assertContentIndexRefPosture,
   assertContractIntentionPosture,
+  assertAssociationBoundaryProof,
   assertHostFabricFulfillmentPlan,
   assertHostFabricMemberContribution,
   assertLifecyclePlanPosture,
@@ -1949,6 +1950,27 @@ test("host fabric records separate association, composition, lifecycle, source t
   });
   assert.equal(plan.memberContributionRefs[0], memberContribution.contributionId);
 
+  const associationBoundary = assertAssociationBoundaryProof({
+    kind: SWARM.RECORD_KIND.ASSOCIATION_BOUNDARY_PROOF,
+    proofId: "association-boundary-proof:lab-gateway",
+    hostRef: "host:lab-gateway",
+    ownerRef: "identity:aux",
+    fabricRef: "fabric:lab-gateway",
+    state: FABRIC.ASSOCIATION_BOUNDARY_PROOF_STATE.READY,
+    substrateHandoffRef: handoff.handoffId,
+    initialAssociationRefs: handoff.initialAssociationRefs,
+    gatewayAssociationRefs: handoff.gatewayAssociationRefs,
+    routeAssociationRefs: ["route-association:gateway:lab-gateway"],
+    servicePresenceRefs: ["service-presence:nvr:lab-gateway"],
+    membershipRefs: ["member-presence:service:nvr:lab-gateway"],
+    fabricPlanRefs: [plan.planId],
+    evidenceRefs: ["evidence:association-boundary:distinct"],
+    safeFacts: { phaseSplit: "substrate-gateway-route-service-membership" },
+    observedAt,
+    expiresAt: observedAt + 600,
+  });
+  assert.equal(associationBoundary.routeAssociationRefs[0], "route-association:gateway:lab-gateway");
+
   const contentIndex = assertContentIndexRefPosture({
     kind: SWARM.RECORD_KIND.CONTENT_INDEX_REF_POSTURE,
     postureId: "content-index-posture:gateway-association",
@@ -2011,6 +2033,14 @@ test("host fabric records separate association, composition, lifecycle, source t
     ...handoff,
     gatewayAssociationRefs: [],
   }), /gatewayAssociationRefs/);
+  assert.throws(() => assertAssociationBoundaryProof({
+    ...associationBoundary,
+    membershipRefs: associationBoundary.gatewayAssociationRefs,
+  }), /collapses phase ref/);
+  assert.throws(() => assertAssociationBoundaryProof({
+    ...associationBoundary,
+    routeAssociationRefs: [],
+  }), /routeAssociationRefs/);
   assert.throws(() => assertLifecyclePlanPosture({
     ...lifecycle,
     lifecyclePlanId: "lifecycle-plan:bad:blocked",

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -2189,6 +2189,28 @@ test("local workstation contract target vector validates desktop dev proof postu
   assert.ok(registry.proofRefs.includes("proof:long-stream-10m:20260522T074937Z"));
 });
 
+test("lab linux contract target vector marks host slots apart from protected client proof", () => {
+  const vector = JSON.parse(readFileSync(new URL("../vectors/contract-target-lab-linux-v1.json", import.meta.url), "utf8"));
+  const target = assertContractTarget(vector.target);
+  const registry = assertContractTargetRegistryPosture(vector.registry);
+
+  assert.equal(target.platformRef, "platform:linux.lab");
+  assert.equal(target.state, FABRIC.CONTRACT_TARGET_STATE.SELECTED);
+  assert.equal(target.compatibilityState, FABRIC.CONTRACT_TARGET_COMPATIBILITY_STATE.DEGRADED);
+  assert.ok(target.missingSlotRefs.includes("slot:runtime-client"));
+  assert.ok(target.missingSlotRefs.includes("slot:lab-proof-automation"));
+  assert.equal(registry.state, FABRIC.CONTRACT_TARGET_REGISTRY_STATE.DEGRADED);
+  assert.equal(
+    registry.slotPostures.find((slot) => slot.slotRef === "slot:gateway")?.state,
+    FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE,
+  );
+  assert.equal(
+    registry.slotPostures.find((slot) => slot.slotRef === "slot:lab-proof-automation")?.state,
+    FABRIC.CONTRACT_TARGET_SLOT_STATE.MISSING,
+  );
+  assert.ok(registry.proofRequirementRefs.includes("proof-requirement:lab-live"));
+});
+
 test("app runner fulfillment reports reduce operation lifecycle, release, resources, and proof", () => {
   const observedAt = 1700000020;
   const report = assertAppRunnerFulfillmentReport({

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -22,6 +22,7 @@ import {
   assertAppRunnerAdvertisement,
   assertAppRunnerFulfillmentReport,
   assertAppRunnerFulfillmentLifecycle,
+  assertContractTarget,
   assertContentIndexRefPosture,
   assertContractIntentionPosture,
   assertHostFabricFulfillmentPlan,
@@ -2033,6 +2034,62 @@ test("host fabric records separate association, composition, lifecycle, source t
   assert.throws(() => assertHostFabricMemberContribution({
     ...memberContribution,
     contributionId: "fabric-contribution:bad:secret",
+    safeFacts: { token: "nope" },
+  }), /unsafe safe fact key|forbidden protocol field/);
+});
+
+test("contract targets declare platform branch adapter slots and proof posture", () => {
+  const issuedAt = 1700000050;
+  const target = assertContractTarget({
+    kind: SWARM.RECORD_KIND.CONTRACT_TARGET,
+    targetRef: "contract-target:desktop-dev:msa-transition",
+    contractRef: "app:contract:nvr@0.1.0",
+    profileRef: "host-profile:desktop",
+    platformRef: "platform:windows",
+    substrateRef: "substrate:desktop-dev",
+    hostRef: "host:local-workstation",
+    state: FABRIC.CONTRACT_TARGET_STATE.DEGRADED,
+    compatibilityState: FABRIC.CONTRACT_TARGET_COMPATIBILITY_STATE.COMPATIBLE,
+    modifierRefs: ["modifier:dev"],
+    branchRefs: ["branch:0x/msa-transition"],
+    subbranchRefs: ["subbranch:target-contract"],
+    capabilitySlotRefs: [
+      "slot:runtime",
+      "slot:gateway",
+      "slot:nvr-service",
+      "slot:nvr-surface",
+    ],
+    adapterPackRef: "adapter-pack:desktop-dev",
+    adapterRefs: ["adapter:webrtc:browser", "adapter:host-service:windows"],
+    negativeSlotRefs: ["slot:native-client"],
+    degradedSlotRefs: ["slot:operator-proof-focus"],
+    proofProfileRefs: ["proof-profile:nvr-smoke-5s", "proof-profile:long-stream-10m"],
+    proofRefs: ["proof:nvr-smoke-5s:20260522"],
+    compatibilityRefs: ["compat:runtime-2.56"],
+    evidenceRefs: ["evidence:target:selected"],
+    targetAudience: "developer",
+    safeFacts: { profile: "desktop-dev" },
+    issuedAt,
+    expiresAt: issuedAt + 3600,
+  });
+  assert.equal(target.negativeSlotRefs[0], "slot:native-client");
+  assert.equal(target.compatibilityState, FABRIC.CONTRACT_TARGET_COMPATIBILITY_STATE.COMPATIBLE);
+
+  assert.throws(() => assertContractTarget({
+    ...target,
+    targetRef: "contract-target:bad:ready-with-missing",
+    state: FABRIC.CONTRACT_TARGET_STATE.READY,
+    missingSlotRefs: ["slot:gateway"],
+  }), /missingSlotRefs/);
+  assert.throws(() => assertContractTarget({
+    ...target,
+    targetRef: "contract-target:bad:incompatible",
+    compatibilityState: FABRIC.CONTRACT_TARGET_COMPATIBILITY_STATE.INCOMPATIBLE,
+    blockedReasons: [],
+  }), /blockedReasons/);
+  assert.throws(() => assertContractTarget({
+    ...target,
+    targetRef: "contract-target:bad:secret",
     safeFacts: { token: "nope" },
   }), /unsafe safe fact key|forbidden protocol field/);
 });

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -7,6 +7,7 @@ import {
   AGREEMENT,
   APP,
   LOGGING,
+  FABRIC,
   PROJECTION,
   RUNNER,
   ReplayCache,
@@ -21,8 +22,15 @@ import {
   assertAppRunnerAdvertisement,
   assertAppRunnerFulfillmentReport,
   assertAppRunnerFulfillmentLifecycle,
+  assertContentIndexRefPosture,
+  assertContractIntentionPosture,
+  assertHostFabricFulfillmentPlan,
+  assertHostFabricMemberContribution,
+  assertLifecyclePlanPosture,
   assertRunnerHostFulfillmentPosture,
   assertRunnerOperation,
+  assertSubstrateAssociationHandoff,
+  assertUniqueEdgeClassification,
   assertCapabilityAdvertisement,
   assertCapabilityDefinition,
   assertCapabilityName,
@@ -1860,6 +1868,173 @@ test("runner operations bind host fulfillment to grants, resources, secrets, rel
     state: RUNNER.HOST_FULFILLMENT_STATE.BLOCKED,
     blockedReasons: [],
   }), /requires blockedReasons/);
+});
+
+test("host fabric records separate association, composition, lifecycle, source truth, and unique edges", () => {
+  const observedAt = 1700000040;
+  const handoff = assertSubstrateAssociationHandoff({
+    kind: SWARM.RECORD_KIND.SUBSTRATE_ASSOCIATION_HANDOFF,
+    handoffId: "handoff:lab-gateway:initial-owner",
+    substrateRef: "substrate:first-trust:lab",
+    hostRef: "host:lab-gateway",
+    ownerRef: "identity:aux",
+    fabricRef: "fabric:lab-gateway",
+    state: FABRIC.ASSOCIATION_HANDOFF_STATE.HANDED_OFF,
+    initialAssociationRefs: ["association:substrate:aux:lab-gateway"],
+    gatewayAssociationRefs: ["association:gateway:lab-gateway:ongoing"],
+    evidenceRefs: ["evidence:substrate:verified"],
+    safeFacts: { handoff: "substrate-to-gateway-association" },
+    issuedAt: observedAt - 10,
+    handedOffAt: observedAt - 1,
+    expiresAt: observedAt + 3600,
+  });
+  assert.equal(handoff.state, FABRIC.ASSOCIATION_HANDOFF_STATE.HANDED_OFF);
+
+  const memberContribution = assertHostFabricMemberContribution({
+    kind: SWARM.RECORD_KIND.HOST_FABRIC_MEMBER_CONTRIBUTION,
+    contributionId: "fabric-contribution:gateway-association:1",
+    fabricRef: "fabric:lab-gateway",
+    hostRef: "host:lab-gateway",
+    memberRef: BROWSER_PK,
+    role: FABRIC.MEMBER_ROLE.GATEWAY_ASSOCIATION,
+    state: FABRIC.MEMBER_CONTRIBUTION_STATE.RUNNING,
+    contractRef: "contract:gateway-association@0.1.0",
+    subjectRef: "association:gateway:lab-gateway:ongoing",
+    capabilityRefs: ["gateway.association.fulfill"],
+    grantRefs: ["grant:gateway-association:fulfill"],
+    evidenceRefs: ["evidence:gateway-association:presence"],
+    lifecyclePlanRefs: ["lifecycle-plan:gateway-association:1"],
+    safeFacts: { role: "gatewayAssociation" },
+    observedAt,
+    expiresAt: observedAt + 600,
+  });
+  assert.equal(memberContribution.role, FABRIC.MEMBER_ROLE.GATEWAY_ASSOCIATION);
+
+  const lifecycle = assertLifecyclePlanPosture({
+    kind: SWARM.RECORD_KIND.LIFECYCLE_PLAN_POSTURE,
+    lifecyclePlanId: "lifecycle-plan:gateway-association:1",
+    subjectRef: "association:gateway:lab-gateway:ongoing",
+    contractRef: "contract:lifecycle.gateway-association@0.1.0",
+    state: FABRIC.LIFECYCLE_PLAN_STATE.READY,
+    lifecycleContractRefs: ["contract:lifecycle.gateway-association@0.1.0"],
+    phasePostures: [
+      { phase: FABRIC.LIFECYCLE_PHASE.SOURCE, state: FABRIC.LIFECYCLE_PHASE_STATE.READY, evidenceRefs: ["evidence:source:indexed"] },
+      { phase: FABRIC.LIFECYCLE_PHASE.RUN, state: FABRIC.LIFECYCLE_PHASE_STATE.RUNNING, evidenceRefs: ["evidence:association:running"] },
+      { phase: FABRIC.LIFECYCLE_PHASE.OBSERVE, state: FABRIC.LIFECYCLE_PHASE_STATE.READY, evidenceRefs: ["evidence:association:observed"] },
+    ],
+    memberContributionRefs: [memberContribution.contributionId],
+    evidenceRefs: ["evidence:lifecycle:reduced"],
+    observedAt,
+    expiresAt: observedAt + 600,
+  });
+  assert.equal(lifecycle.phasePostures.length, 3);
+
+  const plan = assertHostFabricFulfillmentPlan({
+    kind: SWARM.RECORD_KIND.HOST_FABRIC_FULFILLMENT_PLAN,
+    planId: "fabric-plan:lab-gateway:association",
+    fabricRef: "fabric:lab-gateway",
+    hostRef: "host:lab-gateway",
+    contractRef: "contract:gateway-association@0.1.0",
+    state: FABRIC.FULFILLMENT_PLAN_STATE.READY,
+    requiredRoleRefs: ["role:gatewayAssociation"],
+    memberContributionRefs: [memberContribution.contributionId],
+    lifecyclePlanRefs: [lifecycle.lifecyclePlanId],
+    materializationBudgetRefs: ["materialization-budget:gateway-association"],
+    associationHandoffRef: handoff.handoffId,
+    evidenceRefs: ["evidence:fabric:plan-ready"],
+    observedAt,
+    expiresAt: observedAt + 600,
+  });
+  assert.equal(plan.memberContributionRefs[0], memberContribution.contributionId);
+
+  const contentIndex = assertContentIndexRefPosture({
+    kind: SWARM.RECORD_KIND.CONTENT_INDEX_REF_POSTURE,
+    postureId: "content-index-posture:gateway-association",
+    contentIndexRef: "content-index:gateway-association@0.1.0",
+    state: FABRIC.CONTENT_INDEX_STATE.READY,
+    sourceRefs: ["source:gateway-association:contract"],
+    materializedProjectionRefs: ["projection:gateway-association:hot"],
+    storageRefs: ["storage:pin:gateway-association:contract"],
+    schemaRefs: ["schema:content-index:v1"],
+    evidenceRefs: ["evidence:content-index:materialized"],
+    observedAt,
+    expiresAt: observedAt + 600,
+  });
+  assert.equal(contentIndex.sourceRefs[0], "source:gateway-association:contract");
+
+  const intention = assertContractIntentionPosture({
+    kind: SWARM.RECORD_KIND.CONTRACT_INTENTION_POSTURE,
+    postureId: "contract-intention-posture:gateway-association",
+    intentionRef: "contract-intention:gateway-association@0.1.0",
+    state: FABRIC.CONTRACT_INTENTION_STATE.READY,
+    canonicalHashRef: "hash:contract-intention:gateway-association",
+    contentIndexRefs: [contentIndex.contentIndexRef],
+    authoringSurfaceRefs: ["authoring:typed-library"],
+    proofGateRefs: ["proof-gate:protocol-validated"],
+    reducerRefs: ["reducer:gateway-association"],
+    evidenceRefs: ["evidence:intention:signed"],
+    observedAt,
+    expiresAt: observedAt + 600,
+  });
+  assert.equal(intention.contentIndexRefs[0], contentIndex.contentIndexRef);
+
+  const uniqueEdge = assertUniqueEdgeClassification({
+    kind: SWARM.RECORD_KIND.UNIQUE_EDGE_CLASSIFICATION,
+    classificationId: "unique-edge:host-service-adapter:systemd",
+    subjectRef: "adapter:host-service:systemd",
+    state: FABRIC.UNIQUE_EDGE_CLASSIFICATION.UNIQUE_EDGE,
+    externalRealityRef: "external:host-os:systemd",
+    interactionRef: "interaction:service-lifecycle:systemd-unit",
+    policyRefs: ["policy:host-service-adapter"],
+    grantRefs: ["grant:host-service-adapter"],
+    evidenceRefs: ["evidence:systemd:unit-state"],
+    observedAt,
+    expiresAt: observedAt + 600,
+  });
+  assert.equal(uniqueEdge.state, FABRIC.UNIQUE_EDGE_CLASSIFICATION.UNIQUE_EDGE);
+
+  const genericPrimitive = assertUniqueEdgeClassification({
+    kind: SWARM.RECORD_KIND.UNIQUE_EDGE_CLASSIFICATION,
+    classificationId: "unique-edge:runtime-client:generic",
+    subjectRef: "module:runtime-client",
+    state: FABRIC.UNIQUE_EDGE_CLASSIFICATION.GENERIC_PRIMITIVE,
+    primitiveRef: "primitive:surface-runtime-client",
+    evidenceRefs: ["evidence:runtime-client:generic"],
+    observedAt,
+    expiresAt: observedAt + 600,
+  });
+  assert.equal(genericPrimitive.primitiveRef, "primitive:surface-runtime-client");
+
+  assert.throws(() => assertSubstrateAssociationHandoff({
+    ...handoff,
+    gatewayAssociationRefs: [],
+  }), /gatewayAssociationRefs/);
+  assert.throws(() => assertLifecyclePlanPosture({
+    ...lifecycle,
+    lifecyclePlanId: "lifecycle-plan:bad:blocked",
+    state: FABRIC.LIFECYCLE_PLAN_STATE.BLOCKED,
+    blockedReasons: [],
+  }), /requires blockedReasons/);
+  assert.throws(() => assertContentIndexRefPosture({
+    ...contentIndex,
+    postureId: "content-index-posture:bad:storage-only",
+    sourceRefs: [],
+  }), /requires sourceRefs/);
+  assert.throws(() => assertContractIntentionPosture({
+    ...intention,
+    postureId: "contract-intention-posture:bad:no-hash",
+    canonicalHashRef: "",
+  }), /canonicalHashRef/);
+  assert.throws(() => assertUniqueEdgeClassification({
+    ...uniqueEdge,
+    classificationId: "unique-edge:bad:no-external",
+    externalRealityRef: "",
+  }), /externalRealityRef/);
+  assert.throws(() => assertHostFabricMemberContribution({
+    ...memberContribution,
+    contributionId: "fabric-contribution:bad:secret",
+    safeFacts: { token: "nope" },
+  }), /unsafe safe fact key|forbidden protocol field/);
 });
 
 test("app runner fulfillment reports reduce operation lifecycle, release, resources, and proof", () => {

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -2173,6 +2173,22 @@ test("contract target registry posture maps slots to candidates and blockers", (
   }), /unsafe safe fact key|forbidden protocol field/);
 });
 
+test("local workstation contract target vector validates desktop dev proof posture", () => {
+  const vector = JSON.parse(readFileSync(new URL("../vectors/contract-target-local-workstation-v1.json", import.meta.url), "utf8"));
+  const target = assertContractTarget(vector.target);
+  const registry = assertContractTargetRegistryPosture(vector.registry);
+
+  assert.equal(target.platformRef, "platform:windows.desktop");
+  assert.deepEqual(target.branchRefs, ["branch:0x/msa-transition"]);
+  assert.deepEqual(target.negativeSlotRefs, ["slot:native-client"]);
+  assert.equal(registry.state, FABRIC.CONTRACT_TARGET_REGISTRY_STATE.READY);
+  assert.equal(
+    registry.slotPostures.find((slot) => slot.slotRef === "slot:native-client")?.state,
+    FABRIC.CONTRACT_TARGET_SLOT_STATE.NOT_REQUIRED,
+  );
+  assert.ok(registry.proofRefs.includes("proof:long-stream-10m:20260522T074937Z"));
+});
+
 test("app runner fulfillment reports reduce operation lifecycle, release, resources, and proof", () => {
   const observedAt = 1700000020;
   const report = assertAppRunnerFulfillmentReport({

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -23,6 +23,7 @@ import {
   assertAppRunnerFulfillmentReport,
   assertAppRunnerFulfillmentLifecycle,
   assertContractTarget,
+  assertContractTargetRegistryPosture,
   assertContentIndexRefPosture,
   assertContractIntentionPosture,
   assertHostFabricFulfillmentPlan,
@@ -2091,6 +2092,84 @@ test("contract targets declare platform branch adapter slots and proof posture",
     ...target,
     targetRef: "contract-target:bad:secret",
     safeFacts: { token: "nope" },
+  }), /unsafe safe fact key|forbidden protocol field/);
+});
+
+test("contract target registry posture maps slots to candidates and blockers", () => {
+  const observedAt = 1700000060;
+  const registry = assertContractTargetRegistryPosture({
+    kind: SWARM.RECORD_KIND.CONTRACT_TARGET_REGISTRY_POSTURE,
+    registryRef: "contract-target-registry:desktop-dev:msa-transition",
+    targetRef: "contract-target:desktop-dev:msa-transition",
+    contractRef: "app:contract:nvr@0.1.0",
+    state: FABRIC.CONTRACT_TARGET_REGISTRY_STATE.DEGRADED,
+    slotPostures: [
+      {
+        slotRef: "slot:runtime",
+        state: FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE,
+        platformFitState: FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.COMPATIBLE,
+        candidateFulfillmentRefs: ["fulfillment:runtime:browser"],
+        selectedFulfillmentRef: "fulfillment:runtime:browser",
+        sourceRefs: ["content-index:runtime-client"],
+        buildRefs: ["build:runtime-client:local"],
+        platformRefs: ["platform:browser"],
+        adapterRefs: ["adapter:runtime-surface-client"],
+        proofRequirementRefs: ["proof-requirement:surface-load"],
+        proofRefs: ["proof:nvr-smoke-5s:20260522"],
+        evidenceRefs: ["evidence:runtime:attached"],
+      },
+      {
+        slotRef: "slot:native-client",
+        state: FABRIC.CONTRACT_TARGET_SLOT_STATE.NOT_REQUIRED,
+        platformFitState: FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.UNKNOWN,
+      },
+      {
+        slotRef: "slot:operator-focus",
+        state: FABRIC.CONTRACT_TARGET_SLOT_STATE.DEGRADED,
+        platformFitState: FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.COMPATIBLE,
+        candidateFulfillmentRefs: ["fulfillment:operator:aux-firefox"],
+        evidenceRefs: ["evidence:operator:focus-repaired"],
+      },
+    ],
+    candidateFulfillmentRefs: ["fulfillment:runtime:browser", "fulfillment:operator:aux-firefox"],
+    sourceRefs: ["content-index:nvr-surface"],
+    buildRefs: ["build:nvr-surface:local"],
+    adapterRefs: ["adapter:webrtc:browser"],
+    proofRequirementRefs: ["proof-requirement:long-stream-10m"],
+    proofRefs: ["proof:long-stream-10m:20260522"],
+    evidenceRefs: ["evidence:registry:reduced"],
+    safeFacts: { target: "desktop-dev" },
+    observedAt,
+    expiresAt: observedAt + 3600,
+  });
+  assert.equal(registry.slotPostures.length, 3);
+  assert.equal(registry.slotPostures[0].candidateFulfillmentRefs[0], "fulfillment:runtime:browser");
+
+  assert.throws(() => assertContractTargetRegistryPosture({
+    ...registry,
+    registryRef: "contract-target-registry:bad:ready-with-degraded-slot",
+    state: FABRIC.CONTRACT_TARGET_REGISTRY_STATE.READY,
+  }), /ready contract target registry posture/);
+  assert.throws(() => assertContractTargetRegistryPosture({
+    ...registry,
+    registryRef: "contract-target-registry:bad:available-without-candidate",
+    slotPostures: [{
+      slotRef: "slot:runtime",
+      state: FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE,
+      platformFitState: FABRIC.CONTRACT_TARGET_PLATFORM_FIT_STATE.COMPATIBLE,
+      candidateFulfillmentRefs: [],
+    }],
+  }), /candidateFulfillmentRefs/);
+  assert.throws(() => assertContractTargetRegistryPosture({
+    ...registry,
+    registryRef: "contract-target-registry:bad:blocked",
+    state: FABRIC.CONTRACT_TARGET_REGISTRY_STATE.BLOCKED,
+    blockedReasons: [],
+  }), /blockedReasons/);
+  assert.throws(() => assertContractTargetRegistryPosture({
+    ...registry,
+    registryRef: "contract-target-registry:bad:secret",
+    safeFacts: { secret: "nope" },
   }), /unsafe safe fact key|forbidden protocol field/);
 });
 

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -2211,6 +2211,25 @@ test("lab linux contract target vector marks host slots apart from protected cli
   assert.ok(registry.proofRequirementRefs.includes("proof-requirement:lab-live"));
 });
 
+test("multi-gateway contract target vector keeps candidates in registry and fabric contributions", () => {
+  const vector = JSON.parse(readFileSync(new URL("../vectors/contract-target-multi-gateway-v1.json", import.meta.url), "utf8"));
+  const target = assertContractTarget(vector.target);
+  const registry = assertContractTargetRegistryPosture(vector.registry);
+  const contributions = vector.hostFabricContributions.map(assertHostFabricMemberContribution);
+  const plan = assertHostFabricFulfillmentPlan(vector.fulfillmentPlan);
+
+  assert.equal(target.state, FABRIC.CONTRACT_TARGET_STATE.READY);
+  const gatewaySlot = registry.slotPostures.find((slot) => slot.slotRef === "slot:gateway-association");
+  assert.equal(gatewaySlot.state, FABRIC.CONTRACT_TARGET_SLOT_STATE.AVAILABLE);
+  assert.equal(gatewaySlot.candidateFulfillmentRefs.length, 2);
+  assert.equal(gatewaySlot.selectedFulfillmentRef, "fulfillment:gateway-association:local-dev");
+  assert.equal(contributions.filter((entry) => entry.role === FABRIC.MEMBER_ROLE.GATEWAY_ASSOCIATION).length, 2);
+  assert.equal(contributions.find((entry) => entry.role === FABRIC.MEMBER_ROLE.SERVICE_EDGE_ADAPTER)?.subjectRef, "service:nvr");
+  assert.equal(plan.state, FABRIC.FULFILLMENT_PLAN_STATE.READY);
+  assert.ok(plan.memberContributionRefs.includes("fabric-contribution:gateway-association:lab-dev"));
+  assert.ok(!registry.slotPostures.some((slot) => slot.safeFacts?.serviceIdentityMutation));
+});
+
 test("app runner fulfillment reports reduce operation lifecycle, release, resources, and proof", () => {
   const observedAt = 1700000020;
   const report = assertAppRunnerFulfillmentReport({

--- a/vectors/contract-target-lab-linux-v1.json
+++ b/vectors/contract-target-lab-linux-v1.json
@@ -1,0 +1,278 @@
+{
+  "target": {
+    "kind": "contract.target",
+    "targetRef": "contract-target:home-linux-lab:msa-transition",
+    "contractRef": "app:contract:constitute-nvr@0.1.0",
+    "profileRef": "host-profile:home",
+    "platformRef": "platform:linux.lab",
+    "state": "selected",
+    "compatibilityState": "degraded",
+    "hostRef": "host:lab-gateway",
+    "substrateRef": "substrate:home-dev",
+    "modifierRefs": [
+      "modifier:home",
+      "modifier:dev"
+    ],
+    "branchRefs": [
+      "branch:0x/msa-transition"
+    ],
+    "subbranchRefs": [
+      "subbranch:target-contract"
+    ],
+    "capabilitySlotRefs": [
+      "slot:gateway",
+      "slot:storage",
+      "slot:service-manager",
+      "slot:nvr-service",
+      "slot:runtime-client",
+      "slot:nvr-surface",
+      "slot:browser-webrtc",
+      "slot:rollback",
+      "slot:lab-proof-automation"
+    ],
+    "adapterPackRef": "adapter-pack:linux-lab-dev",
+    "adapterRefs": [
+      "adapter:host-service:linux",
+      "adapter:gateway:linux",
+      "adapter:storage:local"
+    ],
+    "negativeSlotRefs": [
+      "slot:browser-webrtc"
+    ],
+    "missingSlotRefs": [
+      "slot:runtime-client",
+      "slot:nvr-surface",
+      "slot:lab-proof-automation"
+    ],
+    "degradedSlotRefs": [
+      "slot:rollback"
+    ],
+    "proofProfileRefs": [
+      "proof-profile:service-manager-lab",
+      "proof-profile:gateway-native-smoke",
+      "proof-profile:nvr-smoke-5s"
+    ],
+    "proofRefs": [
+      "proof:service-manager-cargo-test:20260522"
+    ],
+    "compatibilityRefs": [
+      "compat:runtime-2.56",
+      "compat:branch-family:msa-transition"
+    ],
+    "evidenceRefs": [
+      "evidence:lab-target:contract-only",
+      "evidence:service-manager:target-reducer"
+    ],
+    "targetAudience": "developer",
+    "safeFacts": {
+      "profile": "home-dev",
+      "platform": "linux.lab",
+      "proofAutomation": "manualProtected"
+    },
+    "issuedAt": 1778760000,
+    "expiresAt": 1778846400
+  },
+  "registry": {
+    "kind": "contract.target.registry.posture",
+    "registryRef": "contract-target-registry:home-linux-lab:msa-transition",
+    "targetRef": "contract-target:home-linux-lab:msa-transition",
+    "contractRef": "app:contract:constitute-nvr@0.1.0",
+    "state": "degraded",
+    "slotPostures": [
+      {
+        "slotRef": "slot:gateway",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:gateway:lab-dev"
+        ],
+        "selectedFulfillmentRef": "fulfillment:gateway:lab-dev",
+        "platformRefs": [
+          "platform:linux.lab"
+        ],
+        "adapterRefs": [
+          "adapter:gateway:linux"
+        ],
+        "evidenceRefs": [
+          "evidence:gateway:lab:configured"
+        ]
+      },
+      {
+        "slotRef": "slot:storage",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:storage:lab-local"
+        ],
+        "selectedFulfillmentRef": "fulfillment:storage:lab-local",
+        "platformRefs": [
+          "platform:linux.lab"
+        ],
+        "adapterRefs": [
+          "adapter:storage:local"
+        ],
+        "proofRequirementRefs": [
+          "proof-requirement:storage-availability"
+        ],
+        "evidenceRefs": [
+          "evidence:storage:lab:configured"
+        ]
+      },
+      {
+        "slotRef": "slot:service-manager",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:service-manager:lab"
+        ],
+        "selectedFulfillmentRef": "fulfillment:service-manager:lab",
+        "platformRefs": [
+          "platform:linux.lab"
+        ],
+        "adapterRefs": [
+          "adapter:host-service:linux"
+        ],
+        "proofRefs": [
+          "proof:service-manager-cargo-test:20260522"
+        ],
+        "evidenceRefs": [
+          "evidence:service-manager:target-reducer"
+        ]
+      },
+      {
+        "slotRef": "slot:nvr-service",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:nvr-service:lab-network"
+        ],
+        "selectedFulfillmentRef": "fulfillment:nvr-service:lab-network",
+        "platformRefs": [
+          "platform:linux.lab"
+        ],
+        "proofRequirementRefs": [
+          "proof-requirement:nvr-service-live"
+        ],
+        "evidenceRefs": [
+          "evidence:nvr-service:lab:configured"
+        ]
+      },
+      {
+        "slotRef": "slot:runtime-client",
+        "state": "missing",
+        "platformFitState": "unknown",
+        "proofRequirementRefs": [
+          "proof-requirement:client-target-selected"
+        ],
+        "blockedReasons": [
+          "blocked:lab-client-target-unselected"
+        ],
+        "safeFacts": {
+          "reason": "lab host target does not include a proved local client"
+        }
+      },
+      {
+        "slotRef": "slot:nvr-surface",
+        "state": "missing",
+        "platformFitState": "unknown",
+        "sourceRefs": [
+          "content-index:nvr-surface"
+        ],
+        "proofRequirementRefs": [
+          "proof-requirement:surface-load"
+        ],
+        "blockedReasons": [
+          "blocked:lab-client-target-unselected"
+        ],
+        "safeFacts": {
+          "reason": "surface proof belongs to a client target"
+        }
+      },
+      {
+        "slotRef": "slot:browser-webrtc",
+        "state": "notRequired",
+        "platformFitState": "unknown",
+        "evidenceRefs": [
+          "evidence:target:browser-webrtc:not-host-slot"
+        ],
+        "safeFacts": {
+          "reason": "lab host target"
+        }
+      },
+      {
+        "slotRef": "slot:rollback",
+        "state": "degraded",
+        "platformFitState": "degraded",
+        "candidateFulfillmentRefs": [
+          "fulfillment:rollback:manual"
+        ],
+        "selectedFulfillmentRef": "fulfillment:rollback:manual",
+        "proofRequirementRefs": [
+          "proof-requirement:rollback-automation"
+        ],
+        "safeFacts": {
+          "reason": "manual rollback only"
+        }
+      },
+      {
+        "slotRef": "slot:lab-proof-automation",
+        "state": "missing",
+        "platformFitState": "unknown",
+        "proofRequirementRefs": [
+          "proof-requirement:bootstrap",
+          "proof-requirement:secrets",
+          "proof-requirement:rollback",
+          "proof-requirement:lab-live"
+        ],
+        "blockedReasons": [
+          "blocked:lab-proof-protected-manual"
+        ],
+        "safeFacts": {
+          "reason": "lab proof remains protected until bootstrap, secrets, and rollback contracts automate it"
+        }
+      }
+    ],
+    "candidateFulfillmentRefs": [
+      "fulfillment:gateway:lab-dev",
+      "fulfillment:storage:lab-local",
+      "fulfillment:service-manager:lab",
+      "fulfillment:nvr-service:lab-network",
+      "fulfillment:rollback:manual"
+    ],
+    "sourceRefs": [
+      "content-index:nvr-surface",
+      "content-index:runtime-surface-client"
+    ],
+    "buildRefs": [
+      "build:lab:gateway",
+      "build:lab:service-manager",
+      "build:lab:nvr-service"
+    ],
+    "adapterRefs": [
+      "adapter:host-service:linux",
+      "adapter:gateway:linux",
+      "adapter:storage:local"
+    ],
+    "proofRequirementRefs": [
+      "proof-requirement:bootstrap",
+      "proof-requirement:secrets",
+      "proof-requirement:rollback",
+      "proof-requirement:lab-live",
+      "proof-requirement:client-target-selected"
+    ],
+    "proofRefs": [
+      "proof:service-manager-cargo-test:20260522"
+    ],
+    "evidenceRefs": [
+      "evidence:lab-target:contract-only",
+      "evidence:service-manager:target-reducer"
+    ],
+    "safeFacts": {
+      "profile": "home-dev",
+      "platform": "linux.lab",
+      "proofAutomation": "manualProtected"
+    },
+    "observedAt": 1778760000,
+    "expiresAt": 1778846400
+  }
+}

--- a/vectors/contract-target-local-workstation-v1.json
+++ b/vectors/contract-target-local-workstation-v1.json
@@ -1,0 +1,243 @@
+{
+  "target": {
+    "kind": "contract.target",
+    "targetRef": "contract-target:desktop-windows-dev:msa-transition",
+    "contractRef": "app:contract:constitute-nvr@0.1.0",
+    "profileRef": "host-profile:desktop",
+    "platformRef": "platform:windows.desktop",
+    "state": "ready",
+    "compatibilityState": "compatible",
+    "hostRef": "host:local-workstation",
+    "substrateRef": "substrate:desktop-dev",
+    "modifierRefs": [
+      "modifier:dev"
+    ],
+    "branchRefs": [
+      "branch:0x/msa-transition"
+    ],
+    "subbranchRefs": [
+      "subbranch:target-contract"
+    ],
+    "capabilitySlotRefs": [
+      "slot:gateway",
+      "slot:runtime",
+      "slot:service-manager",
+      "slot:nvr-service",
+      "slot:nvr-surface",
+      "slot:browser-webrtc",
+      "slot:native-client"
+    ],
+    "adapterPackRef": "adapter-pack:desktop-dev",
+    "adapterRefs": [
+      "adapter:runtime-surface-client",
+      "adapter:browser-webrtc",
+      "adapter:host-service:windows"
+    ],
+    "negativeSlotRefs": [
+      "slot:native-client"
+    ],
+    "proofProfileRefs": [
+      "proof-profile:nvr-smoke-5s",
+      "proof-profile:long-stream-10m"
+    ],
+    "proofRefs": [
+      "proof:nvr-smoke-5s:20260522T073913Z",
+      "proof:long-stream-10m:20260522T074937Z"
+    ],
+    "compatibilityRefs": [
+      "compat:runtime-2.56",
+      "compat:branch-family:msa-transition"
+    ],
+    "evidenceRefs": [
+      "evidence:desktop-target:local-workstation",
+      "evidence:media:nonzero-video-dimensions",
+      "evidence:media:transport-usable"
+    ],
+    "targetAudience": "developer",
+    "safeFacts": {
+      "profile": "desktop-dev",
+      "platform": "windows.desktop",
+      "nativeClient": "notRequired"
+    },
+    "issuedAt": 1778760000,
+    "expiresAt": 1778846400
+  },
+  "registry": {
+    "kind": "contract.target.registry.posture",
+    "registryRef": "contract-target-registry:desktop-windows-dev:msa-transition",
+    "targetRef": "contract-target:desktop-windows-dev:msa-transition",
+    "contractRef": "app:contract:constitute-nvr@0.1.0",
+    "state": "ready",
+    "slotPostures": [
+      {
+        "slotRef": "slot:gateway",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:gateway:local-dev"
+        ],
+        "selectedFulfillmentRef": "fulfillment:gateway:local-dev",
+        "platformRefs": [
+          "platform:windows.desktop"
+        ],
+        "adapterRefs": [
+          "adapter:host-service:windows"
+        ],
+        "proofRefs": [
+          "proof:nvr-smoke-5s:20260522T073913Z"
+        ],
+        "evidenceRefs": [
+          "evidence:gateway:local-dev:ready"
+        ]
+      },
+      {
+        "slotRef": "slot:runtime",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:runtime:browser"
+        ],
+        "selectedFulfillmentRef": "fulfillment:runtime:browser",
+        "sourceRefs": [
+          "content-index:runtime-surface-client"
+        ],
+        "platformRefs": [
+          "platform:browser"
+        ],
+        "adapterRefs": [
+          "adapter:runtime-surface-client"
+        ],
+        "proofRefs": [
+          "proof:nvr-smoke-5s:20260522T073913Z"
+        ],
+        "evidenceRefs": [
+          "evidence:runtime:attached"
+        ]
+      },
+      {
+        "slotRef": "slot:service-manager",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:service-manager:local-dev"
+        ],
+        "selectedFulfillmentRef": "fulfillment:service-manager:local-dev",
+        "platformRefs": [
+          "platform:windows.desktop"
+        ],
+        "adapterRefs": [
+          "adapter:host-service:windows"
+        ],
+        "evidenceRefs": [
+          "evidence:service-manager:target-reducer"
+        ]
+      },
+      {
+        "slotRef": "slot:nvr-service",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:nvr-service:local-network"
+        ],
+        "selectedFulfillmentRef": "fulfillment:nvr-service:local-network",
+        "proofRefs": [
+          "proof:long-stream-10m:20260522T074937Z"
+        ],
+        "evidenceRefs": [
+          "evidence:media:answer-materialized",
+          "evidence:media:transport-usable"
+        ]
+      },
+      {
+        "slotRef": "slot:nvr-surface",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:nvr-surface:browser"
+        ],
+        "selectedFulfillmentRef": "fulfillment:nvr-surface:browser",
+        "sourceRefs": [
+          "content-index:nvr-surface"
+        ],
+        "proofRefs": [
+          "proof:long-stream-10m:20260522T074937Z"
+        ],
+        "evidenceRefs": [
+          "evidence:media:nonzero-video-dimensions"
+        ]
+      },
+      {
+        "slotRef": "slot:browser-webrtc",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:browser-webrtc:firefox-aux"
+        ],
+        "selectedFulfillmentRef": "fulfillment:browser-webrtc:firefox-aux",
+        "adapterRefs": [
+          "adapter:browser-webrtc"
+        ],
+        "proofRefs": [
+          "proof:long-stream-10m:20260522T074937Z"
+        ],
+        "evidenceRefs": [
+          "evidence:media:track-live",
+          "evidence:media:visible-frame"
+        ]
+      },
+      {
+        "slotRef": "slot:native-client",
+        "state": "notRequired",
+        "platformFitState": "unknown",
+        "evidenceRefs": [
+          "evidence:target:native-client:not-required"
+        ],
+        "safeFacts": {
+          "reason": "browser target"
+        }
+      }
+    ],
+    "candidateFulfillmentRefs": [
+      "fulfillment:gateway:local-dev",
+      "fulfillment:runtime:browser",
+      "fulfillment:service-manager:local-dev",
+      "fulfillment:nvr-service:local-network",
+      "fulfillment:nvr-surface:browser",
+      "fulfillment:browser-webrtc:firefox-aux"
+    ],
+    "sourceRefs": [
+      "content-index:nvr-surface",
+      "content-index:runtime-surface-client"
+    ],
+    "buildRefs": [
+      "build:local:constitute-nvr-ui",
+      "build:local:constitute-account"
+    ],
+    "adapterRefs": [
+      "adapter:runtime-surface-client",
+      "adapter:browser-webrtc",
+      "adapter:host-service:windows"
+    ],
+    "proofRequirementRefs": [
+      "proof-requirement:surface-load",
+      "proof-requirement:media-nonzero-dimensions",
+      "proof-requirement:long-stream-10m"
+    ],
+    "proofRefs": [
+      "proof:nvr-smoke-5s:20260522T073913Z",
+      "proof:long-stream-10m:20260522T074937Z"
+    ],
+    "evidenceRefs": [
+      "evidence:desktop-target:local-workstation",
+      "evidence:media:transport-usable",
+      "evidence:media:nonzero-video-dimensions"
+    ],
+    "safeFacts": {
+      "profile": "desktop-dev",
+      "platform": "windows.desktop",
+      "nativeClient": "notRequired"
+    },
+    "observedAt": 1778760000,
+    "expiresAt": 1778846400
+  }
+}

--- a/vectors/contract-target-local-workstation-v1.json
+++ b/vectors/contract-target-local-workstation-v1.json
@@ -171,9 +171,9 @@
         "state": "available",
         "platformFitState": "compatible",
         "candidateFulfillmentRefs": [
-          "fulfillment:browser-webrtc:firefox-aux"
+          "fulfillment:browser-webrtc:authenticated-desktop-browser"
         ],
-        "selectedFulfillmentRef": "fulfillment:browser-webrtc:firefox-aux",
+        "selectedFulfillmentRef": "fulfillment:browser-webrtc:authenticated-desktop-browser",
         "adapterRefs": [
           "adapter:browser-webrtc"
         ],
@@ -203,7 +203,7 @@
       "fulfillment:service-manager:local-dev",
       "fulfillment:nvr-service:local-network",
       "fulfillment:nvr-surface:browser",
-      "fulfillment:browser-webrtc:firefox-aux"
+      "fulfillment:browser-webrtc:authenticated-desktop-browser"
     ],
     "sourceRefs": [
       "content-index:nvr-surface",

--- a/vectors/contract-target-multi-gateway-v1.json
+++ b/vectors/contract-target-multi-gateway-v1.json
@@ -1,0 +1,311 @@
+{
+  "target": {
+    "kind": "contract.target",
+    "targetRef": "contract-target:multi-gateway:msa-transition",
+    "contractRef": "app:contract:constitute-nvr@0.1.0",
+    "profileRef": "host-profile:mixed-dev",
+    "platformRef": "platform:mixed.local-lab",
+    "state": "ready",
+    "compatibilityState": "compatible",
+    "hostRef": "host:fabric-dev",
+    "substrateRef": "substrate:mixed-dev",
+    "modifierRefs": [
+      "modifier:dev",
+      "modifier:multi-gateway"
+    ],
+    "branchRefs": [
+      "branch:0x/msa-transition"
+    ],
+    "subbranchRefs": [
+      "subbranch:target-contract"
+    ],
+    "capabilitySlotRefs": [
+      "slot:gateway-association",
+      "slot:service-edge-adapter",
+      "slot:platform-adapter",
+      "slot:runtime",
+      "slot:nvr-service"
+    ],
+    "adapterPackRef": "adapter-pack:mixed-dev",
+    "adapterRefs": [
+      "adapter:gateway:windows",
+      "adapter:gateway:linux",
+      "adapter:browser-webrtc",
+      "adapter:nvr-service-edge"
+    ],
+    "proofProfileRefs": [
+      "proof-profile:target-registry-candidate-reduction"
+    ],
+    "proofRefs": [
+      "proof:protocol-multi-gateway-vector:20260522"
+    ],
+    "compatibilityRefs": [
+      "compat:branch-family:msa-transition"
+    ],
+    "evidenceRefs": [
+      "evidence:target-registry:multi-gateway",
+      "evidence:host-fabric:member-contributions"
+    ],
+    "targetAudience": "developer",
+    "safeFacts": {
+      "profile": "mixed-dev",
+      "gatewayCandidates": 2,
+      "serviceEdgeCandidates": 2
+    },
+    "issuedAt": 1778760000,
+    "expiresAt": 1778846400
+  },
+  "registry": {
+    "kind": "contract.target.registry.posture",
+    "registryRef": "contract-target-registry:multi-gateway:msa-transition",
+    "targetRef": "contract-target:multi-gateway:msa-transition",
+    "contractRef": "app:contract:constitute-nvr@0.1.0",
+    "state": "ready",
+    "slotPostures": [
+      {
+        "slotRef": "slot:gateway-association",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:gateway-association:local-dev",
+          "fulfillment:gateway-association:lab-dev"
+        ],
+        "selectedFulfillmentRef": "fulfillment:gateway-association:local-dev",
+        "platformRefs": [
+          "platform:windows.desktop",
+          "platform:linux.lab"
+        ],
+        "adapterRefs": [
+          "adapter:gateway:windows",
+          "adapter:gateway:linux"
+        ],
+        "evidenceRefs": [
+          "evidence:gateway-association:candidates"
+        ]
+      },
+      {
+        "slotRef": "slot:service-edge-adapter",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:nvr-service-edge:local-network",
+          "fulfillment:nvr-service-edge:lab-network"
+        ],
+        "selectedFulfillmentRef": "fulfillment:nvr-service-edge:local-network",
+        "platformRefs": [
+          "platform:windows.desktop",
+          "platform:linux.lab"
+        ],
+        "adapterRefs": [
+          "adapter:nvr-service-edge"
+        ],
+        "evidenceRefs": [
+          "evidence:service-edge:candidates"
+        ]
+      },
+      {
+        "slotRef": "slot:platform-adapter",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:platform-adapter:browser-webrtc"
+        ],
+        "selectedFulfillmentRef": "fulfillment:platform-adapter:browser-webrtc",
+        "adapterRefs": [
+          "adapter:browser-webrtc"
+        ],
+        "evidenceRefs": [
+          "evidence:platform-adapter:browser-webrtc"
+        ]
+      },
+      {
+        "slotRef": "slot:runtime",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:runtime:browser"
+        ],
+        "selectedFulfillmentRef": "fulfillment:runtime:browser",
+        "sourceRefs": [
+          "content-index:runtime-surface-client"
+        ],
+        "evidenceRefs": [
+          "evidence:runtime:surface-client"
+        ]
+      },
+      {
+        "slotRef": "slot:nvr-service",
+        "state": "available",
+        "platformFitState": "compatible",
+        "candidateFulfillmentRefs": [
+          "fulfillment:nvr-service:local-network",
+          "fulfillment:nvr-service:lab-network"
+        ],
+        "selectedFulfillmentRef": "fulfillment:nvr-service:local-network",
+        "evidenceRefs": [
+          "evidence:nvr-service:candidates"
+        ]
+      }
+    ],
+    "candidateFulfillmentRefs": [
+      "fulfillment:gateway-association:local-dev",
+      "fulfillment:gateway-association:lab-dev",
+      "fulfillment:nvr-service-edge:local-network",
+      "fulfillment:nvr-service-edge:lab-network",
+      "fulfillment:platform-adapter:browser-webrtc",
+      "fulfillment:runtime:browser",
+      "fulfillment:nvr-service:local-network",
+      "fulfillment:nvr-service:lab-network"
+    ],
+    "sourceRefs": [
+      "content-index:nvr-service-edge",
+      "content-index:runtime-surface-client"
+    ],
+    "adapterRefs": [
+      "adapter:gateway:windows",
+      "adapter:gateway:linux",
+      "adapter:browser-webrtc",
+      "adapter:nvr-service-edge"
+    ],
+    "proofRequirementRefs": [
+      "proof-requirement:candidate-reduction",
+      "proof-requirement:selected-fulfillment",
+      "proof-requirement:no-service-identity-mutation"
+    ],
+    "proofRefs": [
+      "proof:protocol-multi-gateway-vector:20260522"
+    ],
+    "evidenceRefs": [
+      "evidence:target-registry:multi-gateway",
+      "evidence:host-fabric:member-contributions"
+    ],
+    "safeFacts": {
+      "gatewayCandidates": 2,
+      "serviceEdgeCandidates": 2,
+      "selectedGateway": "fulfillment:gateway-association:local-dev"
+    },
+    "observedAt": 1778760000,
+    "expiresAt": 1778846400
+  },
+  "hostFabricContributions": [
+    {
+      "kind": "hostFabric.member.contribution",
+      "contributionId": "fabric-contribution:gateway-association:local-dev",
+      "fabricRef": "fabric:multi-gateway-dev",
+      "hostRef": "host:local-workstation",
+      "memberRef": "e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13",
+      "role": "gatewayAssociation",
+      "state": "running",
+      "contractRef": "contract:gateway-association@0.1.0",
+      "subjectRef": "association:gateway:local-dev",
+      "capabilityRefs": [
+        "gateway.association.fulfill"
+      ],
+      "grantRefs": [
+        "grant:gateway-association:local-dev"
+      ],
+      "outputRefs": [
+        "fulfillment:gateway-association:local-dev"
+      ],
+      "evidenceRefs": [
+        "evidence:gateway-association:local-dev"
+      ],
+      "safeFacts": {
+        "role": "gatewayAssociation",
+        "candidate": "local-dev"
+      },
+      "observedAt": 1778760000,
+      "expiresAt": 1778846400
+    },
+    {
+      "kind": "hostFabric.member.contribution",
+      "contributionId": "fabric-contribution:gateway-association:lab-dev",
+      "fabricRef": "fabric:multi-gateway-dev",
+      "hostRef": "host:lab-gateway",
+      "memberRef": "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
+      "role": "gatewayAssociation",
+      "state": "running",
+      "contractRef": "contract:gateway-association@0.1.0",
+      "subjectRef": "association:gateway:lab-dev",
+      "capabilityRefs": [
+        "gateway.association.fulfill"
+      ],
+      "grantRefs": [
+        "grant:gateway-association:lab-dev"
+      ],
+      "outputRefs": [
+        "fulfillment:gateway-association:lab-dev"
+      ],
+      "evidenceRefs": [
+        "evidence:gateway-association:lab-dev"
+      ],
+      "safeFacts": {
+        "role": "gatewayAssociation",
+        "candidate": "lab-dev"
+      },
+      "observedAt": 1778760000,
+      "expiresAt": 1778846400
+    },
+    {
+      "kind": "hostFabric.member.contribution",
+      "contributionId": "fabric-contribution:service-edge:nvr",
+      "fabricRef": "fabric:multi-gateway-dev",
+      "hostRef": "host:nvr-service",
+      "memberRef": "f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9",
+      "role": "serviceEdgeAdapter",
+      "state": "running",
+      "contractRef": "contract:nvr-service-edge@0.1.0",
+      "subjectRef": "service:nvr",
+      "capabilityRefs": [
+        "service.edge.fulfill"
+      ],
+      "grantRefs": [
+        "grant:nvr-service-edge:fulfill"
+      ],
+      "outputRefs": [
+        "fulfillment:nvr-service-edge:local-network",
+        "fulfillment:nvr-service-edge:lab-network"
+      ],
+      "evidenceRefs": [
+        "evidence:service-edge:nvr"
+      ],
+      "safeFacts": {
+        "role": "serviceEdgeAdapter",
+        "domain": "nvr"
+      },
+      "observedAt": 1778760000,
+      "expiresAt": 1778846400
+    }
+  ],
+  "fulfillmentPlan": {
+    "kind": "hostFabric.fulfillment.plan",
+    "planId": "fabric-plan:multi-gateway:target-registry",
+    "fabricRef": "fabric:multi-gateway-dev",
+    "hostRef": "host:fabric-dev",
+    "contractRef": "app:contract:constitute-nvr@0.1.0",
+    "state": "ready",
+    "requiredRoleRefs": [
+      "role:gatewayAssociation",
+      "role:serviceEdgeAdapter",
+      "role:platformAdapter"
+    ],
+    "memberContributionRefs": [
+      "fabric-contribution:gateway-association:local-dev",
+      "fabric-contribution:gateway-association:lab-dev",
+      "fabric-contribution:service-edge:nvr"
+    ],
+    "materializationBudgetRefs": [
+      "materialization-budget:target-registry:hot"
+    ],
+    "evidenceRefs": [
+      "contract-target-registry:multi-gateway:msa-transition",
+      "evidence:host-fabric:member-contributions"
+    ],
+    "safeFacts": {
+      "gatewayCandidates": 2,
+      "selectedBy": "target-registry"
+    },
+    "observedAt": 1778760000,
+    "expiresAt": 1778846400
+  }
+}


### PR DESCRIPTION
Adds shared target, host-fabric, association, lifecycle, media, compliance, and fixture allowance primitives used by the MSA transition.\n\nProof: local protocol, native, browser, convergence, affected, and aggregate checks passed.