### PR TITLE
Add cybersecurity processor posture records

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -48,6 +48,10 @@ pub struct BuildContract {
     #[serde(default)]
     pub content_index_refs: Vec<String>,
     #[serde(default)]
+    pub processor_contract_refs: Vec<String>,
+    #[serde(default)]
+    pub processor_role_refs: Vec<String>,
+    #[serde(default)]
     pub runner_role_refs: Vec<String>,
     #[serde(default)]
     pub runner_refs: Vec<String>,
@@ -88,6 +92,10 @@ pub struct BuildRun {
     pub source_operation_refs: Vec<String>,
     #[serde(default)]
     pub content_index_refs: Vec<String>,
+    #[serde(default)]
+    pub processor_contract_refs: Vec<String>,
+    #[serde(default)]
+    pub processor_role_refs: Vec<String>,
     #[serde(default)]
     pub grant_refs: Vec<String>,
     #[serde(default)]
@@ -158,6 +166,10 @@ pub struct BuildProof {
     #[serde(default)]
     pub source_operation_refs: Vec<String>,
     #[serde(default)]
+    pub processor_contract_refs: Vec<String>,
+    #[serde(default)]
+    pub processor_role_refs: Vec<String>,
+    #[serde(default)]
     pub artifact_refs: Vec<String>,
     #[serde(default)]
     pub log_refs: Vec<String>,
@@ -198,6 +210,14 @@ pub fn validate_build_contract(record: &BuildContract) -> Result<()> {
     validate_ref_list(
         &record.content_index_refs,
         "build contract contentIndexRefs",
+    )?;
+    validate_ref_list(
+        &record.processor_contract_refs,
+        "build contract processorContractRefs",
+    )?;
+    validate_ref_list(
+        &record.processor_role_refs,
+        "build contract processorRoleRefs",
     )?;
     validate_ref_list(&record.runner_role_refs, "build contract runnerRoleRefs")?;
     validate_ref_list(&record.runner_refs, "build contract runnerRefs")?;
@@ -250,6 +270,11 @@ pub fn validate_build_run(record: &BuildRun) -> Result<()> {
         "build run sourceOperationRefs",
     )?;
     validate_ref_list(&record.content_index_refs, "build run contentIndexRefs")?;
+    validate_ref_list(
+        &record.processor_contract_refs,
+        "build run processorContractRefs",
+    )?;
+    validate_ref_list(&record.processor_role_refs, "build run processorRoleRefs")?;
     validate_ref_list(&record.grant_refs, "build run grantRefs")?;
     validate_ref_list(&record.resource_grant_refs, "build run resourceGrantRefs")?;
     validate_ref_list(&record.secret_boundary_refs, "build run secretBoundaryRefs")?;
@@ -349,6 +374,11 @@ pub fn validate_build_proof(record: &BuildProof) -> Result<()> {
         &record.source_operation_refs,
         "build proof sourceOperationRefs",
     )?;
+    validate_ref_list(
+        &record.processor_contract_refs,
+        "build proof processorContractRefs",
+    )?;
+    validate_ref_list(&record.processor_role_refs, "build proof processorRoleRefs")?;
     validate_ref_list(&record.artifact_refs, "build proof artifactRefs")?;
     validate_ref_list(&record.log_refs, "build proof logRefs")?;
     validate_ref_list(&record.metric_refs, "build proof metricRefs")?;
@@ -548,6 +578,8 @@ mod tests {
             state: BUILD_CONTRACT_STATE_READY.to_string(),
             source_operation_refs: vec!["source:operation:ref-update".to_string()],
             content_index_refs: vec!["content-index:source:constitute-git".to_string()],
+            processor_contract_refs: vec!["processor-contract:logging.cybersec".to_string()],
+            processor_role_refs: vec!["role:cybersec.processor".to_string()],
             runner_role_refs: vec!["runner:role:build".to_string()],
             runner_refs: vec!["runner:instance:local".to_string()],
             resource_grant_refs: vec!["resource:grant:build-lite".to_string()],
@@ -579,6 +611,8 @@ mod tests {
             state: BUILD_RUN_STATE_SUCCEEDED.to_string(),
             source_operation_refs: contract.source_operation_refs.clone(),
             content_index_refs: contract.content_index_refs.clone(),
+            processor_contract_refs: contract.processor_contract_refs.clone(),
+            processor_role_refs: contract.processor_role_refs.clone(),
             grant_refs: vec!["authority:grant:runner-build".to_string()],
             resource_grant_refs: vec!["resource:grant:build-lite".to_string()],
             secret_boundary_refs: vec!["secret:boundary:not-required".to_string()],
@@ -624,6 +658,8 @@ mod tests {
             source_snapshot_ref: contract.source_snapshot_ref,
             runner_ref: "runner:instance:local".to_string(),
             source_operation_refs: run.source_operation_refs.clone(),
+            processor_contract_refs: run.processor_contract_refs.clone(),
+            processor_role_refs: run.processor_role_refs.clone(),
             artifact_refs: vec![artifact.artifact_ref],
             log_refs: vec!["storage:object:build-log".to_string()],
             metric_refs: vec!["metrics:build:1".to_string()],
@@ -652,6 +688,8 @@ mod tests {
             state: BUILD_RUN_STATE_FAILED.to_string(),
             source_operation_refs: vec![],
             content_index_refs: vec![],
+            processor_contract_refs: vec![],
+            processor_role_refs: vec![],
             grant_refs: vec!["authority:grant:runner-build".to_string()],
             resource_grant_refs: vec!["resource:grant:build-lite".to_string()],
             secret_boundary_refs: vec!["secret:boundary:not-required".to_string()],

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1518,6 +1518,25 @@ export type CybersecMitigationRecommendationRecord = {
   expiresAt?: number;
 };
 
+export type CybersecMitigationConsumerPostureRecord = {
+  kind?: "cybersec.mitigation.consumer.posture";
+  postureId: string;
+  recommendationRef: string;
+  findingRef: string;
+  processorReportRef: string;
+  consumerRef: string;
+  actionKind: "observe" | "requestEvidence" | "retainEvidence" | "quarantine" | "block" | "rateLimit" | "degrade" | "notify";
+  targetRef: string;
+  state: "unsupported" | "waitingAuthority" | "actionable" | "accepted" | "rejected" | "applied" | "blocked" | "expired";
+  authorityRefs?: string[];
+  supportedActionKinds?: Array<"observe" | "requestEvidence" | "retainEvidence" | "quarantine" | "block" | "rateLimit" | "degrade" | "notify">;
+  evidenceRefs?: string[];
+  blockedReasons?: string[];
+  safeFacts?: Record<string, unknown>;
+  observedAt: number;
+  expiresAt?: number;
+};
+
 export type ProjectionSnapshot = {
   projectionId: string;
   policyId: string;
@@ -3393,6 +3412,7 @@ export function assertCybersecProcessorSeed(record: unknown): CybersecProcessorS
 export function assertCybersecFinding(record: unknown): CybersecFindingRecord;
 export function assertCybersecEvidenceHold(record: unknown): CybersecEvidenceHoldRecord;
 export function assertCybersecMitigationRecommendation(record: unknown): CybersecMitigationRecommendationRecord;
+export function assertCybersecMitigationConsumerPosture(record: unknown): CybersecMitigationConsumerPostureRecord;
 export function assertSwarmIdentityGraph(records: unknown): unknown[];
 export function assertCaacEnvelopeForMode(envelope: unknown, opts?: { mode?: string; now?: number }): CaacEnvelope | Record<string, unknown>;
 export function buildCapabilityDirectoryProjection(input?: {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1411,6 +1411,11 @@ export type EventFabricProcessorReportRecord = {
   observedEventRefs?: string[];
   heldEventRefs?: string[];
   storageRefs?: string[];
+  findingRefs?: string[];
+  alertRefs?: string[];
+  evidenceHoldRefs?: string[];
+  retentionDemandRefs?: string[];
+  mitigationRecommendationRefs?: string[];
   safeFacts?: Record<string, unknown>;
   evidenceRefs?: string[];
   blockedReasons?: string[];
@@ -1447,6 +1452,67 @@ export type CybersecProcessorSeedRecord = {
   };
   safeFacts?: Record<string, unknown>;
   evidenceRefs?: string[];
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type CybersecFindingRecord = {
+  kind?: "cybersec.finding";
+  findingId: string;
+  processorReportRef: string;
+  processorRef: string;
+  processorRoleRef: string;
+  subjectRef: string;
+  findingKind: string;
+  severity: "info" | "low" | "medium" | "high" | "critical";
+  state: "open" | "triaged" | "suppressed" | "resolved" | "blocked" | "expired";
+  confidenceScore: number;
+  inputAccessClassRefs?: string[];
+  observedEventRefs?: string[];
+  accessGroupRefs?: string[];
+  evidenceRefs?: string[];
+  evidenceHoldRefs?: string[];
+  retentionDemandRefs?: string[];
+  mitigationRecommendationRefs?: string[];
+  safeFacts?: Record<string, unknown>;
+  blockedReasons?: string[];
+  observedAt: number;
+  expiresAt?: number;
+};
+
+export type CybersecEvidenceHoldRecord = {
+  kind?: "cybersec.evidence.hold";
+  holdId: string;
+  findingRef: string;
+  processorReportRef: string;
+  subjectRef: string;
+  state: "requested" | "holding" | "released" | "blocked" | "expired";
+  eventRefs?: string[];
+  detailRefs?: string[];
+  storageRefs?: string[];
+  retentionDemandRefs?: string[];
+  accessGroupRefs?: string[];
+  evidenceRefs?: string[];
+  safeFacts?: Record<string, unknown>;
+  blockedReasons?: string[];
+  issuedAt: number;
+  expiresAt?: number;
+};
+
+export type CybersecMitigationRecommendationRecord = {
+  kind?: "cybersec.mitigation.recommendation";
+  recommendationId: string;
+  findingRef: string;
+  processorReportRef: string;
+  recommenderRef: string;
+  actionKind: "observe" | "requestEvidence" | "retainEvidence" | "quarantine" | "block" | "rateLimit" | "degrade" | "notify";
+  targetRef: string;
+  state: "recommended" | "accepted" | "rejected" | "applied" | "blocked" | "expired";
+  authorityRefs?: string[];
+  consumerRefs?: string[];
+  evidenceRefs?: string[];
+  safeFacts?: Record<string, unknown>;
   blockedReasons?: string[];
   issuedAt: number;
   expiresAt?: number;
@@ -3324,6 +3390,9 @@ export function assertEventFabricAccessClass(record: unknown): EventFabricAccess
 export function assertEventFabricProcessorContract(record: unknown): EventFabricProcessorContractRecord;
 export function assertEventFabricProcessorReport(record: unknown): EventFabricProcessorReportRecord;
 export function assertCybersecProcessorSeed(record: unknown): CybersecProcessorSeedRecord;
+export function assertCybersecFinding(record: unknown): CybersecFindingRecord;
+export function assertCybersecEvidenceHold(record: unknown): CybersecEvidenceHoldRecord;
+export function assertCybersecMitigationRecommendation(record: unknown): CybersecMitigationRecommendationRecord;
 export function assertSwarmIdentityGraph(records: unknown): unknown[];
 export function assertCaacEnvelopeForMode(envelope: unknown, opts?: { mode?: string; now?: number }): CaacEnvelope | Record<string, unknown>;
 export function buildCapabilityDirectoryProjection(input?: {

--- a/src/index.js
+++ b/src/index.js
@@ -1541,6 +1541,9 @@ export const SWARM = Object.freeze({
     EVENT_FABRIC_PROCESSOR_CONTRACT: "event.fabric.processor.contract",
     EVENT_FABRIC_PROCESSOR_REPORT: "event.fabric.processor.report",
     CYBERSEC_PROCESSOR_SEED: "cybersec.processor.seed",
+    CYBERSEC_FINDING: "cybersec.finding",
+    CYBERSEC_EVIDENCE_HOLD: "cybersec.evidence.hold",
+    CYBERSEC_MITIGATION_RECOMMENDATION: "cybersec.mitigation.recommendation",
     PARTICIPANT_RUNLEVEL: "participant.runlevel",
     PARTICIPANT_SELF_CAPABILITY: "participant.selfCapability",
     INGRESS_LANE_POSTURE: "ingress.lane.posture",
@@ -5208,6 +5211,11 @@ export function assertEventFabricProcessorReport(record) {
   assertOptionalReferenceList(record.observedEventRefs, "event fabric processor report observedEventRefs");
   assertOptionalReferenceList(record.heldEventRefs, "event fabric processor report heldEventRefs");
   assertOptionalReferenceList(record.storageRefs, "event fabric processor report storageRefs");
+  assertOptionalReferenceList(record.findingRefs, "event fabric processor report findingRefs");
+  assertOptionalReferenceList(record.alertRefs, "event fabric processor report alertRefs");
+  assertOptionalReferenceList(record.evidenceHoldRefs, "event fabric processor report evidenceHoldRefs");
+  assertOptionalReferenceList(record.retentionDemandRefs, "event fabric processor report retentionDemandRefs");
+  assertOptionalReferenceList(record.mitigationRecommendationRefs, "event fabric processor report mitigationRecommendationRefs");
   assertOptionalReferenceList(record.evidenceRefs, "event fabric processor report evidenceRefs");
   const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "event fabric processor report blockedReasons");
   if (state === "blocked" && blockedReasons.length === 0) {
@@ -5270,6 +5278,128 @@ export function assertCybersecProcessorSeed(record) {
   if (!Number(record.issuedAt || 0)) throw new Error("cybersec processor seed missing issuedAt");
   if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) {
     throw new Error("cybersec processor seed expires before issuedAt");
+  }
+  return { ...record, plane: AGREEMENT.PLANE.MATERIALIZATION };
+}
+
+function assertCybersecFindingSeverity(severity) {
+  const value = requireString(severity, "cybersec finding severity");
+  if (!["info", "low", "medium", "high", "critical"].includes(value)) throw new Error("invalid cybersec finding severity");
+  return value;
+}
+
+function assertCybersecMitigationAction(actionKind) {
+  const value = requireString(actionKind, "cybersec mitigation recommendation actionKind");
+  if (!["observe", "requestEvidence", "retainEvidence", "quarantine", "block", "rateLimit", "degrade", "notify"].includes(value)) {
+    throw new Error("invalid cybersec mitigation recommendation actionKind");
+  }
+  return value;
+}
+
+export function assertCybersecFinding(record) {
+  if (!isObject(record)) throw new Error("cybersec finding must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.CYBERSEC_FINDING, "cybersec finding");
+  requireString(record.findingId, "cybersec finding findingId");
+  requireString(record.processorReportRef, "cybersec finding processorReportRef");
+  requireString(record.processorRef, "cybersec finding processorRef");
+  requireString(record.processorRoleRef, "cybersec finding processorRoleRef");
+  requireString(record.subjectRef, "cybersec finding subjectRef");
+  requireString(record.findingKind, "cybersec finding findingKind");
+  assertCybersecFindingSeverity(record.severity);
+  const state = requireString(record.state, "cybersec finding state");
+  if (!["open", "triaged", "suppressed", "resolved", "blocked", "expired"].includes(state)) throw new Error("invalid cybersec finding state");
+  const confidenceScore = Number(record.confidenceScore);
+  if (!Number.isFinite(confidenceScore) || confidenceScore < 0 || confidenceScore > 1) {
+    throw new Error("cybersec finding confidenceScore must be between 0 and 1");
+  }
+  assertOptionalReferenceList(record.inputAccessClassRefs, "cybersec finding inputAccessClassRefs");
+  assertOptionalReferenceList(record.observedEventRefs, "cybersec finding observedEventRefs");
+  assertOptionalReferenceList(record.accessGroupRefs, "cybersec finding accessGroupRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "cybersec finding evidenceRefs");
+  assertOptionalReferenceList(record.evidenceHoldRefs, "cybersec finding evidenceHoldRefs");
+  assertOptionalReferenceList(record.retentionDemandRefs, "cybersec finding retentionDemandRefs");
+  assertOptionalReferenceList(record.mitigationRecommendationRefs, "cybersec finding mitigationRecommendationRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "cybersec finding blockedReasons");
+  if (state === "blocked" && blockedReasons.length === 0) {
+    throw new Error("cybersec finding blocked state requires blockedReasons");
+  }
+  if (record.safeFacts !== undefined) {
+    assertSafeObject(record.safeFacts, "cybersec finding safeFacts");
+    assertNoPrivateContentFields(record.safeFacts, "cybersec finding safeFacts");
+  }
+  rejectRouteControlByteFields(record, "cybersec finding");
+  if (!Number(record.observedAt || 0)) throw new Error("cybersec finding missing observedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.observedAt || 0)) {
+    throw new Error("cybersec finding expires before observedAt");
+  }
+  return { ...record, plane: AGREEMENT.PLANE.MATERIALIZATION };
+}
+
+export function assertCybersecEvidenceHold(record) {
+  if (!isObject(record)) throw new Error("cybersec evidence hold must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.CYBERSEC_EVIDENCE_HOLD, "cybersec evidence hold");
+  requireString(record.holdId, "cybersec evidence hold holdId");
+  requireString(record.findingRef, "cybersec evidence hold findingRef");
+  requireString(record.processorReportRef, "cybersec evidence hold processorReportRef");
+  requireString(record.subjectRef, "cybersec evidence hold subjectRef");
+  const state = requireString(record.state, "cybersec evidence hold state");
+  if (!["requested", "holding", "released", "blocked", "expired"].includes(state)) throw new Error("invalid cybersec evidence hold state");
+  const eventRefs = assertOptionalReferenceList(record.eventRefs, "cybersec evidence hold eventRefs");
+  const detailRefs = assertOptionalReferenceList(record.detailRefs, "cybersec evidence hold detailRefs");
+  const storageRefs = assertOptionalReferenceList(record.storageRefs, "cybersec evidence hold storageRefs");
+  assertOptionalReferenceList(record.retentionDemandRefs, "cybersec evidence hold retentionDemandRefs");
+  assertOptionalReferenceList(record.accessGroupRefs, "cybersec evidence hold accessGroupRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "cybersec evidence hold evidenceRefs");
+  if (state === "holding" && eventRefs.length === 0 && detailRefs.length === 0 && storageRefs.length === 0) {
+    throw new Error("cybersec evidence hold holding state requires eventRefs, detailRefs, or storageRefs");
+  }
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "cybersec evidence hold blockedReasons");
+  if (state === "blocked" && blockedReasons.length === 0) {
+    throw new Error("cybersec evidence hold blocked state requires blockedReasons");
+  }
+  if (record.safeFacts !== undefined) {
+    assertSafeObject(record.safeFacts, "cybersec evidence hold safeFacts");
+    assertNoPrivateContentFields(record.safeFacts, "cybersec evidence hold safeFacts");
+  }
+  rejectRouteControlByteFields(record, "cybersec evidence hold");
+  if (!Number(record.issuedAt || 0)) throw new Error("cybersec evidence hold missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) {
+    throw new Error("cybersec evidence hold expires before issuedAt");
+  }
+  return { ...record, plane: AGREEMENT.PLANE.MATERIALIZATION };
+}
+
+export function assertCybersecMitigationRecommendation(record) {
+  if (!isObject(record)) throw new Error("cybersec mitigation recommendation must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.CYBERSEC_MITIGATION_RECOMMENDATION, "cybersec mitigation recommendation");
+  requireString(record.recommendationId, "cybersec mitigation recommendation recommendationId");
+  requireString(record.findingRef, "cybersec mitigation recommendation findingRef");
+  requireString(record.processorReportRef, "cybersec mitigation recommendation processorReportRef");
+  requireString(record.recommenderRef, "cybersec mitigation recommendation recommenderRef");
+  assertCybersecMitigationAction(record.actionKind);
+  requireString(record.targetRef, "cybersec mitigation recommendation targetRef");
+  const state = requireString(record.state, "cybersec mitigation recommendation state");
+  if (!["recommended", "accepted", "rejected", "applied", "blocked", "expired"].includes(state)) {
+    throw new Error("invalid cybersec mitigation recommendation state");
+  }
+  const authorityRefs = assertOptionalReferenceList(record.authorityRefs, "cybersec mitigation recommendation authorityRefs");
+  assertOptionalReferenceList(record.consumerRefs, "cybersec mitigation recommendation consumerRefs");
+  assertOptionalReferenceList(record.evidenceRefs, "cybersec mitigation recommendation evidenceRefs");
+  if (["recommended", "accepted", "applied"].includes(state) && authorityRefs.length === 0) {
+    throw new Error("cybersec mitigation recommendation actionable state requires authorityRefs");
+  }
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "cybersec mitigation recommendation blockedReasons");
+  if (state === "blocked" && blockedReasons.length === 0) {
+    throw new Error("cybersec mitigation recommendation blocked state requires blockedReasons");
+  }
+  if (record.safeFacts !== undefined) {
+    assertSafeObject(record.safeFacts, "cybersec mitigation recommendation safeFacts");
+    assertNoPrivateContentFields(record.safeFacts, "cybersec mitigation recommendation safeFacts");
+  }
+  rejectRouteControlByteFields(record, "cybersec mitigation recommendation");
+  if (!Number(record.issuedAt || 0)) throw new Error("cybersec mitigation recommendation missing issuedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) {
+    throw new Error("cybersec mitigation recommendation expires before issuedAt");
   }
   return { ...record, plane: AGREEMENT.PLANE.MATERIALIZATION };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1544,6 +1544,7 @@ export const SWARM = Object.freeze({
     CYBERSEC_FINDING: "cybersec.finding",
     CYBERSEC_EVIDENCE_HOLD: "cybersec.evidence.hold",
     CYBERSEC_MITIGATION_RECOMMENDATION: "cybersec.mitigation.recommendation",
+    CYBERSEC_MITIGATION_CONSUMER_POSTURE: "cybersec.mitigation.consumer.posture",
     PARTICIPANT_RUNLEVEL: "participant.runlevel",
     PARTICIPANT_SELF_CAPABILITY: "participant.selfCapability",
     INGRESS_LANE_POSTURE: "ingress.lane.posture",
@@ -5400,6 +5401,44 @@ export function assertCybersecMitigationRecommendation(record) {
   if (!Number(record.issuedAt || 0)) throw new Error("cybersec mitigation recommendation missing issuedAt");
   if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.issuedAt || 0)) {
     throw new Error("cybersec mitigation recommendation expires before issuedAt");
+  }
+  return { ...record, plane: AGREEMENT.PLANE.MATERIALIZATION };
+}
+
+export function assertCybersecMitigationConsumerPosture(record) {
+  if (!isObject(record)) throw new Error("cybersec mitigation consumer posture must be an object");
+  assertRecordKind(record, SWARM.RECORD_KIND.CYBERSEC_MITIGATION_CONSUMER_POSTURE, "cybersec mitigation consumer posture");
+  requireString(record.postureId, "cybersec mitigation consumer posture postureId");
+  requireString(record.recommendationRef, "cybersec mitigation consumer posture recommendationRef");
+  requireString(record.findingRef, "cybersec mitigation consumer posture findingRef");
+  requireString(record.processorReportRef, "cybersec mitigation consumer posture processorReportRef");
+  requireString(record.consumerRef, "cybersec mitigation consumer posture consumerRef");
+  assertCybersecMitigationAction(record.actionKind);
+  requireString(record.targetRef, "cybersec mitigation consumer posture targetRef");
+  const state = requireString(record.state, "cybersec mitigation consumer posture state");
+  if (!["unsupported", "waitingAuthority", "actionable", "accepted", "rejected", "applied", "blocked", "expired"].includes(state)) {
+    throw new Error("invalid cybersec mitigation consumer posture state");
+  }
+  const authorityRefs = assertOptionalReferenceList(record.authorityRefs, "cybersec mitigation consumer posture authorityRefs");
+  const supportedActionKinds = requireArray(record.supportedActionKinds || [], "cybersec mitigation consumer posture supportedActionKinds")
+    .map((actionKind) => requireString(actionKind, "cybersec mitigation consumer posture supportedActionKind"));
+  for (const actionKind of supportedActionKinds) assertCybersecMitigationAction(actionKind);
+  assertOptionalReferenceList(record.evidenceRefs, "cybersec mitigation consumer posture evidenceRefs");
+  const blockedReasons = assertOptionalReferenceList(record.blockedReasons, "cybersec mitigation consumer posture blockedReasons");
+  if (["actionable", "accepted", "applied"].includes(state) && authorityRefs.length === 0) {
+    throw new Error("cybersec mitigation consumer actionable state requires authorityRefs");
+  }
+  if (["unsupported", "blocked"].includes(state) && blockedReasons.length === 0) {
+    throw new Error("cybersec mitigation consumer blocked state requires blockedReasons");
+  }
+  if (record.safeFacts !== undefined) {
+    assertSafeObject(record.safeFacts, "cybersec mitigation consumer posture safeFacts");
+    assertNoPrivateContentFields(record.safeFacts, "cybersec mitigation consumer posture safeFacts");
+  }
+  rejectRouteControlByteFields(record, "cybersec mitigation consumer posture");
+  if (!Number(record.observedAt || 0)) throw new Error("cybersec mitigation consumer posture missing observedAt");
+  if (record.expiresAt !== undefined && Number(record.expiresAt || 0) <= Number(record.observedAt || 0)) {
+    throw new Error("cybersec mitigation consumer posture expires before observedAt");
   }
   return { ...record, plane: AGREEMENT.PLANE.MATERIALIZATION };
 }

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -103,6 +103,9 @@ pub const RECORD_EVENT_FABRIC_ACCESS_CLASS: &str = "event.fabric.accessClass";
 pub const RECORD_EVENT_FABRIC_PROCESSOR_CONTRACT: &str = "event.fabric.processor.contract";
 pub const RECORD_EVENT_FABRIC_PROCESSOR_REPORT: &str = "event.fabric.processor.report";
 pub const RECORD_CYBERSEC_PROCESSOR_SEED: &str = "cybersec.processor.seed";
+pub const RECORD_CYBERSEC_FINDING: &str = "cybersec.finding";
+pub const RECORD_CYBERSEC_EVIDENCE_HOLD: &str = "cybersec.evidence.hold";
+pub const RECORD_CYBERSEC_MITIGATION_RECOMMENDATION: &str = "cybersec.mitigation.recommendation";
 pub const RECORD_PARTICIPANT_RUNLEVEL: &str = "participant.runlevel";
 pub const RECORD_PARTICIPANT_SELF_CAPABILITY: &str = "participant.selfCapability";
 pub const RECORD_EVENT_ADMISSION: &str = "event.admission";
@@ -2041,6 +2044,16 @@ pub struct EventFabricProcessorReportRecord {
     #[serde(default)]
     pub storage_refs: Vec<String>,
     #[serde(default)]
+    pub finding_refs: Vec<String>,
+    #[serde(default)]
+    pub alert_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_hold_refs: Vec<String>,
+    #[serde(default)]
+    pub retention_demand_refs: Vec<String>,
+    #[serde(default)]
+    pub mitigation_recommendation_refs: Vec<String>,
+    #[serde(default)]
     pub safe_facts: Value,
     #[serde(default)]
     pub evidence_refs: Vec<String>,
@@ -2094,6 +2107,101 @@ pub struct CybersecProcessorSeedRecord {
     pub safe_facts: Value,
     #[serde(default)]
     pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CybersecFindingRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub finding_id: String,
+    pub processor_report_ref: String,
+    pub processor_ref: String,
+    pub processor_role_ref: String,
+    pub subject_ref: String,
+    pub finding_kind: String,
+    pub severity: String,
+    pub state: String,
+    pub confidence_score: f64,
+    #[serde(default)]
+    pub input_access_class_refs: Vec<String>,
+    #[serde(default)]
+    pub observed_event_refs: Vec<String>,
+    #[serde(default)]
+    pub access_group_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_hold_refs: Vec<String>,
+    #[serde(default)]
+    pub retention_demand_refs: Vec<String>,
+    #[serde(default)]
+    pub mitigation_recommendation_refs: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    pub observed_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CybersecEvidenceHoldRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub hold_id: String,
+    pub finding_ref: String,
+    pub processor_report_ref: String,
+    pub subject_ref: String,
+    pub state: String,
+    #[serde(default)]
+    pub event_refs: Vec<String>,
+    #[serde(default)]
+    pub detail_refs: Vec<String>,
+    #[serde(default)]
+    pub storage_refs: Vec<String>,
+    #[serde(default)]
+    pub retention_demand_refs: Vec<String>,
+    #[serde(default)]
+    pub access_group_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CybersecMitigationRecommendationRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub recommendation_id: String,
+    pub finding_ref: String,
+    pub processor_report_ref: String,
+    pub recommender_ref: String,
+    pub action_kind: String,
+    pub target_ref: String,
+    pub state: String,
+    #[serde(default)]
+    pub authority_refs: Vec<String>,
+    #[serde(default)]
+    pub consumer_refs: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
     #[serde(default)]
     pub blocked_reasons: Vec<String>,
     pub issued_at: u64,
@@ -5430,6 +5538,26 @@ pub fn validate_event_fabric_processor_report(
         "event fabric processor report missing storageRefs",
     )?;
     validate_reference_list(
+        &record.finding_refs,
+        "event fabric processor report missing findingRefs",
+    )?;
+    validate_reference_list(
+        &record.alert_refs,
+        "event fabric processor report missing alertRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_hold_refs,
+        "event fabric processor report missing evidenceHoldRefs",
+    )?;
+    validate_reference_list(
+        &record.retention_demand_refs,
+        "event fabric processor report missing retentionDemandRefs",
+    )?;
+    validate_reference_list(
+        &record.mitigation_recommendation_refs,
+        "event fabric processor report missing mitigationRecommendationRefs",
+    )?;
+    validate_reference_list(
         &record.evidence_refs,
         "event fabric processor report missing evidenceRefs",
     )?;
@@ -5615,6 +5743,292 @@ pub fn validate_cybersec_processor_seed(record: &CybersecProcessorSeedRecord) ->
     {
         return Err(anyhow!(
             "cybersec processor seed expiresAt must be after issuedAt"
+        ));
+    }
+    Ok(())
+}
+
+fn validate_cybersec_severity(severity: &str) -> Result<()> {
+    if matches!(severity, "info" | "low" | "medium" | "high" | "critical") {
+        Ok(())
+    } else {
+        Err(anyhow!("invalid cybersec finding severity"))
+    }
+}
+
+fn validate_cybersec_mitigation_action(action_kind: &str) -> Result<()> {
+    if matches!(
+        action_kind,
+        "observe"
+            | "requestEvidence"
+            | "retainEvidence"
+            | "quarantine"
+            | "block"
+            | "rateLimit"
+            | "degrade"
+            | "notify"
+    ) {
+        Ok(())
+    } else {
+        Err(anyhow!("invalid cybersec mitigation actionKind"))
+    }
+}
+
+pub fn validate_cybersec_finding(record: &CybersecFindingRecord) -> Result<()> {
+    validate_optional_kind(&record.kind, RECORD_CYBERSEC_FINDING, "cybersec finding")?;
+    require_non_empty(&record.finding_id, "cybersec finding missing findingId")?;
+    require_non_empty(
+        &record.processor_report_ref,
+        "cybersec finding missing processorReportRef",
+    )?;
+    require_non_empty(
+        &record.processor_ref,
+        "cybersec finding missing processorRef",
+    )?;
+    require_non_empty(
+        &record.processor_role_ref,
+        "cybersec finding missing processorRoleRef",
+    )?;
+    require_non_empty(&record.subject_ref, "cybersec finding missing subjectRef")?;
+    require_non_empty(&record.finding_kind, "cybersec finding missing findingKind")?;
+    validate_cybersec_severity(&record.severity)?;
+    if !matches!(
+        record.state.as_str(),
+        "open" | "triaged" | "suppressed" | "resolved" | "blocked" | "expired"
+    ) {
+        return Err(anyhow!("invalid cybersec finding state"));
+    }
+    if !(0.0..=1.0).contains(&record.confidence_score) {
+        return Err(anyhow!(
+            "cybersec finding confidenceScore must be between 0 and 1"
+        ));
+    }
+    validate_reference_list(
+        &record.input_access_class_refs,
+        "cybersec finding missing inputAccessClassRefs",
+    )?;
+    validate_reference_list(
+        &record.observed_event_refs,
+        "cybersec finding missing observedEventRefs",
+    )?;
+    validate_reference_list(
+        &record.access_group_refs,
+        "cybersec finding missing accessGroupRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "cybersec finding missing evidenceRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_hold_refs,
+        "cybersec finding missing evidenceHoldRefs",
+    )?;
+    validate_reference_list(
+        &record.retention_demand_refs,
+        "cybersec finding missing retentionDemandRefs",
+    )?;
+    validate_reference_list(
+        &record.mitigation_recommendation_refs,
+        "cybersec finding missing mitigationRecommendationRefs",
+    )?;
+    if record.state == "blocked" && record.blocked_reasons.is_empty() {
+        return Err(anyhow!(
+            "cybersec finding blocked state requires blockedReasons"
+        ));
+    }
+    validate_reference_list(
+        &record.blocked_reasons,
+        "cybersec finding missing blockedReasons",
+    )?;
+    validate_safe_facts(&record.safe_facts, "cybersec finding safeFacts")?;
+    reject_private_content_fields(&record.safe_facts, "cybersec finding safeFacts")?;
+    reject_media_byte_fields(&serde_json::to_value(record)?, "cybersec finding")?;
+    if record.observed_at == 0 {
+        return Err(anyhow!("cybersec finding missing observedAt"));
+    }
+    if record
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= record.observed_at)
+    {
+        return Err(anyhow!(
+            "cybersec finding expiresAt must be after observedAt"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_cybersec_evidence_hold(record: &CybersecEvidenceHoldRecord) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_CYBERSEC_EVIDENCE_HOLD,
+        "cybersec evidence hold",
+    )?;
+    require_non_empty(&record.hold_id, "cybersec evidence hold missing holdId")?;
+    require_non_empty(
+        &record.finding_ref,
+        "cybersec evidence hold missing findingRef",
+    )?;
+    require_non_empty(
+        &record.processor_report_ref,
+        "cybersec evidence hold missing processorReportRef",
+    )?;
+    require_non_empty(
+        &record.subject_ref,
+        "cybersec evidence hold missing subjectRef",
+    )?;
+    if !matches!(
+        record.state.as_str(),
+        "requested" | "holding" | "released" | "blocked" | "expired"
+    ) {
+        return Err(anyhow!("invalid cybersec evidence hold state"));
+    }
+    validate_reference_list(
+        &record.event_refs,
+        "cybersec evidence hold missing eventRefs",
+    )?;
+    validate_reference_list(
+        &record.detail_refs,
+        "cybersec evidence hold missing detailRefs",
+    )?;
+    validate_reference_list(
+        &record.storage_refs,
+        "cybersec evidence hold missing storageRefs",
+    )?;
+    validate_reference_list(
+        &record.retention_demand_refs,
+        "cybersec evidence hold missing retentionDemandRefs",
+    )?;
+    validate_reference_list(
+        &record.access_group_refs,
+        "cybersec evidence hold missing accessGroupRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "cybersec evidence hold missing evidenceRefs",
+    )?;
+    if record.state == "holding"
+        && record.event_refs.is_empty()
+        && record.detail_refs.is_empty()
+        && record.storage_refs.is_empty()
+    {
+        return Err(anyhow!(
+            "cybersec evidence hold holding state requires eventRefs, detailRefs, or storageRefs"
+        ));
+    }
+    if record.state == "blocked" && record.blocked_reasons.is_empty() {
+        return Err(anyhow!(
+            "cybersec evidence hold blocked state requires blockedReasons"
+        ));
+    }
+    validate_reference_list(
+        &record.blocked_reasons,
+        "cybersec evidence hold missing blockedReasons",
+    )?;
+    validate_safe_facts(&record.safe_facts, "cybersec evidence hold safeFacts")?;
+    reject_private_content_fields(&record.safe_facts, "cybersec evidence hold safeFacts")?;
+    reject_media_byte_fields(&serde_json::to_value(record)?, "cybersec evidence hold")?;
+    if record.issued_at == 0 {
+        return Err(anyhow!("cybersec evidence hold missing issuedAt"));
+    }
+    if record
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= record.issued_at)
+    {
+        return Err(anyhow!(
+            "cybersec evidence hold expiresAt must be after issuedAt"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_cybersec_mitigation_recommendation(
+    record: &CybersecMitigationRecommendationRecord,
+) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_CYBERSEC_MITIGATION_RECOMMENDATION,
+        "cybersec mitigation recommendation",
+    )?;
+    require_non_empty(
+        &record.recommendation_id,
+        "cybersec mitigation recommendation missing recommendationId",
+    )?;
+    require_non_empty(
+        &record.finding_ref,
+        "cybersec mitigation recommendation missing findingRef",
+    )?;
+    require_non_empty(
+        &record.processor_report_ref,
+        "cybersec mitigation recommendation missing processorReportRef",
+    )?;
+    require_non_empty(
+        &record.recommender_ref,
+        "cybersec mitigation recommendation missing recommenderRef",
+    )?;
+    validate_cybersec_mitigation_action(&record.action_kind)?;
+    require_non_empty(
+        &record.target_ref,
+        "cybersec mitigation recommendation missing targetRef",
+    )?;
+    if !matches!(
+        record.state.as_str(),
+        "recommended" | "accepted" | "rejected" | "applied" | "blocked" | "expired"
+    ) {
+        return Err(anyhow!("invalid cybersec mitigation recommendation state"));
+    }
+    validate_reference_list(
+        &record.authority_refs,
+        "cybersec mitigation recommendation missing authorityRefs",
+    )?;
+    validate_reference_list(
+        &record.consumer_refs,
+        "cybersec mitigation recommendation missing consumerRefs",
+    )?;
+    validate_reference_list(
+        &record.evidence_refs,
+        "cybersec mitigation recommendation missing evidenceRefs",
+    )?;
+    if matches!(
+        record.state.as_str(),
+        "recommended" | "accepted" | "applied"
+    ) && record.authority_refs.is_empty()
+    {
+        return Err(anyhow!(
+            "cybersec mitigation recommendation actionable state requires authorityRefs"
+        ));
+    }
+    if record.state == "blocked" && record.blocked_reasons.is_empty() {
+        return Err(anyhow!(
+            "cybersec mitigation recommendation blocked state requires blockedReasons"
+        ));
+    }
+    validate_reference_list(
+        &record.blocked_reasons,
+        "cybersec mitigation recommendation missing blockedReasons",
+    )?;
+    validate_safe_facts(
+        &record.safe_facts,
+        "cybersec mitigation recommendation safeFacts",
+    )?;
+    reject_private_content_fields(
+        &record.safe_facts,
+        "cybersec mitigation recommendation safeFacts",
+    )?;
+    reject_media_byte_fields(
+        &serde_json::to_value(record)?,
+        "cybersec mitigation recommendation",
+    )?;
+    if record.issued_at == 0 {
+        return Err(anyhow!(
+            "cybersec mitigation recommendation missing issuedAt"
+        ));
+    }
+    if record
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= record.issued_at)
+    {
+        return Err(anyhow!(
+            "cybersec mitigation recommendation expiresAt must be after issuedAt"
         ));
     }
     Ok(())
@@ -11955,6 +12369,8 @@ fn is_unsafe_safe_fact_key(key: &str) -> bool {
             | "sdp"
             | "offerSdp"
             | "answerSdp"
+            | "rawPayload"
+            | "requestBody"
             | "cameraUrl"
             | "servicePrivateUrl"
             | "rtspUrl"
@@ -14265,6 +14681,13 @@ mod tests {
             observed_event_refs: vec!["event:runtime:media-path:1".to_string()],
             held_event_refs: vec!["event:runtime:media-path:1".to_string()],
             storage_refs: vec!["storage:logging.archive".to_string()],
+            finding_refs: vec!["cybersec:finding:runtime-media-path:1".to_string()],
+            alert_refs: vec!["cybersec:alert:runtime-media-path:1".to_string()],
+            evidence_hold_refs: vec!["cybersec:evidence-hold:runtime-media-path:1".to_string()],
+            retention_demand_refs: vec!["retention:cybersec:runtime-media-path:1".to_string()],
+            mitigation_recommendation_refs: vec![
+                "cybersec:recommendation:runtime-media-path:observe".to_string(),
+            ],
             safe_facts: json!({
                 "eventCount": 1,
                 "alertCount": 1,
@@ -14284,7 +14707,7 @@ mod tests {
         bad_processor_report.report_id = "processor-report:blocked".to_string();
         bad_processor_report.state = "blocked".to_string();
         assert!(validate_event_fabric_processor_report(&bad_processor_report).is_err());
-        let mut leaky_processor_report = processor_report;
+        let mut leaky_processor_report = processor_report.clone();
         leaky_processor_report.safe_facts = json!({ "ciphertext": "not-safe" });
         assert!(validate_event_fabric_processor_report(&leaky_processor_report).is_err());
 
@@ -14333,6 +14756,88 @@ mod tests {
         let mut missing_boundary = cybersec_seed;
         missing_boundary.semantic_boundaries = json!({ "logging": "mayConsumeMaterializations" });
         assert!(validate_cybersec_processor_seed(&missing_boundary).is_err());
+
+        let finding = CybersecFindingRecord {
+            kind: Some(RECORD_CYBERSEC_FINDING.to_string()),
+            finding_id: "cybersec:finding:runtime-media-path:1".to_string(),
+            processor_report_ref: processor_report.report_id.clone(),
+            processor_ref: processor_report.processor_ref.clone(),
+            processor_role_ref: processor_report.processor_role_ref.clone(),
+            subject_ref: "runtime:media-path:1".to_string(),
+            finding_kind: "mediaPathAnomaly".to_string(),
+            severity: "medium".to_string(),
+            state: "open".to_string(),
+            confidence_score: 0.86,
+            input_access_class_refs: vec![event_class.class_id.clone()],
+            observed_event_refs: processor_report.observed_event_refs.clone(),
+            access_group_refs: vec![group.group_id.clone()],
+            evidence_refs: vec![processor_report.report_id.clone()],
+            evidence_hold_refs: processor_report.evidence_hold_refs.clone(),
+            retention_demand_refs: processor_report.retention_demand_refs.clone(),
+            mitigation_recommendation_refs: processor_report.mitigation_recommendation_refs.clone(),
+            safe_facts: json!({
+                "kind": "mediaPathAnomaly",
+                "severity": "medium",
+                "confidence": 0.86
+            }),
+            blocked_reasons: Vec::new(),
+            observed_at: 1_700_000_076,
+            expires_at: Some(1_700_000_436),
+        };
+        validate_cybersec_finding(&finding).expect("valid cybersec finding");
+        let mut leaky_finding = finding.clone();
+        leaky_finding.safe_facts = json!({ "rawPayload": "not-safe" });
+        assert!(validate_cybersec_finding(&leaky_finding).is_err());
+
+        let evidence_hold = CybersecEvidenceHoldRecord {
+            kind: Some(RECORD_CYBERSEC_EVIDENCE_HOLD.to_string()),
+            hold_id: "cybersec:evidence-hold:runtime-media-path:1".to_string(),
+            finding_ref: finding.finding_id.clone(),
+            processor_report_ref: processor_report.report_id.clone(),
+            subject_ref: finding.subject_ref.clone(),
+            state: "holding".to_string(),
+            event_refs: processor_report.observed_event_refs.clone(),
+            detail_refs: vec!["encrypted-detail:logging.default".to_string()],
+            storage_refs: processor_report.storage_refs.clone(),
+            retention_demand_refs: processor_report.retention_demand_refs.clone(),
+            access_group_refs: vec![group.group_id.clone()],
+            evidence_refs: vec![finding.finding_id.clone()],
+            safe_facts: json!({ "heldEventCount": 1 }),
+            blocked_reasons: Vec::new(),
+            issued_at: 1_700_000_077,
+            expires_at: Some(1_707_776_077),
+        };
+        validate_cybersec_evidence_hold(&evidence_hold).expect("valid cybersec evidence hold");
+        let mut empty_hold = evidence_hold.clone();
+        empty_hold.event_refs.clear();
+        empty_hold.detail_refs.clear();
+        empty_hold.storage_refs.clear();
+        assert!(validate_cybersec_evidence_hold(&empty_hold).is_err());
+
+        let recommendation = CybersecMitigationRecommendationRecord {
+            kind: Some(RECORD_CYBERSEC_MITIGATION_RECOMMENDATION.to_string()),
+            recommendation_id: "cybersec:recommendation:runtime-media-path:observe".to_string(),
+            finding_ref: finding.finding_id.clone(),
+            processor_report_ref: processor_report.report_id.clone(),
+            recommender_ref: processor_report.processor_ref.clone(),
+            action_kind: "requestEvidence".to_string(),
+            target_ref: finding.subject_ref.clone(),
+            state: "recommended".to_string(),
+            authority_refs: vec!["authority:security-ops".to_string()],
+            consumer_refs: vec!["gateway:ops".to_string(), "moderation:queue".to_string()],
+            evidence_refs: vec![finding.finding_id.clone()],
+            safe_facts: json!({ "recommendationOnly": true }),
+            blocked_reasons: Vec::new(),
+            issued_at: 1_700_000_078,
+            expires_at: Some(1_700_000_438),
+        };
+        validate_cybersec_mitigation_recommendation(&recommendation)
+            .expect("valid cybersec mitigation recommendation");
+        let mut unauthoritative_recommendation = recommendation;
+        unauthoritative_recommendation.authority_refs.clear();
+        assert!(
+            validate_cybersec_mitigation_recommendation(&unauthoritative_recommendation).is_err()
+        );
 
         let revocation = AuthorityGrantRevocationPostureRecord {
             kind: Some(RECORD_AUTHORITY_GRANT_REVOCATION_POSTURE.to_string()),

--- a/src/swarm.rs
+++ b/src/swarm.rs
@@ -106,6 +106,8 @@ pub const RECORD_CYBERSEC_PROCESSOR_SEED: &str = "cybersec.processor.seed";
 pub const RECORD_CYBERSEC_FINDING: &str = "cybersec.finding";
 pub const RECORD_CYBERSEC_EVIDENCE_HOLD: &str = "cybersec.evidence.hold";
 pub const RECORD_CYBERSEC_MITIGATION_RECOMMENDATION: &str = "cybersec.mitigation.recommendation";
+pub const RECORD_CYBERSEC_MITIGATION_CONSUMER_POSTURE: &str =
+    "cybersec.mitigation.consumer.posture";
 pub const RECORD_PARTICIPANT_RUNLEVEL: &str = "participant.runlevel";
 pub const RECORD_PARTICIPANT_SELF_CAPABILITY: &str = "participant.selfCapability";
 pub const RECORD_EVENT_ADMISSION: &str = "event.admission";
@@ -2205,6 +2207,34 @@ pub struct CybersecMitigationRecommendationRecord {
     #[serde(default)]
     pub blocked_reasons: Vec<String>,
     pub issued_at: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<u64>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CybersecMitigationConsumerPostureRecord {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<String>,
+    pub posture_id: String,
+    pub recommendation_ref: String,
+    pub finding_ref: String,
+    pub processor_report_ref: String,
+    pub consumer_ref: String,
+    pub action_kind: String,
+    pub target_ref: String,
+    pub state: String,
+    #[serde(default)]
+    pub authority_refs: Vec<String>,
+    #[serde(default)]
+    pub supported_action_kinds: Vec<String>,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+    #[serde(default)]
+    pub blocked_reasons: Vec<String>,
+    #[serde(default)]
+    pub safe_facts: Value,
+    pub observed_at: u64,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<u64>,
 }
@@ -6029,6 +6059,111 @@ pub fn validate_cybersec_mitigation_recommendation(
     {
         return Err(anyhow!(
             "cybersec mitigation recommendation expiresAt must be after issuedAt"
+        ));
+    }
+    Ok(())
+}
+
+pub fn validate_cybersec_mitigation_consumer_posture(
+    record: &CybersecMitigationConsumerPostureRecord,
+) -> Result<()> {
+    validate_optional_kind(
+        &record.kind,
+        RECORD_CYBERSEC_MITIGATION_CONSUMER_POSTURE,
+        "cybersec mitigation consumer posture",
+    )?;
+    require_non_empty(
+        &record.posture_id,
+        "cybersec mitigation consumer posture missing postureId",
+    )?;
+    require_non_empty(
+        &record.recommendation_ref,
+        "cybersec mitigation consumer posture missing recommendationRef",
+    )?;
+    require_non_empty(
+        &record.finding_ref,
+        "cybersec mitigation consumer posture missing findingRef",
+    )?;
+    require_non_empty(
+        &record.processor_report_ref,
+        "cybersec mitigation consumer posture missing processorReportRef",
+    )?;
+    require_non_empty(
+        &record.consumer_ref,
+        "cybersec mitigation consumer posture missing consumerRef",
+    )?;
+    validate_cybersec_mitigation_action(&record.action_kind)?;
+    require_non_empty(
+        &record.target_ref,
+        "cybersec mitigation consumer posture missing targetRef",
+    )?;
+    if !matches!(
+        record.state.as_str(),
+        "unsupported"
+            | "waitingAuthority"
+            | "actionable"
+            | "accepted"
+            | "rejected"
+            | "applied"
+            | "blocked"
+            | "expired"
+    ) {
+        return Err(anyhow!(
+            "invalid cybersec mitigation consumer posture state"
+        ));
+    }
+    validate_reference_list(
+        &record.authority_refs,
+        "cybersec mitigation consumer posture missing authorityRefs",
+    )?;
+    for action_kind in &record.supported_action_kinds {
+        validate_cybersec_mitigation_action(action_kind)?;
+    }
+    validate_reference_list(
+        &record.evidence_refs,
+        "cybersec mitigation consumer posture missing evidenceRefs",
+    )?;
+    validate_reference_list(
+        &record.blocked_reasons,
+        "cybersec mitigation consumer posture missing blockedReasons",
+    )?;
+    if matches!(record.state.as_str(), "actionable" | "accepted" | "applied")
+        && record.authority_refs.is_empty()
+    {
+        return Err(anyhow!(
+            "cybersec mitigation consumer actionable state requires authorityRefs"
+        ));
+    }
+    if matches!(record.state.as_str(), "unsupported" | "blocked")
+        && record.blocked_reasons.is_empty()
+    {
+        return Err(anyhow!(
+            "cybersec mitigation consumer blocked state requires blockedReasons"
+        ));
+    }
+    validate_safe_facts(
+        &record.safe_facts,
+        "cybersec mitigation consumer posture safeFacts",
+    )?;
+    reject_private_content_fields(
+        &record.safe_facts,
+        "cybersec mitigation consumer posture safeFacts",
+    )?;
+    reject_media_byte_fields(
+        &serde_json::to_value(record)?,
+        "cybersec mitigation consumer posture",
+    )?;
+    if record.observed_at == 0 {
+        return Err(anyhow!(
+            "cybersec mitigation consumer posture missing observedAt"
+        ));
+    }
+    if record
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= record.observed_at)
+    {
+        return Err(anyhow!(
+            "cybersec mitigation consumer posture expiresAt must be after observedAt"
         ));
     }
     Ok(())
@@ -14833,6 +14968,33 @@ mod tests {
         };
         validate_cybersec_mitigation_recommendation(&recommendation)
             .expect("valid cybersec mitigation recommendation");
+        let consumer_posture = CybersecMitigationConsumerPostureRecord {
+            kind: Some(RECORD_CYBERSEC_MITIGATION_CONSUMER_POSTURE.to_string()),
+            posture_id: "cybersec:mitigation-consumer:gateway:runtime-media-path".to_string(),
+            recommendation_ref: recommendation.recommendation_id.clone(),
+            finding_ref: recommendation.finding_ref.clone(),
+            processor_report_ref: recommendation.processor_report_ref.clone(),
+            consumer_ref: "gateway:ops".to_string(),
+            action_kind: recommendation.action_kind.clone(),
+            target_ref: recommendation.target_ref.clone(),
+            state: "actionable".to_string(),
+            authority_refs: vec!["authority:security-ops".to_string()],
+            supported_action_kinds: vec!["requestEvidence".to_string(), "notify".to_string()],
+            evidence_refs: vec![recommendation.recommendation_id.clone()],
+            blocked_reasons: Vec::new(),
+            safe_facts: json!({
+                "recommendationOnly": true,
+                "enforcementOwner": "gateway.consumer"
+            }),
+            observed_at: 1_700_000_079,
+            expires_at: Some(1_700_000_439),
+        };
+        validate_cybersec_mitigation_consumer_posture(&consumer_posture)
+            .expect("valid cybersec mitigation consumer posture");
+        let mut unsupported_consumer = consumer_posture.clone();
+        unsupported_consumer.state = "unsupported".to_string();
+        unsupported_consumer.blocked_reasons.clear();
+        assert!(validate_cybersec_mitigation_consumer_posture(&unsupported_consumer).is_err());
         let mut unauthoritative_recommendation = recommendation;
         unauthoritative_recommendation.authority_refs.clear();
         assert!(

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -145,6 +145,9 @@ import {
   assertEventFabricProcessorContract,
   assertEventFabricProcessorReport,
   assertCybersecProcessorSeed,
+  assertCybersecFinding,
+  assertCybersecEvidenceHold,
+  assertCybersecMitigationRecommendation,
   assertPrivateContentEnvelope,
   assertSwarmActivation,
   assertSwarmDevice,
@@ -3871,6 +3874,11 @@ test("agreement grammar separates action authority, access epochs, private reada
     observedEventRefs: ["event:runtime:media-path:1"],
     heldEventRefs: ["event:runtime:media-path:1"],
     storageRefs: ["storage:logging.archive"],
+    findingRefs: ["cybersec:finding:runtime-media-path:1"],
+    alertRefs: ["cybersec:alert:runtime-media-path:1"],
+    evidenceHoldRefs: ["cybersec:evidence-hold:runtime-media-path:1"],
+    retentionDemandRefs: ["retention:cybersec:runtime-media-path:1"],
+    mitigationRecommendationRefs: ["cybersec:recommendation:runtime-media-path:observe"],
     safeFacts: {
       eventCount: 1,
       alertCount: 1,
@@ -3943,6 +3951,93 @@ test("agreement grammar separates action authority, access epochs, private reada
     ...cybersecSeed,
     semanticBoundaries: { logging: "mayConsumeMaterializations" },
   }), /semanticBoundaries storage/);
+
+  const finding = assertCybersecFinding({
+    kind: SWARM.RECORD_KIND.CYBERSEC_FINDING,
+    findingId: "cybersec:finding:runtime-media-path:1",
+    processorReportRef: processorReport.reportId,
+    processorRef: processorReport.processorRef,
+    processorRoleRef: processorReport.processorRoleRef,
+    subjectRef: "runtime:media-path:1",
+    findingKind: "mediaPathAnomaly",
+    severity: "medium",
+    state: "open",
+    confidenceScore: 0.86,
+    inputAccessClassRefs: ["event-class:cybersec-runtime"],
+    observedEventRefs: processorReport.observedEventRefs,
+    accessGroupRefs: [group.groupId],
+    evidenceRefs: [processorReport.reportId],
+    evidenceHoldRefs: processorReport.evidenceHoldRefs,
+    retentionDemandRefs: processorReport.retentionDemandRefs,
+    mitigationRecommendationRefs: processorReport.mitigationRecommendationRefs,
+    safeFacts: {
+      findingKind: "mediaPathAnomaly",
+      severity: "medium",
+      confidenceScore: 0.86,
+    },
+    observedAt: 1700000076,
+    expiresAt: 1700000436,
+  });
+  assert.equal(finding.plane, AGREEMENT.PLANE.MATERIALIZATION);
+  assert.throws(() => assertCybersecFinding({
+    ...finding,
+    findingId: "cybersec:finding:leaky",
+    safeFacts: { rawPayload: "not-safe" },
+  }), /unsafe safe fact key|forbidden protocol field/);
+  assert.throws(() => assertCybersecFinding({
+    ...finding,
+    findingId: "cybersec:finding:confidence",
+    confidenceScore: 1.5,
+  }), /confidenceScore/);
+
+  const evidenceHold = assertCybersecEvidenceHold({
+    kind: SWARM.RECORD_KIND.CYBERSEC_EVIDENCE_HOLD,
+    holdId: "cybersec:evidence-hold:runtime-media-path:1",
+    findingRef: finding.findingId,
+    processorReportRef: processorReport.reportId,
+    subjectRef: finding.subjectRef,
+    state: "holding",
+    eventRefs: processorReport.observedEventRefs,
+    detailRefs: ["encrypted-detail:logging.default"],
+    storageRefs: processorReport.storageRefs,
+    retentionDemandRefs: processorReport.retentionDemandRefs,
+    accessGroupRefs: [group.groupId],
+    evidenceRefs: [finding.findingId],
+    safeFacts: { heldEventCount: 1 },
+    issuedAt: 1700000077,
+    expiresAt: 1707776077,
+  });
+  assert.equal(evidenceHold.plane, AGREEMENT.PLANE.MATERIALIZATION);
+  assert.throws(() => assertCybersecEvidenceHold({
+    ...evidenceHold,
+    holdId: "cybersec:evidence-hold:empty",
+    eventRefs: [],
+    detailRefs: [],
+    storageRefs: [],
+  }), /holding state requires eventRefs/);
+
+  const recommendation = assertCybersecMitigationRecommendation({
+    kind: SWARM.RECORD_KIND.CYBERSEC_MITIGATION_RECOMMENDATION,
+    recommendationId: "cybersec:recommendation:runtime-media-path:observe",
+    findingRef: finding.findingId,
+    processorReportRef: processorReport.reportId,
+    recommenderRef: processorReport.processorRef,
+    actionKind: "requestEvidence",
+    targetRef: finding.subjectRef,
+    state: "recommended",
+    authorityRefs: ["authority:security-ops"],
+    consumerRefs: ["gateway:ops", "moderation:queue"],
+    evidenceRefs: [finding.findingId],
+    safeFacts: { recommendationOnly: true },
+    issuedAt: 1700000078,
+    expiresAt: 1700000438,
+  });
+  assert.equal(recommendation.plane, AGREEMENT.PLANE.MATERIALIZATION);
+  assert.throws(() => assertCybersecMitigationRecommendation({
+    ...recommendation,
+    recommendationId: "cybersec:recommendation:unauthorized",
+    authorityRefs: [],
+  }), /actionable state requires authorityRefs/);
 
   assert.equal(assertAuthorityGrantRevocationPosture({
     kind: "authority.grant.revocationPosture",

--- a/tests/protocol.test.js
+++ b/tests/protocol.test.js
@@ -148,6 +148,7 @@ import {
   assertCybersecFinding,
   assertCybersecEvidenceHold,
   assertCybersecMitigationRecommendation,
+  assertCybersecMitigationConsumerPosture,
   assertPrivateContentEnvelope,
   assertSwarmActivation,
   assertSwarmDevice,
@@ -4033,6 +4034,30 @@ test("agreement grammar separates action authority, access epochs, private reada
     expiresAt: 1700000438,
   });
   assert.equal(recommendation.plane, AGREEMENT.PLANE.MATERIALIZATION);
+  const consumerPosture = assertCybersecMitigationConsumerPosture({
+    kind: SWARM.RECORD_KIND.CYBERSEC_MITIGATION_CONSUMER_POSTURE,
+    postureId: "cybersec:mitigation-consumer:gateway:runtime-media-path",
+    recommendationRef: recommendation.recommendationId,
+    findingRef: recommendation.findingRef,
+    processorReportRef: recommendation.processorReportRef,
+    consumerRef: "gateway:ops",
+    actionKind: recommendation.actionKind,
+    targetRef: recommendation.targetRef,
+    state: "actionable",
+    authorityRefs: recommendation.authorityRefs,
+    supportedActionKinds: ["requestEvidence", "notify"],
+    evidenceRefs: [recommendation.recommendationId],
+    safeFacts: { recommendationOnly: true, enforcementOwner: "gateway.consumer" },
+    observedAt: 1700000079,
+    expiresAt: 1700000439,
+  });
+  assert.equal(consumerPosture.plane, AGREEMENT.PLANE.MATERIALIZATION);
+  assert.throws(() => assertCybersecMitigationConsumerPosture({
+    ...consumerPosture,
+    postureId: "cybersec:mitigation-consumer:gateway:unsupported",
+    state: "unsupported",
+    blockedReasons: [],
+  }), /blocked state requires blockedReasons/);
   assert.throws(() => assertCybersecMitigationRecommendation({
     ...recommendation,
     recommendationId: "cybersec:recommendation:unauthorized",


### PR DESCRIPTION
## Summary
Adds shared cybersecurity processor posture records for findings, evidence holds, mitigation recommendations, and mitigation consumer posture.

## Proof
- cargo test
- npm test
- root check:affected